### PR TITLE
Honour suggested backoff time #95 #121

### DIFF
--- a/app/logic/util/util.ts
+++ b/app/logic/util/util.ts
@@ -76,6 +76,16 @@ export function fileExtensionForMIMEType(mimetype: string) {
   return ".ext";
 }
 
+export async function throttleConnectionsPerSecond(nextConnectionTime: number[]) {
+  let milliseconds = Date.now();
+  nextConnectionTime.push(milliseconds + 1000);
+  milliseconds = nextConnectionTime.shift() - milliseconds;
+  if (milliseconds > 0) {
+    console.log(`Throttling for ${milliseconds}ms because there were ${nextConnectionTime.length} connections in the last second`);
+    await sleep(milliseconds / 1000);
+  }
+}
+
 /** Abstract class as base class for allowing more specific error classes */
 export class SpecificError extends Error {
   constructor(ex: Error, message: string) {


### PR DESCRIPTION
I couldn't get this to trigger using the STR in #121 but what I was able to do was as follows:
- Delete `~/.mustang/mail.db`
- Set up the account when prompted
- Click on a miscellaneous folder in the account itself
- Click on All Accounts

This seems to trigger a list of every single folder in the account in parallel, thus triggering the server busy error. (This doesn't happen after a restart; you have to do it in the same session.)