### PR TITLE
JPC: Catch errors when serializing Error objects. Retains at least the error message in such cases

### DIFF
--- a/lib/jpc/message.js
+++ b/lib/jpc/message.js
@@ -102,6 +102,7 @@ export default class MessageCall  {
     } catch (ex) {
       let exSerialized;
       try {
+        // Can throw while serializing error object - e.g. issuerCertificate cyclic reference when configuring foo@yahoo.com.au
         exSerialized = JSON.parse(JSON.serialize(ex));
       } catch (ex) {
       }


### PR DESCRIPTION
* Fixes point 2 in https://github.com/mustang-im/mustang/issues/78#issuecomment-2168306968
* Untested. Please test it.