### PR TITLE
Set channel name to mustang

### DIFF
--- a/e2/electron-builder.yml
+++ b/e2/electron-builder.yml
@@ -48,5 +48,6 @@ publish:
   - provider: github
     protocol: https
     releaseType: release
+    channel: mustang
 #  - provider generic
 #    url: https://mustang.im/auto-updates


### PR DESCRIPTION
- Set channel name to `mustang`, it changes the `latest.yml` to `mustang.yml`
- The script in `app/build/parula-brand.sh` changes the channel to `parula`