### PR TITLE
Toggle Send Key

### DIFF
--- a/app/frontend/Shared/Editor/HTMLEditorToolbar.svelte
+++ b/app/frontend/Shared/Editor/HTMLEditorToolbar.svelte
@@ -173,7 +173,8 @@ block
       />
     {#if hasExtension('sendOnEnter')}
       <Button
-      label="Toggle send button"
+      tooltip={editor.storage.sendOnEnter.isSendOnEnter ? "Use Ctrl-Enter to send" : "Use Enter to send"}
+      selected={editor.storage.sendOnEnter.isSendOnEnter}
       on:click={() => editor.chain().focus().toggleSendKey().run()}
       icon={ForwardIcon}
       iconOnly

--- a/app/frontend/Shared/Editor/SendOnEnter.ts
+++ b/app/frontend/Shared/Editor/SendOnEnter.ts
@@ -7,6 +7,10 @@ export interface SendOnEnterOptions {
   sendFunc: Function;
 }
 
+export interface SendOnEnterStorage {
+  isSendOnEnter: boolean;
+}
+
 declare module '@tiptap/core' {
   interface Commands<ReturnType> {
     toggleSendKey: {
@@ -25,11 +29,11 @@ declare module '@tiptap/core' {
 /** Extension for calling a callback on `Ctrl-Enter` or `Enter`
  * to send message.
  */
-export const SendOnEnter = Extension.create<SendOnEnterOptions>({
+export const SendOnEnter = Extension.create<SendOnEnterOptions, SendOnEnterStorage>({
   name: 'sendOnEnter',
   addStorage() {
     return {
-      sendOnCtrlEnter: true,
+      isSendOnEnter: false,
     }
   },
   addOptions() {
@@ -64,8 +68,10 @@ export const SendOnEnter = Extension.create<SendOnEnterOptions>({
       toggleSendKey: () => () => {
         if (this.options.sendKey === 'Enter') {
           this.options.sendKey = 'Ctrl-Enter';
+          this.storage.isSendOnEnter = false;
         } else {
           this.options.sendKey = 'Enter';
+          this.storage.isSendOnEnter = true;
         }
         return true;
       },


### PR DESCRIPTION
## Toggle Send Key Extension

1. Emits `send` event on `Enter` or `Ctrl-Enter` with `Ctrl-Enter` being the default option
2. Works by returning false if the key pressed is not the set send key and executing only if the key pressed is the selected send key

### Basic Concept
```
if keypressed is keyset
    emit send
    return true so the editor doesn't execute any other commands for this key
else 
    return false so the editor moves on to the next command execute for this key
```