### PR TITLE
Fix typo reading autodiscover XML

### DIFF
--- a/app/logic/Mail/AutoConfig/exchangeConfig.ts
+++ b/app/logic/Mail/AutoConfig/exchangeConfig.ts
@@ -71,7 +71,7 @@ async function fetchV1HTTP(url: URLString, callArgs: any, abort: AbortController
 function readAutoDiscoverV1XML(xmlStr: string): ArrayColl<MailAccount> {
   let jxon = JXON.parse(xmlStr);
   assert(typeof (jxon) == "object", "Did not receive XML");
-  let protocolsXML = jxon?.Autodiscover?.Response?.Account?.Protocol;
+  let protocolsXML = jxon?.Autodiscover?.Response?.Account?.$Protocol;
   console.log("Got AutoDiscover XML", protocolsXML, "full", jxon);
   assert(protocolsXML, "Did not receive valid AutoDiscover XML");
   let accounts = new ArrayColl<MailAccount>();


### PR DESCRIPTION
Compare https://searchfox.org/comm-central/source/mail/components/accountcreation/modules/ExchangeAutoDiscover.sys.mjs#402 (note that you don't need `array_or_undef` because you check on line 76 that it's not undefined).