### PR TITLE
Enter key newline behavior extension

### DIFF
--- a/app/frontend/Shared/Editor/HTMLEditor.svelte
+++ b/app/frontend/Shared/Editor/HTMLEditor.svelte
@@ -59,10 +59,6 @@
 
 <style>
   /** Fix app.css, see .value */
-  .html-editor :global(p) {
-    margin: 0 0 1em 0;
-  }
-
   .html-editor :global(*) {
     user-select: text;
   }
@@ -80,6 +76,9 @@
   /* Content styles
      TODO @import url(../Message/content.css); into iframe */
 
+  .html-editor :global(p) {
+    margin: 0 0 1em 0;
+  }
   .html-editor :global(blockquote) {
     border-left: 3px solid blue;
     padding-left: 20px;


### PR DESCRIPTION
### `Enter` key newline behavior extension

1. On `Enter` keypress, inserts newline `<br>` instead of creating new paragraph.
2. On two consecutive `Enter` keypresses, it deletes the previous `<br>` and creates a new paragraph.
3. If there's a `<br>` before the cursor it will also create a new paragraph
4. If I remove the css workaround it causes even the `<li>` to have margins since even the `<li>` are wrapped in `<p>`