### PR TITLE
e2: Output ESM instead of CJS for main and preload scripts

### DIFF
--- a/e2/electron.vite.config.ts
+++ b/e2/electron.vite.config.ts
@@ -1,11 +1,13 @@
 import { defineConfig, externalizeDepsPlugin } from 'electron-vite';
 import { nodePolyfills } from "vite-plugin-node-polyfills";
 import { svelte } from '@sveltejs/vite-plugin-svelte';
+import esmShim from 'esm-shim-plugin';
 
 export default defineConfig({
   main: {
     plugins: [
       externalizeDepsPlugin({ exclude: ["@radically-straightforward/sqlite"] }),
+      esmShim(),
     ],
     build: {
       rollupOptions: {
@@ -16,7 +18,10 @@ export default defineConfig({
     },
   },
   preload: {
-    plugins: [externalizeDepsPlugin()],
+    plugins: [
+      externalizeDepsPlugin(),
+      esmShim(),
+    ],
     build: {
       rollupOptions: {
         output: {

--- a/e2/electron.vite.config.ts
+++ b/e2/electron.vite.config.ts
@@ -1,13 +1,15 @@
 import { defineConfig, externalizeDepsPlugin } from 'electron-vite';
 import { nodePolyfills } from "vite-plugin-node-polyfills";
 import { svelte } from '@sveltejs/vite-plugin-svelte';
-import esmShim from 'esm-shim-plugin';
+import replace from '@rollup/plugin-replace';
 
 export default defineConfig({
   main: {
     plugins: [
       externalizeDepsPlugin({ exclude: ["@radically-straightforward/sqlite"] }),
-      esmShim(),
+      replace({
+        __dirname: 'import.meta.dirname',
+      }),
     ],
     build: {
       rollupOptions: {
@@ -20,7 +22,6 @@ export default defineConfig({
   preload: {
     plugins: [
       externalizeDepsPlugin(),
-      esmShim(),
     ],
     build: {
       rollupOptions: {

--- a/e2/electron.vite.config.ts
+++ b/e2/electron.vite.config.ts
@@ -6,10 +6,24 @@ export default defineConfig({
   main: {
     plugins: [
       externalizeDepsPlugin({ exclude: ["@radically-straightforward/sqlite"] }),
-    ]
+    ],
+    build: {
+      rollupOptions: {
+        output: {
+          format: 'es'
+        }
+      }
+    },
   },
   preload: {
-    plugins: [externalizeDepsPlugin()]
+    plugins: [externalizeDepsPlugin()],
+    build: {
+      rollupOptions: {
+        output: {
+          format: 'es'
+        }
+      }
+    },
   },
   renderer: {
     plugins: [nodePolyfills({include: ['buffer'], globals: {global: false, process: false}}), svelte()]

--- a/e2/electron.vite.config.ts
+++ b/e2/electron.vite.config.ts
@@ -11,25 +11,11 @@ export default defineConfig({
         __dirname: 'import.meta.dirname',
       }),
     ],
-    build: {
-      rollupOptions: {
-        output: {
-          format: 'es',
-        },
-      },
-    },
   },
   preload: {
     plugins: [
       externalizeDepsPlugin(),
     ],
-    build: {
-      rollupOptions: {
-        output: {
-          format: 'es',
-        },
-      },
-    },
   },
   renderer: {
     plugins: [nodePolyfills({include: ['buffer'], globals: {global: false, process: false}}), svelte()]

--- a/e2/electron.vite.config.ts
+++ b/e2/electron.vite.config.ts
@@ -12,7 +12,7 @@ export default defineConfig({
     build: {
       rollupOptions: {
         output: {
-          format: 'es'
+          format: 'es',
         },
       },
     },
@@ -25,7 +25,7 @@ export default defineConfig({
     build: {
       rollupOptions: {
         output: {
-          format: 'es'
+          format: 'es',
         },
       },
     },

--- a/e2/electron.vite.config.ts
+++ b/e2/electron.vite.config.ts
@@ -1,6 +1,6 @@
-import { defineConfig, externalizeDepsPlugin } from 'electron-vite'
+import { defineConfig, externalizeDepsPlugin } from 'electron-vite';
 import { nodePolyfills } from "vite-plugin-node-polyfills";
-import { svelte } from '@sveltejs/vite-plugin-svelte'
+import { svelte } from '@sveltejs/vite-plugin-svelte';
 
 export default defineConfig({
   main: {
@@ -11,8 +11,8 @@ export default defineConfig({
       rollupOptions: {
         output: {
           format: 'es'
-        }
-      }
+        },
+      },
     },
   },
   preload: {
@@ -21,8 +21,8 @@ export default defineConfig({
       rollupOptions: {
         output: {
           format: 'es'
-        }
-      }
+        },
+      },
     },
   },
   renderer: {

--- a/e2/package.json
+++ b/e2/package.json
@@ -29,7 +29,6 @@
     "better-sqlite3": "^11.2.1",
     "bufferutil": "^4.0.8",
     "electron-updater": "^6.3.3",
-    "esm-shim-plugin": "https://github.com/jermy-c/esm-shim-plugin",
     "utf-8-validate": "^6.0.3",
     "ws": "^8.16.0"
   },

--- a/e2/package.json
+++ b/e2/package.json
@@ -37,7 +37,7 @@
     "@electron-toolkit/tsconfig": "^1.0.1",
     "@sveltejs/vite-plugin-svelte": "^3.0.1",
     "@types/node": "^18.17.5",
-    "electron": "^25.6.0",
+    "electron": "^32.0.1",
     "electron-builder": "^24.6.3",
     "electron-vite": "^2.3.0",
     "eslint": "^8.47.0",

--- a/e2/package.json
+++ b/e2/package.json
@@ -29,6 +29,7 @@
     "better-sqlite3": "^11.2.1",
     "bufferutil": "^4.0.8",
     "electron-updater": "^6.3.3",
+    "esm-shim-plugin": "https://github.com/jermy-c/esm-shim-plugin",
     "utf-8-validate": "^6.0.3",
     "ws": "^8.16.0"
   },

--- a/e2/package.json
+++ b/e2/package.json
@@ -25,7 +25,7 @@
     "@electron-toolkit/preload": "^2.0.0",
     "@electron-toolkit/utils": "^2.0.0",
     "adm-zip": "^0.5.12",
-    "better-sqlite3": "^9.4.5",
+    "better-sqlite3": "^11.2.1",
     "bufferutil": "^4.0.8",
     "electron-updater": "^6.3.3",
     "utf-8-validate": "^6.0.3",

--- a/e2/package.json
+++ b/e2/package.json
@@ -37,6 +37,7 @@
     "@electron-toolkit/eslint-config-prettier": "^1.0.1",
     "@electron-toolkit/eslint-config-ts": "^1.0.0",
     "@electron-toolkit/tsconfig": "^1.0.1",
+    "@rollup/plugin-replace": "^5.0.7",
     "@sveltejs/vite-plugin-svelte": "^3.0.1",
     "@types/node": "^18.17.5",
     "electron": "^32.0.1",

--- a/e2/package.json
+++ b/e2/package.json
@@ -39,7 +39,7 @@
     "@types/node": "^18.17.5",
     "electron": "^25.6.0",
     "electron-builder": "^24.6.3",
-    "electron-vite": "^1.0.27",
+    "electron-vite": "^2.3.0",
     "eslint": "^8.47.0",
     "eslint-plugin-svelte": "^2.32.4",
     "i18n": "^0.8.3",

--- a/e2/package.json
+++ b/e2/package.json
@@ -3,6 +3,7 @@
   "version": "0.6.4-dev",
   "description": "Mustang - Video conference, chat, mail, calendar, files, contacts",
   "main": "./out/main/index.js",
+  "type": "module",
   "scripts": {
     "format": "prettier --plugin prettier-plugin-svelte --write .",
     "lint": "eslint . --ext .js,.jsx,.cjs,.mjs,.ts,.tsx,.cts,.mts --fix",

--- a/e2/src/main/index.ts
+++ b/e2/src/main/index.ts
@@ -26,7 +26,7 @@ function createWindow(): void {
       frame: false,
       ...(process.platform === 'linux' ? { icon } : {}),
       webPreferences: {
-        preload: join(__dirname, '../preload/index.js'),
+        preload: join(__dirname, '../preload/index.mjs'),
         sandbox: false,
         webviewTag: true,
       }

--- a/e2/src/main/index.ts
+++ b/e2/src/main/index.ts
@@ -26,7 +26,7 @@ function createWindow(): void {
       frame: false,
       ...(process.platform === 'linux' ? { icon } : {}),
       webPreferences: {
-        preload: join(__dirname, '../preload/index.mjs'),
+        preload: join(import.meta.dirname, '../preload/index.mjs'),
         sandbox: false,
         webviewTag: true,
       }

--- a/e2/src/main/index.ts
+++ b/e2/src/main/index.ts
@@ -1,9 +1,10 @@
 import { setMainWindow, startupBackend } from '../../../backend/backend';
 import { app, shell, BrowserWindow } from 'electron'
 import { join } from 'path'
-import { autoUpdater } from 'electron-updater';
+import electronUpdater from 'electron-updater';
 import { electronApp, optimizer, is } from '@electron-toolkit/utils'
 import icon from '../../resources/icon.png?asset'
+const { autoUpdater } = electronUpdater;
 
 // Set app data directory name to capitalized 'Mustang' on Mac OS instead of 'mustang'
 if (process.platform == 'darwin') {

--- a/lib/jpc-ws/protocol.js
+++ b/lib/jpc-ws/protocol.js
@@ -1,6 +1,6 @@
 import WSCall from "./WSCall.js";
 import JPCProtocol from "../jpc/protocol.js";
-import WebSocketNode from "ws";
+import WebSocketNode, { WebSocketServer } from "ws";
 import { assert } from "../jpc/util.js";
 
 /**
@@ -45,7 +45,7 @@ export default class JPCWebSocket extends JPCProtocol {
     assert(typeof (port) == "number", "Need port");
     let host = openPublic ? '0.0.0.0' : '127.0.0.1'; // TODO IPv6
 
-    this._server = new WebSocketNode.Server({
+    this._server = new WebSocketServer({
       host: host,
       port: port,
       maxPayload: 0,


### PR DESCRIPTION
- update better-sqlite3 to 11.2.1 since older versions don't work with electron@32
- update electron-vite to 2.3.0 to support ESM
- update electron to 32.0.1 to support ESM
- use custom ESM shim plugin since the one in `electron-vite` doesn't seem to work nor the `@rollup/esm-shim` plugin, therefore causing the `__dirname` syntax error
- fix syntax errors to be compatible with ESM
- set the config to output ESM for `main` and `preload` scripts
- in the main script set the `preload` to mjs because it outputs it with the`mjs` file extension for some reason

Where should we point the `esm-shim-plugin` package? It is a package based on https://github.com/rollup/plugins/issues/1709#issuecomment-2112362911. Will it be moved to Mustang?