### PR TITLE
Runner: Modernise the Gecko runner, take 2

### DIFF
--- a/svelte-gecko/runner/content/app.js
+++ b/svelte-gecko/runner/content/app.js
@@ -1,10 +1,8 @@
-var Services = Cu.createServicesCache();
-
 function start() {
   console.log("starting");
   let browser = document.getElementById("app-frame");
   let triggeringPrincipal = Services.scriptSecurityManager.createNullPrincipal({});
-  browser.loadURI("http://localhost:5454/", { triggeringPrincipal });
+  browser.loadURI(Services.io.newURI("http://localhost:5454/"), { triggeringPrincipal });
   console.log("started");
 }
 


### PR DESCRIPTION
`Cu.createServicesCache` was made obsolete in Gecko 104.

`browser.loadURI()` requires an nsIURI parameter as of Gecko 114.

Tested with Gecko 115 and Gecko 122.