### PR TITLE
SplitBlockquote: node is null

### DIFF
--- a/app/frontend/Shared/Editor/SplitBlockquote.ts
+++ b/app/frontend/Shared/Editor/SplitBlockquote.ts
@@ -47,10 +47,13 @@ export const SplitBlockquote = Blockquote.extend({
         return chain().setTextSelection($to.pos).splitFirstParent($to.pos)
         .insertContentAt($to.pos + $to.depth, '<p></p>').scrollIntoView().run();
       },
-      splitFirstParent: (pos: number) => ({ tr }) => {
+      splitFirstParent: (pos: number) => ({ tr, dispatch }) => {
         let node = this.editor.$pos(pos);
-        tr.split(node.pos, node.depth);
-        return true;
+        if (dispatch && node) {
+          tr.split(node.pos, node.depth);
+          return true;
+        }
+        return false;
       }
     }
   },


### PR DESCRIPTION
### Changes

1. Change `setNodeSelection()` to `setTextSelection()`
2. Add validation of node position in `SplitFirstParent()`
3. Add validation if `SplitFirstParent()` can be dispatched
4. Declare interface for `SplitBlockquote`
5. Scroll in to view after splitting

### Reproduction of Bug

1. Press enter in non-blockquote area i.e. create paragraphs
2. Select the empty paragraphs created
3. Press toggle blockquote button
6. Place cursor in the blockquote with empty paragraphs
7. Press enter

### Notes

1. The bug was probably cause by the blockquote being empty
2. `tr` or transaction is more up-to-date than `state` so you when press enter it fixes the unresponsiveness on the first press because it has the outdated state

