### PR TITLE
Fix: Search: UI freezes after loading an email folder then clicking search

### DIFF
--- a/app/frontend/Mail/LeftPane/LeftPane.svelte
+++ b/app/frontend/Mail/LeftPane/LeftPane.svelte
@@ -24,7 +24,7 @@
     <AccountList accounts={$accounts} bind:selectedAccount />
     <FolderList {folders} bind:selectedFolder bind:selectedFolders />
     {#if selectedFolder && !(selectedFolder instanceof SavedSearchFolder)}
-      <TagsList folder={selectedFolder} bind:searchMessages on:clear={onClearSearch} />
+      <TagsList folder={selectedFolder} bind:searchMessages />
     {/if}
     <hbox class="separator" />
     <ViewSwitcher />


### PR DESCRIPTION
- Do nothing on TagList clear event