### PR TITLE
Mac: Code Signing

### DIFF
--- a/.github/workflows/installer-mac-parula.yml
+++ b/.github/workflows/installer-mac-parula.yml
@@ -24,9 +24,17 @@ jobs:
     - run: cd lib; npm install
     - run: cd backend; npm install
     - run: cd e2; npm install --legacy-peer-deps
+    - run: |
+        mkdir -p ~/private_keys/
+        echo '${{ secrets.APPLE_API_KEY }}' > ~/private_keys/AuthKey_${{ secrets.APPLE_API_KEY_ID }}.p8
     - run: cd e2; npm run build:release:mac
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        CSC_LINK: ${{ secrets.CSC_LINK }}
+        CSC_KEY_PASSWORD: ${{ secrets.CSC_KEY_PASSWORD }}
+        APPLE_API_KEY: ~/private_keys/AuthKey_${{ secrets.APPLE_API_KEY_ID }}.p8
+        APPLE_API_KEY_ID: ${{ secrets.APPLE_API_KEY_ID }}
+        APPLE_API_ISSUER: ${{ secrets.APPLE_API_ISSUER }}
     - name: Upload
       uses: actions/upload-artifact@v4
       with:

--- a/.github/workflows/installer-mac.yml
+++ b/.github/workflows/installer-mac.yml
@@ -29,6 +29,9 @@ jobs:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         CSC_LINK: ${{ secrets.CSC_LINK }}
         CSC_KEY_PASSWORD: ${{ secrets.CSC_KEY_PASSWORD }}
+        APPLE_API_KEY: ${{ secrets.APPLE_API_KEY }}
+        APPLE_API_KEY_ID: ${{ secrets.APPLE_API_KEY_ID }}
+        APPLE_API_ISSUER: ${{ secrets.APPLE_API_ISSUER }}
     - name: Upload
       uses: actions/upload-artifact@v4
       with:

--- a/.github/workflows/installer-mac.yml
+++ b/.github/workflows/installer-mac.yml
@@ -27,6 +27,8 @@ jobs:
     - run: cd e2; npm run build:release:mac
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        CSC_LINK: ${{ secrets.CSC_LINK }}
+        CSC_KEY_PASSWORD: ${{ secrets.CSC_KEY_PASSWORD }}
     - name: Upload
       uses: actions/upload-artifact@v4
       with:

--- a/.github/workflows/installer-mac.yml
+++ b/.github/workflows/installer-mac.yml
@@ -24,12 +24,15 @@ jobs:
     - run: cd lib; npm install
     - run: cd backend; npm install
     - run: cd e2; npm install --legacy-peer-deps
+    - run: |
+        mkdir -p ~/private_keys/
+        echo '${{ secrets.APPLE_API_KEY }}' > ~/private_keys/AuthKey_${{ secrets.APPLE_API_KEY_ID }}.p8
     - run: cd e2; npm run build:release:mac
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         CSC_LINK: ${{ secrets.CSC_LINK }}
         CSC_KEY_PASSWORD: ${{ secrets.CSC_KEY_PASSWORD }}
-        APPLE_API_KEY: ${{ secrets.APPLE_API_KEY }}
+        APPLE_API_KEY: ~/private_keys/AuthKey_${{ secrets.APPLE_API_KEY_ID }}.p8
         APPLE_API_KEY_ID: ${{ secrets.APPLE_API_KEY_ID }}
         APPLE_API_ISSUER: ${{ secrets.APPLE_API_ISSUER }}
     - name: Upload

--- a/e2/build/entitlements.mac.plist
+++ b/e2/build/entitlements.mac.plist
@@ -8,5 +8,7 @@
     <true/>
     <key>com.apple.security.cs.allow-dyld-environment-variables</key>
     <true/>
+    <key>com.apple.security.cs.disable-library-validation</key>
+    <true/>
   </dict>
 </plist>

--- a/e2/electron-builder.yml
+++ b/e2/electron-builder.yml
@@ -30,7 +30,7 @@ mac:
     - NSMicrophoneUsageDescription: Application requests access to the device's microphone.
     - NSDocumentsFolderUsageDescription: Application requests access to the user's Documents folder.
     - NSDownloadsFolderUsageDescription: Application requests access to the user's Downloads folder.
-  notarize: false
+  notarize: true
 dmg:
   artifactName: ${name}-${version}.${ext}
 linux:


### PR DESCRIPTION
- Set notarize to true in electron-builder.yml
- `<key>com.apple.security.cs.disable-library-validation</key> <true/>` to fix "Team ID doesn't match" error after app is signed
- Add code-signing and notarization steps to workflow

Note: Notarization step not tested on CI yet