### PR TITLE
Include .deb and .rpm artifacts in release

### DIFF
--- a/e2/electron-builder.yml
+++ b/e2/electron-builder.yml
@@ -36,7 +36,7 @@ dmg:
 linux:
   target:
     - AppImage
-    - snap
+    # - snap
     - deb
     - rpm
   maintainer: Mustang

--- a/e2/package.json
+++ b/e2/package.json
@@ -18,7 +18,7 @@
     "build:linux": "npm run build && electron-builder --linux --config",
     "build:release:win": "npm run build && electron-builder --win --config --publish always",
     "build:release:mac": "npm run build && electron-builder --mac --config --publish always",
-    "build:release:linux": "npm run build && electron-builder --linux AppImage --config --publish always",
+    "build:release:linux": "npm run build && electron-builder --linux --config --publish always",
     "postinstall": "electron-builder install-app-deps"
   },
   "dependencies": {


### PR DESCRIPTION
**Changes**

- Remove AppImage param from `build:release:linux` script so it uses the targets in `e2/electron-builder.yml`
- Comment out `snap` target in `e2/electron-builder.yml` because it tries to publish to Snap instead of GitHub and also it needs `snapcraft` to be installed. It causes errors also.

Draft release generated by the action: https://github.com/mustang-im/mustang/releases/tag/untagged-beaee3af94b3a3e82b90