### PR TITLE
Disable changing the special folder type for an All accounts special folder

### DIFF
--- a/app/logic/Mail/Virtual/AllFolders.ts
+++ b/app/logic/Mail/Virtual/AllFolders.ts
@@ -55,6 +55,10 @@ export class AllFolders extends Folder {
     throw new Error("Select a folder in a specific account first, to create a subfolder");
   }
 
+  disableChangeSpecial(): string | false {
+    return "You cannot change an All accounts special folder."
+  }
+
   newEMail(): EMail {
     let account = this.account.accounts.first;
     assert(account, "Setup and select email account first");


### PR DESCRIPTION
This prevents a crash when clicking on the ellipsis on an All accounts special folder.