### PR TITLE
Split blockquote nested

### DIFF
--- a/app/frontend/Shared/Editor/SplitBlockquote.ts
+++ b/app/frontend/Shared/Editor/SplitBlockquote.ts
@@ -32,7 +32,7 @@ export const SplitBlockquote = Blockquote.extend({
         return chain().setNodeSelection($to.pos).splitFirstParent($to.pos)
         .insertContentAt($to.pos + $to.depth, '<p></p>').run();
       },
-      splitFirstParent: (pos :number) => ({ tr }) => {
+      splitFirstParent: (pos: number) => ({ tr }) => {
         let node = this.editor.$pos(pos);
         tr.split(node.pos, node.depth);
         return true;


### PR DESCRIPTION
### New Split Blockquote

1.  splits it using ProseMirror's split function, it splits it based on the depth of the blockquote
2. inserts new paragraphs at the outermost blockquote node so it doesn't create new paragraph and split like before
3. removed `name: 'split-blockquote'` because it causes the split function to name the NodeType to `split-blockquote` instead of `blockquote`
![image](https://github.com/benbucksch/mustang/assets/71667021/954bf0a2-4087-47ce-9068-bceabd28e434)
