### PR TITLE
Fix L10n: messages-compiled.json are not compiled automatically by vite

### DIFF
--- a/app/.gitignore
+++ b/app/.gitignore
@@ -12,8 +12,6 @@ dist
 dist-ssr
 public/olm.wasm
 *.local
-# Temp workaround for bug #112
-l10n/locales/*/messages-compiled.json
 
 # Editor directories and files
 .vscode/*

--- a/app/l10n/l10n.ts
+++ b/app/l10n/l10n.ts
@@ -3,27 +3,27 @@ import { derived } from 'svelte/store';
 
 import { sourceLocale } from './list';
 
-import { messages as en } from './locales/en/messages-compiled.json';
-import { messages as de } from './locales/de/messages-compiled.json';
-import { messages as fr } from './locales/fr/messages-compiled.json';
-import { messages as it } from './locales/it/messages-compiled.json';
-import { messages as es } from './locales/es/messages-compiled.json';
-import { messages as pt } from './locales/pt/messages-compiled.json';
-import { messages as pl } from './locales/pl/messages-compiled.json';
-import { messages as ja } from './locales/ja/messages-compiled.json';
-import { messages as zh } from './locales/zh/messages-compiled.json';
+import { messages as en } from './locales/en/messages.json?lingui';
+import { messages as de } from './locales/de/messages.json?lingui';
+import { messages as fr } from './locales/fr/messages.json?lingui';
+import { messages as it } from './locales/it/messages.json?lingui';
+import { messages as es } from './locales/es/messages.json?lingui';
+import { messages as pt } from './locales/pt/messages.json?lingui';
+import { messages as pl } from './locales/pl/messages.json?lingui';
+import { messages as ja } from './locales/ja/messages.json?lingui';
+import { messages as zh } from './locales/zh/messages.json?lingui';
 
-import { messages as ar } from './locales/ar/messages-compiled.json';
-import { messages as cs } from './locales/cs/messages-compiled.json';
-import { messages as da } from './locales/da/messages-compiled.json';
-import { messages as el } from './locales/el/messages-compiled.json';
-import { messages as fi } from './locales/fi/messages-compiled.json';
-import { messages as nl } from './locales/nl/messages-compiled.json';
-import { messages as no } from './locales/no/messages-compiled.json';
-import { messages as ro } from './locales/ro/messages-compiled.json';
-import { messages as ru } from './locales/ru/messages-compiled.json';
-import { messages as sv } from './locales/sv/messages-compiled.json';
-import { messages as uk } from './locales/uk/messages-compiled.json';
+import { messages as ar } from './locales/ar/messages.json?lingui';
+import { messages as cs } from './locales/cs/messages.json?lingui';
+import { messages as da } from './locales/da/messages.json?lingui';
+import { messages as el } from './locales/el/messages.json?lingui';
+import { messages as fi } from './locales/fi/messages.json?lingui';
+import { messages as nl } from './locales/nl/messages.json?lingui';
+import { messages as no } from './locales/no/messages.json?lingui';
+import { messages as ro } from './locales/ro/messages.json?lingui';
+import { messages as ru } from './locales/ru/messages.json?lingui';
+import { messages as sv } from './locales/sv/messages.json?lingui';
+import { messages as uk } from './locales/uk/messages.json?lingui';
 
 /** Map of lang code to messages.
  * Lang codes: <https://www.wikiwand.com/en/List_of_ISO_639_language_codes> */

--- a/app/lingui.config.ts
+++ b/app/lingui.config.ts
@@ -15,7 +15,5 @@ export default {
     }
   ],
   format: formatter({style: 'minimal'}),
-  catalogsMergePath: 'l10n/locales/{locale}/messages-compiled',
-  compileNamespace: 'json',
   extractors: [jstsExtractor, svelteExtractor],
 };

--- a/app/lingui.config.ts
+++ b/app/lingui.config.ts
@@ -1,13 +1,14 @@
 import { jstsExtractor, svelteExtractor } from 'svelte-i18n-lingui/extractor';
 import {formatter} from "@lingui/format-json";
 import { locales, sourceLocale } from './l10n/list';
+import { resolve } from 'path';
 
 export default {
   locales: locales,
   sourceLocale: sourceLocale,
   catalogs: [
     {
-      path: 'l10n/locales/{locale}/messages',
+      path: resolve(__dirname, 'l10n/locales/{locale}/messages'),
       include: [
         "frontend/",
         "logic/",

--- a/app/package.json
+++ b/app/package.json
@@ -4,8 +4,8 @@
   "private": true,
   "version": "0.5.0",
   "scripts": {
-    "dev": "npm run l10n:compile && vite",
-    "build": "npm run l10n:compile && vite build",
+    "dev": "vite",
+    "build": "vite build",
     "preview": "vite preview",
     "test": "vitest",
     "check": "svelte-check --tsconfig ./tsconfig.json",

--- a/e2/electron.vite.config.ts
+++ b/e2/electron.vite.config.ts
@@ -13,6 +13,10 @@ export default defineConfig({
     plugins: [externalizeDepsPlugin()]
   },
   renderer: {
-    plugins: [nodePolyfills({include: ['buffer'], globals: {global: false, process: false}}), svelte(), lingui({configPath: "../app/lingui.config.ts"})]
+    plugins: [
+      nodePolyfills({include: ['buffer'], globals: {global: false, process: false}}),
+      svelte(),
+      lingui({configPath: "../app/lingui.config.ts"}),
+    ]
   }
 })

--- a/e2/electron.vite.config.ts
+++ b/e2/electron.vite.config.ts
@@ -1,6 +1,7 @@
 import { defineConfig, externalizeDepsPlugin } from 'electron-vite'
 import { nodePolyfills } from "vite-plugin-node-polyfills";
 import { svelte } from '@sveltejs/vite-plugin-svelte'
+import { lingui } from '@lingui/vite-plugin';
 
 export default defineConfig({
   main: {
@@ -12,6 +13,6 @@ export default defineConfig({
     plugins: [externalizeDepsPlugin()]
   },
   renderer: {
-    plugins: [nodePolyfills({include: ['buffer'], globals: {global: false, process: false}}), svelte()]
+    plugins: [nodePolyfills({include: ['buffer'], globals: {global: false, process: false}}), svelte(), lingui({configPath: "../app/lingui.config.ts"})]
   }
 })

--- a/e2/package.json
+++ b/e2/package.json
@@ -34,6 +34,7 @@
     "@electron-toolkit/eslint-config-prettier": "^1.0.1",
     "@electron-toolkit/eslint-config-ts": "^1.0.0",
     "@electron-toolkit/tsconfig": "^1.0.1",
+    "@lingui/vite-plugin": "^4.11.1",
     "@sveltejs/vite-plugin-svelte": "^3.0.1",
     "@types/node": "^18.17.5",
     "electron": "^25.6.0",


### PR DESCRIPTION
**Changes**

- Removed extra compile step i.e. `messages-compiled.json`
- Use `@lingui/vite-plugin` added `?lingui` to message.json imports for compilation when running vite
- Added `@lingui/vite-plugin` to `e2/electron.vite.cofig.ts`