### PR TITLE
OWA: Fast fail until account has logged in #157

### DIFF
--- a/app/logic/Mail/OWA/OWAAccount.ts
+++ b/app/logic/Mail/OWA/OWAAccount.ts
@@ -134,6 +134,9 @@ export class OWAAccount extends MailAccount {
   }
 
   async callOWA(aRequest: any): Promise<any> {
+    if (!this.hasLoggedIn) {
+      throw new LoginError(null, "Please login");
+    }
     let url = this.url + 'service.svc';
     // Need to ensure the request gets passed as a regular object
     let response = await appGlobal.remoteApp.OWA.fetchJSON(this.partition, url, aRequest.type || aRequest.__type.slice(0, -21), Object.assign({}, aRequest));


### PR DESCRIPTION
We default to clearing server cookies if there is an authentication failure response from an OWA call. This does have the unfortunate side-effect that the login window also forgets who you are, but I don't know a better way to reset the cookies to a known state.

However in the case that we know we have failed automatic login (non-Office 365 account, or didn't select "Stay Logged In"), but the user attempted to access OWA anyway, then we can fast fail the OWA call and avoid clearing cookies. This allows the username to be remembered for when the user clicks Get Mail to open the OWA login window.