### PR TITLE
Fix probable logic error

### DIFF
--- a/lib/logic/account/account-list.js
+++ b/lib/logic/account/account-list.js
@@ -40,7 +40,7 @@ export async function readAccounts() {
   if (!gHaveReadAll) {
     for (let accountID of ourPref.get("accountsList", "").split(",")) {
       if (!accountID || gAccounts.get(accountID)) {
-        return;
+        continue;
       }
       try {
         let account = await _readExistingAccountFromPrefs(accountID);


### PR DESCRIPTION
`readAccounts()` returns `undefined` if there are no or duplicated accounts, which is probably the wrong behaviour.