### PR TITLE
Explicitly import Buffer (#86)

### DIFF
--- a/app/logic/Mail/IMAP/IMAPFolder.ts
+++ b/app/logic/Mail/IMAP/IMAPFolder.ts
@@ -6,6 +6,7 @@ import { SQLEMail } from "../SQL/SQLEMail";
 import type { EMail } from "../EMail";
 import { ArrayColl, Collection } from "svelte-collections";
 import { assert, exMessage } from "../../util/util";
+import { Buffer } from "buffer";
 
 export class IMAPFolder extends Folder {
   account: IMAPAccount;

--- a/app/logic/Mail/Store/MailZIP.ts
+++ b/app/logic/Mail/Store/MailZIP.ts
@@ -3,6 +3,7 @@ import { appGlobal } from "../../app";
 import { sanitizeFilename, assert } from "../../util/util";
 import type { Folder } from "../Folder";
 import { ArrayColl, MapColl, SetColl } from "svelte-collections";
+import { Buffer } from "buffer";
 import type Zip from "adm-zip";
 
 /** Save all emails of a folder in a ZIP file in the local disk filesystem.

--- a/lib/jpc/obj.js
+++ b/lib/jpc/obj.js
@@ -1,4 +1,5 @@
 import { assert } from "./util.js";
+import { Buffer } from "buffer";
 
 function getClassName(obj) {
   let proto = Object.getPrototypeOf(obj);


### PR DESCRIPTION
The Buffer polyfill is supposed to define Buffer globally and I can't reproduce the undefined Buffer object in development because it is defined globally but this might fix it by manually importing Buffer.