### PR TITLE
Fix person autocomplete mouse click not firing

### DIFF
--- a/app/frontend/Shared/PersonAutocomplete/PersonAutocomplete.svelte
+++ b/app/frontend/Shared/PersonAutocomplete/PersonAutocomplete.svelte
@@ -6,7 +6,7 @@
     minCharactersToSearch={2}
     localFiltering={false}
     localSorting={false}
-    closeOnBlur={true}
+    closeOnBlur={false}
     hideArrow={true}
     noResultsText="No person found"
     {placeholder}


### PR DESCRIPTION
### Changes

1. make closeOnBlur `false`

### Findings

1. drop down results remain after clicking, should it be cleared after selection?

### Reproduction

1. type `re`
3. click on a person
4. click on the input field again without typing, the same results show up again