### PR TITLE
Standard Conventions for *bold* and /italic/

### DIFF
--- a/app/frontend/Shared/Editor/HTMLEditor.svelte
+++ b/app/frontend/Shared/Editor/HTMLEditor.svelte
@@ -10,10 +10,10 @@
   import CodeWordFeature from '@tiptap/extension-code';
   import { SplitBlockquote } from './SplitBlockquote';
   import { Footer } from './Footer';
+  import { BoldStar, ItalicSlash } from './StdConventions';
   // import CodeBlockLowlightFeature from '@tiptap/extension-code-block-lowlight';
   // import { common as lowlightCommon, createLowlight } from 'lowlight'
   import { onMount, onDestroy } from 'svelte';
-  import { StdConventions } from './StdConventions';
 
   /**
    * TODO Bug: Only accepts `html` on component creation.
@@ -38,7 +38,8 @@
           allowBase64: true,
           inline: true,
         }),
-        StdConventions,
+        BoldStar,
+        ItalicSlash,
         // CodeBlockLowlightFeature.configure({
         //  lowlight: createLowlight(lowlightCommon),
         // }),

--- a/app/frontend/Shared/Editor/StdConventions.ts
+++ b/app/frontend/Shared/Editor/StdConventions.ts
@@ -1,19 +1,6 @@
-import { markInputRule, markPasteRule, Extension } from '@tiptap/core';
+import { markInputRule, markPasteRule } from '@tiptap/core';
 import { Bold } from '@tiptap/extension-bold';
 import { Italic } from '@tiptap/extension-italic';
-
-/** Replaces Markdown conventions with Standard conventions
- * 1. `*abc*` is for **bold** not _italic_
- * 2. `/abc/` is for _italic_
- */
-export const StdConventions = Extension.create({
-  addExtensions() {
-    return [
-      BoldStar,
-      ItalicSlash,
-    ]
-  },
-});
 
 export const starInputRegex = /(?:^|\s)((?:\*)((?:[^*]+))(?:\*))$/
 export const starPasteRegex = /(?:^|\s)((?:\*)((?:[^*]+))(?:\*))/g


### PR DESCRIPTION
### Additions

1. `StdConventions` for which contains `BoldStar` and `ItalicSlash` extensions
2. `BoldStar` extension makes `*abc*` **bold** instead of _italic_
3. `ItalicSlash` extension makes `/abc/` _italic_

### Questions
1. Put them in separate files or leave them as is?
2. Remove `StdConventions` and import extensions separately or leave them as is?