### PR TITLE
IMAP sequence numbers are unstable #120

### DIFF
--- a/app/logic/Mail/IMAP/IMAPEMail.ts
+++ b/app/logic/Mail/IMAP/IMAPEMail.ts
@@ -25,14 +25,14 @@ export class IMAPEMail extends EMail {
 
   async download() {
     let msgInfo = await this.folder.runCommand(async (conn) => {
-      // TODO uid failed for me for msgs with uid > folder msg count
-      return await conn.fetchOne(this.seq + "", {
+      return await conn.fetchOne(this.uid + "", {
+        uid: true,
         size: true,
         threadId: true,
         envelope: true,
         source: true,
         flags: true,
-      });
+      }, { uid: true });
     });
     this.fromFlow(msgInfo);
     await this.parseMIME();

--- a/lib/jpc/message.js
+++ b/lib/jpc/message.js
@@ -174,7 +174,7 @@ export default class MessageCall  {
       Object.assign(ex, message);
       ex.stack = callWaiting.stack;
       callWaiting.reject(ex);
-      console.log("Error", JSON.stringify(message, null, 2));
+      console.log("Error", message);
     }
   }
 


### PR DESCRIPTION
Steps to reproduce problem:
- Don't download all messages in a folder in advance
- Delete a message in a folder
- Read a message with a higher sequence number

Expected results: Message you selected is downloaded

Actual results: Message you selected is overwritten by an unrelated message that now has that sequence number, causing it to become cloned

This is why UIDs were invented, after all...

Well, except when expunging messages; sadly the response only mentions the sequence number of the message, as using or including the UID wouldn't be backwards compatible.

Thunderbird's JavaScript IMAP client works around this by simply refreshing the entire folder if it gets an expunge notification from the server.

Thunderbird's C++ IMAP client keeps an array of the UIDs so that it can always associate a sequence number with a UID even for deleted messages (sequence numbers are always consecutive).