### PR TITLE
Consistently use config and files dir #128

### DIFF
--- a/app/logic/Mail/SQL/Source/SQLSourceDatabase.ts
+++ b/app/logic/Mail/SQL/Source/SQLSourceDatabase.ts
@@ -9,7 +9,7 @@ export async function getDatabase(): Promise<Database> {
     return mailSourceDatabase;
   }
   let dir = await appGlobal.remoteApp.path.join(
-    await appGlobal.remoteApp.getFilesDir(), "backup");
+    await appGlobal.remoteApp.getConfigDir(), "backup");
   await appGlobal.remoteApp.fs.mkdir(dir, { recursive: true, mode: 0o700 });
   const getDatabase = appGlobal.remoteApp.getSQLiteDatabase;
   let file = await appGlobal.remoteApp.path.join("backup", "mail-backup.db");

--- a/app/logic/Mail/Store/RawFilesAttachment.ts
+++ b/app/logic/Mail/Store/RawFilesAttachment.ts
@@ -4,7 +4,7 @@ import { SQLEMail } from "../SQL/SQLEMail";
 import { appGlobal } from "../../app";
 import { sanitizeFilename, fileExtensionForMIMEType, assert } from "../../util/util";
 
-let configDir: string = null;
+let filesDir: string = null;
 
 /** Save email attachments as files in the local disk filesystem */
 export class RawFilesAttachment {
@@ -77,9 +77,7 @@ export class RawFilesAttachment {
   }
 
   static async getDirPath(email: EMail): Promise<string> {
-    if (!configDir) {
-      configDir = await appGlobal.remoteApp.getFilesDir();
-    }
-    return `${configDir}/files/email/${sanitizeFilename(email.from.emailAddress.replace("@", "-"))}/${email.dbID}-${sanitizeFilename(email.subject)}`;
+    filesDir ??= await appGlobal.remoteApp.getFilesDir();
+    return `${filesDir}/files/email/${sanitizeFilename(email.from.emailAddress.replace("@", "-"))}/${email.dbID}-${sanitizeFilename(email.subject)}`;
   }
 }


### PR DESCRIPTION
- Databases are implicitly saved in `Application Support/Mustang`
- As @jermy-c noticed in #128, `SQLSourceDatabase.ts` creates `backup` as a subfolder of `Mustang` rather than of `Application Support/Mustang` which is where the other databases live
- `SQLEmail.ts` and `RawFilesAttachment.ts` save in `Mustang` but uses the variable name normally used for `Application Support/Mustang`, which could be confusing
- `MailZIP.ts` saves in `Mustang` and uses better variable naming, which I have copied to the two above-mentioned files