### PR TITLE
Release to Parula repo from Mustang repo

### DIFF
--- a/.github/workflows/installer-linux-parula.yml
+++ b/.github/workflows/installer-linux-parula.yml
@@ -26,7 +26,7 @@ jobs:
     - run: cd e2; npm install --legacy-peer-deps
     - run: cd e2; npm run build:release:linux
       env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        GITHUB_TOKEN: ${{ secrets.PARULA_GH_TOKEN }}
     - name: Upload
       uses: actions/upload-artifact@v4
       with:

--- a/.github/workflows/installer-mac-parula.yml
+++ b/.github/workflows/installer-mac-parula.yml
@@ -26,7 +26,7 @@ jobs:
     - run: cd e2; npm install --legacy-peer-deps
     - run: cd e2; npm run build:release:mac
       env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        GITHUB_TOKEN: ${{ secrets.PARULA_GH_TOKEN }}
     - name: Upload
       uses: actions/upload-artifact@v4
       with:

--- a/.github/workflows/installer-windows-parula.yml
+++ b/.github/workflows/installer-windows-parula.yml
@@ -25,7 +25,7 @@ jobs:
     - run: cd e2; npm install --legacy-peer-deps
     - run: cd e2; npm run build:release:win
       env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        GITHUB_TOKEN: ${{ secrets.PARULA_GH_TOKEN }}
     - name: Upload
       uses: actions/upload-artifact@v4
       with:

--- a/app/build/parula-brand.sh
+++ b/app/build/parula-brand.sh
@@ -12,11 +12,13 @@ perl -p -i \
   -e "s|https://mustang.im|https://parula.beonex.com|g;" \
   -e "s|\"name\": \"mustang\"|\"name\": \"parula\"|;" \
   -e "s|\"version\": \".*\"|\"version\": \"$VERSION\"|;" \
+  -e "s|mustang.git|parula.git|g;" \
   ../../e2/package.json
 perl -p -i \
   -e "s|Mustang|Parula|g;" \
   -e "s|https://mustang.im|https://parula.beonex.com|g;" \
   -e "s|\"name\": \"mustang\"|\"name\": \"parula\"|;" \
+  -e "s|mustang.git|parula.git|g;" \
   ../../app/package.json
 perl -p -i \
   -e "s|Mustang GmbH|Beonex GmbH|g;" \


### PR DESCRIPTION
- `parula-brand.sh` now also changes the git repo url to `parula.git`
- Uses a `PAT` to push release directly to the Parula repo
- No syncing required but the Parula repo will be outdated. Only the releases will be updated.
- Not tested, yet.