### PR TITLE
Chat viewer: webview resizable

### DIFF
--- a/app/frontend/Chat/MessageView/Message.svelte
+++ b/app/frontend/Chat/MessageView/Message.svelte
@@ -4,7 +4,6 @@
   class:outgoing={$message.outgoing}
   class:followup
   deliveryStatus={$message instanceof ChatMessage ? $message.deliveryStatus : DeliveryStatus.Unknown}
-  bind:this={messageE}
   >
   {#if !$message.outgoing && !followup}
     <vbox class="avatar">
@@ -34,7 +33,7 @@
       <slot name="inner-top" />
       <div class="text selectable">
         <!-- TODO Security: Jail HTML into untrusted <iframe> for additional protection. -->
-        <WebView title={$t`Text`} html={$message.html || ""} {headHTML} autoSize {maxWidth} />
+        <WebView title={$t`Text`} html={$message.html || ""} {headHTML} autoSize />
         <slot name="bubble" />
       </div>
       <slot name="inner-bottom" />
@@ -60,7 +59,6 @@
   import WebView from "../../Shared/WebView.svelte";
   import { getDateString } from "../../Util/date";
   import { t } from "../../../l10n/l10n";
-  import { onMount } from "svelte";
 
   export let message: Message;
   export let previousMessage: Message = null;
@@ -74,21 +72,6 @@
   $: reactions = $message.reactions;
 
   $: headHTML = `<style>\n${cssBody}\n${cssContent}\n</style>`;
-
-  let messageE: HTMLDivElement;
-  let maxWidth: number;
-
-  onMount(() => {
-    observeMaxWidth();
-  });
-
-  function observeMaxWidth() {
-    const observer = new ResizeObserver((entries) => {
-      const el = entries[0];
-      maxWidth = el.contentRect.width * 0.75;
-    });
-    observer.observe(messageE.parentElement);
-  }
 </script>
 
 <style>

--- a/app/frontend/Chat/MessageView/Message.svelte
+++ b/app/frontend/Chat/MessageView/Message.svelte
@@ -32,8 +32,10 @@
       {/if}
       <slot name="inner-top" />
       <div class="text selectable">
-        <!-- TODO Security: Jail HTML into untrusted <iframe> for additional protection. -->
+        {@html $message.html || ""}
+        <!-- TODO Security: Jail HTML into untrusted <iframe> for additional protection.
         <WebView title={$t`Text`} html={$message.html || ""} {headHTML} autoSize />
+        -->
         <slot name="bubble" />
       </div>
       <slot name="inner-bottom" />

--- a/app/frontend/Chat/MessageView/Message.svelte
+++ b/app/frontend/Chat/MessageView/Message.svelte
@@ -32,10 +32,8 @@
       {/if}
       <slot name="inner-top" />
       <div class="text selectable">
-        {@html $message.html || ""}
-        <!-- TODO Security: Jail HTML into untrusted <iframe> for additional protection.
-        <WebView title={$t`Text`} html={message.html} {headHTML} autoSize />
-        -->
+        <!-- TODO Security: Jail HTML into untrusted <iframe> for additional protection. -->
+        <WebView title={$t`Text`} html={$message.html || ""} {headHTML} autoSize />
         <slot name="bubble" />
       </div>
       <slot name="inner-bottom" />

--- a/app/frontend/Chat/MessageView/Message.svelte
+++ b/app/frontend/Chat/MessageView/Message.svelte
@@ -34,7 +34,7 @@
       <slot name="inner-top" />
       <div class="text selectable">
         <!-- TODO Security: Jail HTML into untrusted <iframe> for additional protection. -->
-        <WebView title={$t`Text`} html={$message.html || ""} {headHTML} autoSize {maxWidth}/>
+        <WebView title={$t`Text`} html={$message.html || ""} {headHTML} autoSize {maxWidth} />
         <slot name="bubble" />
       </div>
       <slot name="inner-bottom" />

--- a/app/frontend/Chat/MessageView/Message.svelte
+++ b/app/frontend/Chat/MessageView/Message.svelte
@@ -4,6 +4,7 @@
   class:outgoing={$message.outgoing}
   class:followup
   deliveryStatus={$message instanceof ChatMessage ? $message.deliveryStatus : DeliveryStatus.Unknown}
+  bind:this={messageE}
   >
   {#if !$message.outgoing && !followup}
     <vbox class="avatar">
@@ -33,7 +34,7 @@
       <slot name="inner-top" />
       <div class="text selectable">
         <!-- TODO Security: Jail HTML into untrusted <iframe> for additional protection. -->
-        <WebView title={$t`Text`} html={$message.html || ""} {headHTML} autoSize />
+        <WebView title={$t`Text`} html={$message.html || ""} {headHTML} autoSize {maxWidth}/>
         <slot name="bubble" />
       </div>
       <slot name="inner-bottom" />
@@ -59,6 +60,7 @@
   import WebView from "../../Shared/WebView.svelte";
   import { getDateString } from "../../Util/date";
   import { t } from "../../../l10n/l10n";
+  import { onMount } from "svelte";
 
   export let message: Message;
   export let previousMessage: Message = null;
@@ -72,6 +74,21 @@
   $: reactions = $message.reactions;
 
   $: headHTML = `<style>\n${cssBody}\n${cssContent}\n</style>`;
+
+  let messageE: HTMLDivElement;
+  let maxWidth: number;
+
+  onMount(() => {
+    observeMaxWidth();
+  });
+
+  function observeMaxWidth() {
+    const observer = new ResizeObserver((entries) => {
+      const el = entries[0];
+      maxWidth = el.contentRect.width * 0.75;
+    });
+    observer.observe(messageE.parentElement);
+  }
 </script>
 
 <style>

--- a/app/frontend/Shared/WebView.svelte
+++ b/app/frontend/Shared/WebView.svelte
@@ -35,6 +35,16 @@
    */
   export let allowServerCalls: boolean | string = true;
 
+  const autoSizeCSS = `<style>
+  body {
+    min-height: 0px !important;
+    min-width: 100px !important;
+    height: fit-content !important;
+    width: fit-content !important;
+    over-flow: visible !important;
+  }
+  </style>`;
+
   $: html && setURL();
   async function setURL() {
     url = "";
@@ -44,7 +54,11 @@
     }'">\n\n` + headHTML + `\n\n`; */
     let headPos = displayHTML.indexOf("<head>");
     headPos = headPos < 0 ? 0 : headPos + 6;
-    displayHTML = displayHTML.substring(0, headPos) + head + displayHTML.substring(headPos);
+    if (autoSize) {
+      displayHTML = displayHTML.substring(0, headPos) + head + autoSizeCSS + displayHTML.substring(headPos);
+    } else {
+      displayHTML = displayHTML.substring(0, headPos) + head + displayHTML.substring(headPos);
+    }    
     // console.log("html", displayHTML);
     url = await stringToDataURL("text/html", displayHTML);
   }

--- a/app/frontend/Shared/WebView.svelte
+++ b/app/frontend/Shared/WebView.svelte
@@ -79,18 +79,16 @@
   async function resizeWebview () {
     try {
       const dimensions = await webviewE.executeJavaScript(`
-        document.body.style.minHeight = "0px";
-        document.body.style.height = "fit-content";
-        document.body.style.width = "fit-content";
+        const html = document.documentElement;
+        const body = document.body;
+        const bodyStyles = window.getComputedStyle(body);
+        const width = parseFloat(bodyStyles.width);
+        const height = Math.max( body.scrollHeight, body.offsetHeight, html.clientHeight, html.scrollHeight, html.offsetHeight );
         new Promise(resolve => {
-          const observer = new ResizeObserver(entries => {
-            const contentRect = entries[0].borderBoxSize[0];
-            resolve({
-              width: contentRect.inlineSize,
-              height: contentRect.blockSize,
-            });
+          resolve({
+            width: width,
+            height: height,
           });
-          observer.observe(document.body);
         });
       `);
       webviewE.style.width = (dimensions.width + widthBuffer) + "px";

--- a/app/frontend/Shared/WebView.svelte
+++ b/app/frontend/Shared/WebView.svelte
@@ -84,11 +84,10 @@
     try {
       size = await webviewE.executeJavaScript(`
         try {
-          const html = document.documentElement;
           const body = document.body;
-          const bodyStyles = window.getComputedStyle(body);
-          const width = parseFloat(bodyStyles.width);
-          const height = Math.max( body.scrollHeight, body.offsetHeight, html.clientHeight, html.scrollHeight, html.offsetHeight );
+          const styles = window.getComputedStyle(body);
+          const width = parseFloat(styles.width);
+          const height = Math.max( body.scrollHeight, body.offsetHeight, parseFloat(styles.height) );
           new Promise((resolve) => {
             resolve({
               width: width,
@@ -119,9 +118,7 @@
     if (webviewE.parentElement && size.width < webviewE.parentElement.clientWidth) {
       webviewE.style.width = "100%";
     }
-    if (size.height != webviewE.style.height) {
-      webviewE.style.height = (size.height + heightBuffer) + "px";
-    }
+    webviewE.style.height = (size.height + heightBuffer) + "px";
   };
 </script>
 

--- a/app/frontend/Shared/WebView.svelte
+++ b/app/frontend/Shared/WebView.svelte
@@ -55,7 +55,7 @@
     webviewE.addEventListener("dom-ready", () => {
       dispatch("webview", webviewE);
       if (autoSize) {
-        webviewE.addEventListener("did-finish-load", resizeWebview());
+        webviewE.addEventListener("did-finish-load", resizeWebview);
       }
     }, { once: true });
   }


### PR DESCRIPTION
- `<webview>` is now resizable but by passing in a maxWidth from the parent
- `<webview>` doesn't respect max-width like an iframe so we need to get it from the parent element
- It gets the size only at the first load of the content. After that, it adjusts the width based on the max-width, this should make it much lighter.
- Inject CSS when generating the data:URI so it doesn't reflow

Known Issues:

- The height is still not accurate, and some times the width.
- The height grows every time you switch a chat/person because reuses the same webview and 'fit-content' property fills space available and when we add the buffer it'll become larger. After that, webview is bigger and adds the buffer again.
- The resizing lags sometimes