### PR TITLE
Connect the app to the runner via JPCWebSocket

### DIFF
--- a/app/logic/app.ts
+++ b/app/logic/app.ts
@@ -30,12 +30,17 @@ export let appGlobal = new AppGlobal();
 const kSecret = 'eyache5C'; // TODO generate, and communicate to client, or save in config files.
 
 export async function getStartObjects(): Promise<void> {
+  console.log("getStartObjects");
+  console.trace();
+  console.log("getting test objects");
   await getTestObjects(appGlobal);
-  /*
+  console.log("creating websocket");
   let jpc = new JPCWebSocket(null);
   await jpc.connect(kSecret, "localhost", 5455);
   console.log("connected to server");
   let remoteApp = await jpc.getRemoteStartObject();
+  console.log(remoteApp, "got remote start object");
+  /*
   appGlobal.emailAccounts = await remoteApp.accounts;
   */
   appGlobal.chatAccounts.addAll(await readChatAccounts());

--- a/runner/package.json
+++ b/runner/package.json
@@ -15,6 +15,7 @@
   "type": "module",
   "dependencies": {
     "express": "^4.18.2",
-    "http-proxy": "^1.18.1"
+    "http-proxy": "^1.18.1",
+    "jpc-ws": "https://github.com/benbucksch/jpc-ws/"
   }
 }


### PR DESCRIPTION
Note that I couldn't get this to work with the published version of `jpc-ws` due to the issues in the recent PRs I made but it does work with the browser websocket fix and also something done with the weird `consoleError` import. (But then again my dummy start object is literally just an object, so I don't know how much else will work like that.)

I have adapted the server to start in both developer and production mode; in production mode it will serve the built application on port `5454` while in developer mode it will only serve the JPCWebSocket on port `5455`.

As requested I tried to look into `electron` but it doesn't start up for me and as far as I can tell all of the necessary code is already in place anyway so I don't understand what the issue is there.