### PR TITLE
Runner: Use resource: URLs to access the static generated code files

### DIFF
--- a/svelte-gecko/runner/chrome.manifest
+++ b/svelte-gecko/runner/chrome.manifest
@@ -1,1 +1,2 @@
 content mustang content/
+resource dist ../dist/

--- a/svelte-gecko/runner/content/app.js
+++ b/svelte-gecko/runner/content/app.js
@@ -1,8 +1,8 @@
 function start() {
   console.log("starting");
   let browser = document.getElementById("app-frame");
-  let triggeringPrincipal = Services.scriptSecurityManager.createNullPrincipal({});
-  browser.loadURI(Services.io.newURI("http://localhost:5454/"), { triggeringPrincipal });
+  let triggeringPrincipal = Services.scriptSecurityManager.getSystemPrincipal();
+  browser.loadURI(Services.io.newURI("resource://dist/index.html"), { triggeringPrincipal });
   console.log("started");
 }
 


### PR DESCRIPTION
You can of course move the generated files by modifying `vite.config.ts` and `chrome.manifest` appropriately.