### PR TITLE
Really list new messages

### DIFF
--- a/app/logic/Mail/Folder.ts
+++ b/app/logic/Mail/Folder.ts
@@ -48,9 +48,8 @@ export class Folder extends Observable implements TreeItem<Folder> {
   }
 
   /** Gets the metadata of the emails in this folder.
-   * May be slow, depending on the protocol.
-   * @returns the new messages (not yet downloaded). */
-  async listMessages(): Promise<ArrayColl<EMail>> {
+   * May be slow, depending on the protocol. */
+  async listMessages(): Promise<void> {
     throw new AbstractFunction();
   }
 

--- a/app/logic/Mail/OWA/OWAAccount.ts
+++ b/app/logic/Mail/OWA/OWAAccount.ts
@@ -1,6 +1,7 @@
 import { MailAccount, TLSSocketType } from "../MailAccount";
 import type { EMail } from "../EMail";
 import { OWAFolder } from "./OWAFolder";
+import type { OWAEMail } from "./OWAEMail";
 import OWACreateItemRequest from "./OWACreateItemRequest";
 import { OWAAddressbook } from "../../Contacts/OWA/OWAAddressbook";
 import { OWACalendar } from "../../Calendar/OWA/OWACalendar";
@@ -11,6 +12,7 @@ import { appGlobal } from "../../app";
 import { notifyChangedProperty } from "../../util/Observable";
 import { blobToBase64 } from "../../util/util";
 import { assert } from "../../util/util";
+import { ArrayColl } from "svelte-collections";
 
 class OWAError extends Error {
   constructor(response) {
@@ -222,7 +224,8 @@ export class OWAAccount extends MailAccount {
             }
             if (newMessageIDs.length) {
               let inbox = this.inbox as OWAFolder;
-              let newMessages = await inbox.getNewMessageHeaders(newMessageIDs);
+              let newMessages = new ArrayColl<OWAEMail>();
+              await inbox.getNewMessageHeaders(newMessageIDs, newMessages);
               inbox.messages.addAll(newMessages);
               inbox.downloadMessages(newMessages);
               inbox.dirty = false; // probably


### PR DESCRIPTION
As noted on your commit, there were a few problems with your changes to EWS and OWA, as at best you were weren't actually returning all of the new messages.

Additionally your implementation for new messages for IMAP was to provide a separate function that listed only new messages; indeed you didn't even change the signature of `listMessages` for IMAP, which really threw my TypeScript compiler into a spin, so as part of this I wanted to port that separation to EWS and OWA.