### PR TITLE
OAuth2: Use the username and password from the account. Don't duplicate it.

### DIFF
--- a/app/logic/Auth/OAuth2.ts
+++ b/app/logic/Auth/OAuth2.ts
@@ -40,9 +40,6 @@ export class OAuth2 extends Observable {
   verificationToken: string; /** `state` URL param of authURL/doneURL */
   uiMethod: OAuth2UIMethod = OAuth2UIMethod.Window;
 
-  username: string;
-  protected password: string;
-
   expiresAt: Date | null = null;
   protected expiryTimout: NodeJS.Timeout;
   refreshErrorCallback = (ex: Error) => console.error(ex);
@@ -65,10 +62,6 @@ export class OAuth2 extends Observable {
   setTokenURLPasswordAuth(url: string | null | undefined) {
     assert(!url || url?.startsWith("https://") || url?.startsWith("http://"), "Malformed OAuth2 server token URL for password: " + url);
     this.tokenURLPasswordAuth = url || null;
-  }
-
-  setPassword(password: string) {
-    this.password = password;
   }
 
   /**
@@ -100,9 +93,9 @@ export class OAuth2 extends Observable {
         console.error(ex);
       }
     }
-    if (this.password && this.tokenURLPasswordAuth) {
+    if (this.account.password && this.tokenURLPasswordAuth) {
       try {
-        return await this.loginWithPassword(this.username, this.password);
+        return await this.loginWithPassword(this.account.username, this.account.password);
       } catch (ex) {
         console.error(ex);
       }
@@ -138,8 +131,6 @@ export class OAuth2 extends Observable {
     }, {
       Authentication: `Basic ${basicAuth}`,
     }, this.tokenURLPasswordAuth);
-    this.username = username;
-    this.password = password;
     return accessToken;
   }
 
@@ -240,7 +231,7 @@ export class OAuth2 extends Observable {
       response_mode: "query",
       scope: this.scope,
       state: this.verificationToken,
-      login_hint: this.username,
+      login_hint: this.account.username,
     });
   }
 
@@ -339,6 +330,6 @@ export class OAuth2 extends Observable {
   }
   protected get storageKey(): string {
     let host = new URL(this.tokenURL).host;
-    return `oauth2.refreshToken.${this.username}.${host}`;
+    return `oauth2.refreshToken.${this.account.username}.${host}`;
   }
 }

--- a/app/logic/Mail/AutoConfig/readConfig.ts
+++ b/app/logic/Mail/AutoConfig/readConfig.ts
@@ -148,8 +148,6 @@ function getOAuth2Config(account: MailAccount, autoConfigXML: any): OAuth2 {
     }
   }
   assert(oAuth2, "No suitable OAuth2 config found, neither in AutoConfig XML, nor built-in");
-  oAuth2.setPassword(account.password);
-  oAuth2.username = account.username ?? account.emailAddress;
   account.oAuth2 = oAuth2;
 }
 

--- a/app/logic/Mail/AutoConfig/saveConfig.ts
+++ b/app/logic/Mail/AutoConfig/saveConfig.ts
@@ -60,10 +60,6 @@ export function fillConfig(config: MailAccount, emailAddress: string, password: 
     }
     fillConfig(config.outgoing, emailAddress, password);
   }
-  if (config.authMethod == AuthMethod.OAuth2 && config.oAuth2) {
-    config.oAuth2.username = emailAddress; // Fill oAuth2 username before saving refresh token
-    config.oAuth2.setPassword(password);
-  }
 }
 
 function replaceVar(str: string, emailAddress: string): string {

--- a/app/logic/Mail/EWS/EWSAccount.ts
+++ b/app/logic/Mail/EWS/EWSAccount.ts
@@ -44,8 +44,6 @@ export class EWSAccount extends MailAccount {
       let urls = OAuth2URLs.find(a => a.hostnames.includes(this.hostname));
       this.oAuth2 = new OAuth2(this, urls.tokenURL, urls.authURL, urls.authDoneURL, urls.scope, urls.clientID, urls.clientSecret);
       this.oAuth2.setTokenURLPasswordAuth(urls.tokenURLPasswordAuth);
-      this.oAuth2.setPassword(this.password);
-      this.oAuth2.username = this.username ?? this.emailAddress;
       this.oAuth2.subscribe(() => this.notifyObservers());
       await this.oAuth2.login(interactive);
     }

--- a/app/logic/Mail/IMAP/IMAPAccount.ts
+++ b/app/logic/Mail/IMAP/IMAPAccount.ts
@@ -79,7 +79,7 @@ export class IMAPAccount extends MailAccount {
       auth: {
         user: this.username,
         pass: usePassword ? this.password : undefined,
-        accessToken: this.oAuth2 ? this.oAuth2.accessToken : null,
+        accessToken: useOAuth2 ? this.oAuth2.accessToken : null,
       },
       clientInfo: useragent,
       tls: {

--- a/app/logic/Mail/Import/Thunderbird/TBProfile.ts
+++ b/app/logic/Mail/Import/Thunderbird/TBProfile.ts
@@ -112,7 +112,6 @@ export class ThunderbirdProfile {
           url.clientID,
           url.clientSecret);
         acc.oAuth2.setTokenURLPasswordAuth(url.tokenURLPasswordAuth);
-        acc.oAuth2.username = acc.username ?? acc.emailAddress;
       }
 
       let identityIDs = this.prefs[`${prefBranch}.identities`]?.split(",");

--- a/app/logic/Mail/MailAccount.ts
+++ b/app/logic/Mail/MailAccount.ts
@@ -110,8 +110,6 @@ export class MailAccount extends Account {
       MailIdentity.fromConfigJSON(json, this)));
     if (config.oAuth2) {
       this.oAuth2 = OAuth2.fromConfigJSON(config.oAuth2, this);
-      this.oAuth2.setPassword(this.password);
-      this.oAuth2.username = this.username ?? this.emailAddress;
       this.oAuth2.subscribe(() => this.notifyObservers());
     }
   }


### PR DESCRIPTION
Alternative fix for issue #117, instead of PRs #130 and #131