### PR TITLE
Fix creating new EWS calendar

### DIFF
--- a/app/logic/Calendar/EWS/EWSCalendar.ts
+++ b/app/logic/Calendar/EWS/EWSCalendar.ts
@@ -18,6 +18,10 @@ export class EWSCalendar extends Calendar {
   }
 
   async listEvents() {
+    if (!this.dbID) {
+      await SQLCalendar.save(this);
+    }
+
     /* Disabling tasks for now.
     // syncState is base64-encoded so it's safe to split and join on comma
     let [calendar, tasks] = this.syncState?.split(",") || [];


### PR DESCRIPTION
Creating an EWS account doesn't currently work because the calendar tries to save its events before it's been saved.