### PR TITLE
Chat viewer: New Iframe component with better autosizing and lazyloading

### DIFF
--- a/app/frontend/Chat/MessageView/Message.svelte
+++ b/app/frontend/Chat/MessageView/Message.svelte
@@ -33,7 +33,7 @@
       <slot name="inner-top" />
       <div class="text selectable">
         <!-- TODO Security: Jail HTML into untrusted <iframe> for additional protection. -->
-        <Iframe title={$t`Text`} html={$message.html || ""} {headHTML} autoSize lazyLoad />
+        <Iframe title={$t`Text`} html={$message.html || ""} {headHTML} autoSize lazyLoad lazyUnload/>
         <slot name="bubble" />
       </div>
       <slot name="inner-bottom" />

--- a/app/frontend/Chat/MessageView/Message.svelte
+++ b/app/frontend/Chat/MessageView/Message.svelte
@@ -33,7 +33,7 @@
       <slot name="inner-top" />
       <div class="text selectable">
         <!-- TODO Security: Jail HTML into untrusted <iframe> for additional protection. -->
-        <WebView title={$t`Text`} html={message.html} {headHTML} autoSize />
+        <Iframe title={$t`Text`} html={message.html} {headHTML} autoSize />
         <slot name="bubble" />
       </div>
       <slot name="inner-bottom" />
@@ -59,6 +59,7 @@
   import WebView from "../../Shared/WebView.svelte";
   import { getDateString } from "../../Util/date";
   import { t } from "../../../l10n/l10n";
+  import Iframe from "../../Shared/Iframe.svelte";
 
   export let message: Message;
   export let previousMessage: Message = null;

--- a/app/frontend/Chat/MessageView/Message.svelte
+++ b/app/frontend/Chat/MessageView/Message.svelte
@@ -56,10 +56,9 @@
   import cssBody from "../../Mail/Message/content-body.css?inline";
   import cssFont from "../../asset/font/Karla.css?inline";
   import PersonPicture from "../../Shared/Person/PersonPicture.svelte";
-  import WebView from "../../Shared/WebView.svelte";
+  import Iframe from "../../Shared/Iframe.svelte";
   import { getDateString } from "../../Util/date";
   import { t } from "../../../l10n/l10n";
-  import Iframe from "../../Shared/Iframe.svelte";
 
   export let message: Message;
   export let previousMessage: Message = null;

--- a/app/frontend/Chat/MessageView/Message.svelte
+++ b/app/frontend/Chat/MessageView/Message.svelte
@@ -33,7 +33,7 @@
       <slot name="inner-top" />
       <div class="text selectable">
         <!-- TODO Security: Jail HTML into untrusted <iframe> for additional protection. -->
-        <Iframe title={$t`Text`} html={message.html} {headHTML} autoSize lazyLoad />
+        <Iframe title={$t`Text`} html={$message.html || ""} {headHTML} autoSize lazyLoad />
         <slot name="bubble" />
       </div>
       <slot name="inner-bottom" />

--- a/app/frontend/Chat/MessageView/Message.svelte
+++ b/app/frontend/Chat/MessageView/Message.svelte
@@ -33,7 +33,7 @@
       <slot name="inner-top" />
       <div class="text selectable">
         <!-- TODO Security: Jail HTML into untrusted <iframe> for additional protection. -->
-        <Iframe title={$t`Text`} html={message.html} {headHTML} autoSize />
+        <Iframe title={$t`Text`} html={message.html} {headHTML} autoSize lazyLoad />
         <slot name="bubble" />
       </div>
       <slot name="inner-bottom" />

--- a/app/frontend/Shared/Iframe.svelte
+++ b/app/frontend/Shared/Iframe.svelte
@@ -49,6 +49,7 @@
   const reSizeCSS = `<style>
   body {
     min-height: 0px;
+    min-width: 100px;
     height: fit-content;
     width: fit-content;
   }
@@ -58,9 +59,10 @@
     window.onload = () => {
       window.addEventListener("message", (e) => {
         if (e.origin == "${origin}" && e.data == "dimensions") {
-          const body = document.body;
           const html = document.documentElement;
-          const width = Math.max( body.scrollWidth, body.offsetWidth, html.clientWidth, html.scrollWidth, html.offsetWidth );
+          const body = document.body;
+          const bodyStyles = window.getComputedStyle(body);
+          const width = parseFloat(bodyStyles.width);
           const height = Math.max( body.scrollHeight, body.offsetHeight, html.clientHeight, html.scrollHeight, html.offsetHeight );
           window.parent.postMessage({
             width: width,
@@ -91,19 +93,22 @@
     iframeE.addEventListener("load", () => {
       dispatch("iframe", iframeE);
       if (autoSize) {
-        resizeWebview();
+        resizeIframe();
       }
     }, { once: true });
   }
 
-  async function resizeWebview () {
+  const heigthBuffer = 10;
+  async function resizeIframe () {
     try {
       iframeE.contentWindow.postMessage("dimensions", "*");
       window.addEventListener("message", (e) => {
         const dimensions = e.data;
         if (iframeE) {
-          iframeE.style.width = dimensions.width + "px";
-          iframeE.style.height = dimensions.height + "px";
+          const style = window.getComputedStyle(iframeE);
+          const maxWidth = parseFloat(style.width);
+          iframeE.style.width = Math.min(maxWidth, dimensions.width) + "px";
+          iframeE.style.height = (dimensions.height + heigthBuffer) + "px";
         }
       });
     } catch (ex) {
@@ -153,7 +158,9 @@
   }
   iframe {
     flex: 1 1 0;
-    width: 100%;
+    border: none;
+    width: 1000px;
+    max-width: 100%;
   }
 </style>
 

--- a/app/frontend/Shared/Iframe.svelte
+++ b/app/frontend/Shared/Iframe.svelte
@@ -2,20 +2,20 @@
   <div bind:this={placeholderE} class="placeholder"></div>
 {/if}
 {#if loaded}
-  <!-- TODO Security: Test that this <webview> is untrusted and jailed -->
+  <!-- TODO Security: Test that this <iframe> is untrusted and jailed -->
   <iframe 
     bind:this={iframeE} 
     src={url} 
     {title} 
     sandbox={autoSize ? "allow-scripts" : ""} 
-    csp="sandbox allow-scripts; default-src 'self' 'unsafe-inline'"
+    csp="sandbox {autoSize ? "allow-scripts" : ""}; default-src 'self' 'unsafe-inline'"
     credentialless 
   />
 {/if}
 
 <script lang="ts">
   import { stringToDataURL } from "../Util/util";
-  import { createEventDispatcher, onMount } from 'svelte';
+  import { createEventDispatcher } from 'svelte';
   const dispatch = createEventDispatcher();
 
   /**
@@ -66,20 +66,18 @@
   </style>`;
 
   const autoSizeScript = `<script>
-    window.addEventListener("load", () => {
-      window.addEventListener("message", (e) => {
-        if (e.origin == "${origin}" && e.data == "dimensions") {
-          const html = document.documentElement;
-          const body = document.body;
-          const bodyStyles = window.getComputedStyle(body);
-          const width = parseFloat(bodyStyles.width);
-          const height = Math.max( body.scrollHeight, body.offsetHeight, html.clientHeight, html.scrollHeight, html.offsetHeight );
-          window.parent.postMessage({
-            width: width,
-            height: height,
-          }, "${origin}");
-        }
-      });
+    window.addEventListener("message", (e) => {
+      if (e.origin == "${origin}" && e.data == "dimensions") {
+        const html = document.documentElement;
+        const body = document.body;
+        const bodyStyles = window.getComputedStyle(body);
+        const width = parseFloat(bodyStyles.width);
+        const height = Math.max( body.scrollHeight, body.offsetHeight, html.clientHeight, html.scrollHeight, html.offsetHeight );
+        window.parent.postMessage({
+          width: width,
+          height: height,
+        }, "${origin}");
+      }
     });
   <\/script>`; 
   $: html && setURL();
@@ -175,6 +173,7 @@
     border: none;
     width: 100%;
     max-width: 100%;
+    min-height: 0px;
   }
 </style>
 

--- a/app/frontend/Shared/Iframe.svelte
+++ b/app/frontend/Shared/Iframe.svelte
@@ -86,8 +86,8 @@
 
   let iframeE: HTMLIFrameElement = null;
 
-  $: loaded && iframeE && haveWebView();
-  function haveWebView () {
+  $: loaded && iframeE && haveIframe();
+  function haveIframe () {
     iframeE.addEventListener("load", () => {
       dispatch("iframe", iframeE);
       if (autoSize) {
@@ -103,7 +103,7 @@
         const dimensions = e.data;
         if (iframeE) {
           iframeE.style.width = dimensions.width + "px";
-          iframeE.style.height = dimensions.height + "px";          
+          iframeE.style.height = dimensions.height + "px";
         }
       });
     } catch (ex) {
@@ -137,7 +137,7 @@
         loaded = false;
         observer.unobserve(e.target);
       }
-    });
+    }, { rootMargin: "100px 0px" });
     try {
       observer.observe(iframeE);
     } catch (ex) {
@@ -147,6 +147,10 @@
 </script>
 
 <style>
+  .placeholder {
+    width: 100%;
+    height: 25px;
+  }
   iframe {
     flex: 1 1 0;
     width: 100%;

--- a/app/frontend/Shared/Iframe.svelte
+++ b/app/frontend/Shared/Iframe.svelte
@@ -35,6 +35,8 @@
    */
   export let allowServerCalls: boolean | string = true;
 
+  const origin = window.origin;
+
   const reSizeCSS = `<style>
   body {
     min-height: 0px;
@@ -52,7 +54,7 @@
       window.parent.postMessage({
         width: width,
         height: height,
-      }, "*");
+      }, "${origin}");
     };
   <\/script>`;
   $: html && setURL();
@@ -75,7 +77,7 @@
     iframeE.addEventListener("load", () => {
       dispatch("iframe", iframeE);
       if (autoSize) {
-        iframeE.addEventListener("load", resizeIframe);
+        resizeIframe();
       }
     }, { once: true });
   }
@@ -86,11 +88,10 @@
     try {
       // console.log(iframeE.contentWindow.document);
       window.addEventListener("message", (e) => {
-        console.log(html);
         const dimensions = e.data;
         iframeE.style.width = (dimensions.width + widthBuffer) + "px";
         iframeE.style.height = (dimensions.height + heightBuffer) + "px";
-      })
+      });
       // iframeE.style.width = (dimensions.width + widthBuffer) + "px";
       // iframeE.style.height = (dimensions.height + heightBuffer) + "px";
     } catch (ex) {

--- a/app/frontend/Shared/Iframe.svelte
+++ b/app/frontend/Shared/Iframe.svelte
@@ -3,7 +3,7 @@
 
 <script lang="ts">
   import { stringToDataURL } from "../Util/util";
-  import { createEventDispatcher } from 'svelte';
+  import { createEventDispatcher, onMount } from 'svelte';
   const dispatch = createEventDispatcher();
 
   /**
@@ -72,15 +72,14 @@
   }
 
   let iframeE: HTMLIFrameElement = null;
-  $: iframeE && haveIframe();
-  function haveIframe () {
+  onMount(() => {
     iframeE.addEventListener("load", () => {
       dispatch("iframe", iframeE);
       if (autoSize) {
         resizeIframe();
       }
     }, { once: true });
-  }
+  });
 
   const widthBuffer = 0;
   const heightBuffer = 0;
@@ -91,7 +90,7 @@
         const dimensions = e.data;
         iframeE.style.width = (dimensions.width + widthBuffer) + "px";
         iframeE.style.height = (dimensions.height + heightBuffer) + "px";
-      });
+      }, { once: true });
       // iframeE.style.width = (dimensions.width + widthBuffer) + "px";
       // iframeE.style.height = (dimensions.height + heightBuffer) + "px";
     } catch (ex) {

--- a/app/frontend/Shared/Iframe.svelte
+++ b/app/frontend/Shared/Iframe.svelte
@@ -117,8 +117,8 @@
 
   let placeholderE: HTMLDivElement;
 
-  $: lazyLoad && placeholderE && startLazy();
-  function startLazy() {
+  $: lazyLoad && placeholderE && startLazyLoad();
+  function startLazyLoad() {
     const observer = new IntersectionObserver((entries) => {
       const e = entries[0];
       if (e.isIntersecting) {

--- a/app/frontend/Shared/Iframe.svelte
+++ b/app/frontend/Shared/Iframe.svelte
@@ -3,7 +3,7 @@
 {/if}
 {#if loaded}
   <!-- TODO Security: Test that this <webview> is untrusted and jailed -->
-  <iframe bind:this={iframeE} src={url} {title} />
+  <iframe bind:this={iframeE} src={url} {title} sandbox="allow-scripts" credentialless/>
 {/if}
 
 <script lang="ts">

--- a/app/frontend/Shared/Iframe.svelte
+++ b/app/frontend/Shared/Iframe.svelte
@@ -31,6 +31,8 @@
   export let autoSize = false;
   /** Lazy load iframe */
   export let lazyLoad = false;
+  /** Unload iframe when not in view */
+  export let lazyUnload = false;
   /**
    * Which HTTP servers may be called automatically during the HTML load,
    * e.g. for images, stylesheets etc.?
@@ -57,7 +59,7 @@
   </style>`;
 
   const reSizeScript = `<script>
-    window.onload = () => {
+    window.addEventListener("load", () => {
       window.addEventListener("message", (e) => {
         if (e.origin == "${origin}" && e.data == "dimensions") {
           const html = document.documentElement;
@@ -71,7 +73,7 @@
           }, "${origin}");
         }
       });
-    }
+    });
   <\/script>`; 
   $: html && setURL();
   async function setURL() {
@@ -106,7 +108,9 @@
       window.addEventListener("message", (e) => {
         const dimensions = e.data;
         if (iframeE) {
-          iframeE.style.width =  iframeE.parentElement.clientWidth > dimensions.width ? "100%" : dimensions.width + "px";
+          if (iframeE.parentElement.clientWidth < dimensions.width) {
+            iframeE.style.width = dimensions.width + "px";
+          }
           iframeE.style.height = (dimensions.height + heigthBuffer) + "px";
         }
       });
@@ -133,7 +137,7 @@
     }
   }
 
-  $: lazyLoad && iframeE && startLazyUnload();
+  $: lazyUnload && iframeE && startLazyUnload();
   function startLazyUnload() {
     const observer = new IntersectionObserver((entries) => {
       const e = entries[0];

--- a/app/frontend/Shared/Iframe.svelte
+++ b/app/frontend/Shared/Iframe.svelte
@@ -1,0 +1,108 @@
+<!-- TODO Security: Test that this <iframe> is untrusted and jailed -->
+<iframe bind:this={iframeE} src={url} {title} sandbox="allow-scripts" loading="lazy"/>
+
+<script lang="ts">
+  import { stringToDataURL } from "../Util/util";
+  import { createEventDispatcher } from 'svelte';
+  const dispatch = createEventDispatcher();
+
+  /**
+   * Displays untrusted HTML in a sandboxed iframe which does not allow any JavaScript.
+   */
+
+  /** The HTML to display.
+   * DANGER Attention: The HTML should already be sanitized using `sanitizeHTML()`
+   * Alternative to `url` - set only one of them. */
+  export let html: string | null = null;
+  /** Insert this into the `<head>` section of the HTML, before display.
+   * Optional */
+  export let headHTML = "";
+  /** The webpage to show.
+   * Alternative to `html` - set only one of them. */
+  export let url = "";
+  /** Tooltip when hovering */
+  export let title: string;
+  /** Size the <Iframe> to the size of the content */
+  export let autoSize = false;
+  /**
+   * Which HTTP servers may be called automatically during the HTML load,
+   * e.g. for images, stylesheets etc.?
+   * true (default) = `*` any HTTP server on any domain
+   * false = `none` = No outgoing calls at all
+   * `https://proxy.example.com` = Only allow calls to "https://proxy.example.com/*"
+   *
+   * This does *not* limit user clicks on links like `<a href="https://...">`.
+   */
+  export let allowServerCalls: boolean | string = true;
+
+  const reSizeCSS = `<style>
+  body {
+    min-height: 0px;
+    height: fit-content;
+    width: fit-content;
+  }
+  </style>`;
+
+  const reSizeScript = `<script>
+    window.onload = (e) => {
+      const body = document.body;
+      const html = document.documentElement;
+      const width = Math.max( body.scrollWidth, body.offsetWidth, html.clientWidth, html.scrollWidth, html.offsetWidth );
+      const height = Math.max( body.scrollHeight, body.offsetHeight, html.clientHeight, html.scrollHeight, html.offsetHeight );
+      window.parent.postMessage({
+        width: width,
+        height: height,
+      }, "*");
+    };
+  <\/script>`;
+  $: html && setURL();
+  async function setURL() {
+    url = "";
+    let displayHTML = html;
+    let head = headHTML; /*`<meta http-equiv="Content-Security-Policy" content="default-src '${
+      allowServerCalls === true ? "*" : allowServerCalls === false ? "none" : allowServerCalls
+    }'">\n\n` + headHTML + `\n\n`; */
+    let headPos = displayHTML.indexOf("<head>");
+    headPos = headPos < 0 ? 0 : headPos + 6;
+    displayHTML = displayHTML.substring(0, headPos) + head + reSizeCSS + displayHTML.substring(headPos) + reSizeScript;
+    // console.log("html", displayHTML);
+    url = await stringToDataURL("text/html", displayHTML);
+  }
+
+  let iframeE: HTMLIFrameElement = null;
+  $: iframeE && haveIframe();
+  function haveIframe () {
+    iframeE.addEventListener("load", () => {
+      dispatch("iframe", iframeE);
+      if (autoSize) {
+        iframeE.addEventListener("load", resizeIframe);
+      }
+    }, { once: true });
+  }
+
+  const widthBuffer = 0;
+  const heightBuffer = 0;
+  async function resizeIframe () {
+    try {
+      // console.log(iframeE.contentWindow.document);
+      window.addEventListener("message", (e) => {
+        console.log(html);
+        const dimensions = e.data;
+        iframeE.style.width = (dimensions.width + widthBuffer) + "px";
+        iframeE.style.height = (dimensions.height + heightBuffer) + "px";
+      })
+      // iframeE.style.width = (dimensions.width + widthBuffer) + "px";
+      // iframeE.style.height = (dimensions.height + heightBuffer) + "px";
+    } catch (ex) {
+      console.error(ex);
+    }
+  };
+</script>
+
+<style>
+  iframe {
+    flex: 1 1 0;
+    width: 100%;
+  }
+</style>
+

--- a/app/frontend/Shared/Iframe.svelte
+++ b/app/frontend/Shared/Iframe.svelte
@@ -3,7 +3,14 @@
 {/if}
 {#if loaded}
   <!-- TODO Security: Test that this <webview> is untrusted and jailed -->
-  <iframe bind:this={iframeE} src={url} {title} sandbox={autoSize ? "allow-scripts" : ""} credentialless/>
+  <iframe 
+    bind:this={iframeE} 
+    src={url} 
+    {title} 
+    sandbox={autoSize ? "allow-scripts" : ""} 
+    csp="sandbox allow-scripts; default-src 'self' 'unsafe-inline'"
+    credentialless 
+  />
 {/if}
 
 <script lang="ts">

--- a/app/frontend/Shared/Iframe.svelte
+++ b/app/frontend/Shared/Iframe.svelte
@@ -50,11 +50,11 @@
 
   const autoSizeCSS = `<style>
   body {
-    min-height: 0px;
-    min-width: 100px;
-    height: fit-content;
-    width: fit-content;
-    over-flow: visible;
+    min-height: 0px !important;
+    min-width: 100px !important;
+    height: fit-content !important;
+    width: fit-content !important;
+    over-flow: visible !important;
   }
   </style>`;
 

--- a/app/frontend/Shared/Iframe.svelte
+++ b/app/frontend/Shared/Iframe.svelte
@@ -52,6 +52,7 @@
     min-width: 100px;
     height: fit-content;
     width: fit-content;
+    over-flow: visible;
   }
   </style>`;
 
@@ -105,9 +106,7 @@
       window.addEventListener("message", (e) => {
         const dimensions = e.data;
         if (iframeE) {
-          const style = window.getComputedStyle(iframeE);
-          const maxWidth = parseFloat(style.width);
-          iframeE.style.width = Math.min(maxWidth, dimensions.width) + "px";
+          iframeE.style.width =  iframeE.parentElement.clientWidth > dimensions.width ? "100%" : dimensions.width + "px";
           iframeE.style.height = (dimensions.height + heigthBuffer) + "px";
         }
       });
@@ -159,7 +158,7 @@
   iframe {
     flex: 1 1 0;
     border: none;
-    width: 1000px;
+    width: 100%;
     max-width: 100%;
   }
 </style>


### PR DESCRIPTION
- Inject CSS and JS while generating the `data:URI`
- Set the iframe to the `width` of the content and use `max-width: 100%` to contain it with in the parent
- Only load the iframe when it is in view because each iframe is essentially using the same amount of resource as a browser tab/window.
- We also have to unload the iframe because when switching between the chats the iframes are still there and it tries to load all of the iframes and its contents at once causing the lag
- Uses `message` events and `postMessage()` instead of `executeJavascript()`, and `postMessage()` doesn't work with `<webview>` because it's in a different process
- Set `sandbox` to restrict the iframe, but "allow-scripts" needs to set for the autoSize. Maybe "allow-scripts" only when we need to get the size would be better but I tried setting it just before the postMessage() call to the iframe content and it doesn't work.
- Set "credentialless" an experimental Chrome feature that: "its content will be loaded in a new, ephemeral context."
- Set "csp" an experimental Chrome feature that sets the "Content Security Policy"

**Known Issues**

- The component loads and unloads continuously when on the margin of the frame which makes it look glitch, I tried setting `rootMargin: "100px 0px"` but it doesn't work even with four explicit values for each side doesn't work
- The scroll feels jumpy because of the loading and unloading