### PR TITLE
Check for updates, notify and install on exit

### DIFF
--- a/e2/package.json
+++ b/e2/package.json
@@ -27,6 +27,7 @@
     "adm-zip": "^0.5.12",
     "better-sqlite3": "^9.4.5",
     "bufferutil": "^4.0.8",
+    "electron-updater": "^6.2.1",
     "utf-8-validate": "^6.0.3",
     "ws": "^8.16.0"
   },

--- a/e2/src/main/index.ts
+++ b/e2/src/main/index.ts
@@ -1,9 +1,9 @@
 import { setMainWindow, startupBackend } from '../../../backend/backend';
 import { app, shell, BrowserWindow } from 'electron'
 import { join } from 'path'
+import { autoUpdater } from 'electron-updater';
 import { electronApp, optimizer, is } from '@electron-toolkit/utils'
 import icon from '../../resources/icon.png?asset'
-import { autoUpdater } from 'electron-updater';
 
 // Set app data directory name to capitalized 'Mustang' on Mac OS instead of 'mustang'
 if (process.platform == 'darwin') {

--- a/e2/src/main/index.ts
+++ b/e2/src/main/index.ts
@@ -3,6 +3,7 @@ import { app, shell, BrowserWindow } from 'electron'
 import { join } from 'path'
 import { electronApp, optimizer, is } from '@electron-toolkit/utils'
 import icon from '../../resources/icon.png?asset'
+import { autoUpdater } from 'electron-updater';
 
 // Set app data directory name to capitalized 'Mustang' on Mac OS instead of 'mustang'
 if (process.platform == 'darwin') {
@@ -95,6 +96,8 @@ app.whenReady().then(() => {
     // dock icon is clicked and there are no other windows open.
     if (BrowserWindow.getAllWindows().length === 0) createWindow()
   })
+
+  autoUpdater.checkForUpdatesAndNotify();
 })
 
 // Quit when all windows are closed, except on macOS. There, it's common


### PR DESCRIPTION
- Call `autoUpdater.checkForUpdatesAndNotify();` when app is ready. Check for updates, notify and install on exit.

Note: Doesn't work on Mac OS X, yet. 