### PR TITLE
IMAP: Don't overwrite full msg in DB with half-loaded msg in memory

### DIFF
--- a/app/TODO.md
+++ b/app/TODO.md
@@ -3,7 +3,6 @@
   * SQL: Stable DB
   * Collections sort is slow, and observers keep them alive
   * IMAP
-    * Bug: "MIME source not yet downloaded", stays
     * Bug: After delete, new msgs are removed locally (and come back only after a poll)
     * Bug: Old msgs keep coming back, new msgs not saved
     * See also below

--- a/app/frontend/Mail/3pane/TableMessageListItem.svelte
+++ b/app/frontend/Mail/3pane/TableMessageListItem.svelte
@@ -18,13 +18,13 @@
     icon={CircleIcon}
     iconSize="7px"
     iconOnly
-    label={message.isRead ? $t`Mark this message as unread` : $t`Mark this message as read`}
+    label={$message.isRead ? $t`Mark this message as unread` : $t`Mark this message as read`}
     onClick={toggleRead}
     plain
     />
 </hbox>
 <hbox class="direction">
-  {#if message.outgoing}
+  {#if $message.outgoing}
     <OutgoingIcon size={16} />
   {/if}
 </hbox>
@@ -96,7 +96,7 @@
 
   $: attachments = message.attachments;
   $: tags = message.tags;
-  $: contactName = personDisplayName(message.contact);
+  $: contactName = personDisplayName($message.contact);
 
   async function toggleRead() {
     await message.markRead(!message.isRead);

--- a/app/frontend/Mail/Vertical/VerticalMessageListItem.svelte
+++ b/app/frontend/Mail/Vertical/VerticalMessageListItem.svelte
@@ -6,7 +6,7 @@
   >
   <hbox class="top-row">
     <hbox class="direction">
-      {#if message.outgoing}
+      {#if $message.outgoing}
         <OutgoingIcon size={16} />
       {/if}
     </hbox>
@@ -77,7 +77,7 @@
         icon={CircleIcon}
         iconSize="7px"
         iconOnly
-        label={message.isRead ? $t`Mark this message as unread` : $t`Mark this message as read`}
+        label={$message.isRead ? $t`Mark this message as unread` : $t`Mark this message as read`}
         onClick={toggleRead}
         plain
         />
@@ -111,7 +111,7 @@
 
   $: attachments = message.attachments;
   $: tags = message.tags;
-  $: contactName = personDisplayName(message.contact);
+  $: contactName = personDisplayName($message.contact);
 
   async function toggleRead() {
     await message.markRead(!message.isRead);

--- a/app/logic/Mail/EMail.ts
+++ b/app/logic/Mail/EMail.ts
@@ -261,7 +261,7 @@ export class EMail extends Message {
    *
    * Do this only exactly once per email `dbID`.
    * This typically happens immediately after`parseMIME()`. */
-  async save() {
+  async saveComplete() {
     if (this.isDeleted || await this.isDownloadCompleteDoublecheck()) {
       return;
     }

--- a/app/logic/Mail/EMail.ts
+++ b/app/logic/Mail/EMail.ts
@@ -261,7 +261,7 @@ export class EMail extends Message {
    *
    * Do this only exactly once per email `dbID`.
    * This typically happens immediately after`parseMIME()`. */
-  async saveComplete() {
+  async saveCompleteMessage() {
     if (this.isDeleted || await this.isDownloadCompleteDoublecheck()) {
       return;
     }

--- a/app/logic/Mail/EWS/EWSEMail.ts
+++ b/app/logic/Mail/EWS/EWSEMail.ts
@@ -39,7 +39,7 @@ export class EWSEMail extends EMail {
     let mimeBase64 = sanitize.nonemptystring(getEWSItem(result.Items).MimeContent.Value);
     this.mime = new Uint8Array(await base64ToArrayBuffer(mimeBase64, "message/rfc822"));
     await this.parseMIME();
-    await this.save();
+    await this.saveComplete();
   }
 
   fromXML(xmljs) {

--- a/app/logic/Mail/EWS/EWSEMail.ts
+++ b/app/logic/Mail/EWS/EWSEMail.ts
@@ -39,7 +39,7 @@ export class EWSEMail extends EMail {
     let mimeBase64 = sanitize.nonemptystring(getEWSItem(result.Items).MimeContent.Value);
     this.mime = new Uint8Array(await base64ToArrayBuffer(mimeBase64, "message/rfc822"));
     await this.parseMIME();
-    await this.saveComplete();
+    await this.saveCompleteMessage();
   }
 
   fromXML(xmljs) {

--- a/app/logic/Mail/EWS/EWSFolder.ts
+++ b/app/logic/Mail/EWS/EWSFolder.ts
@@ -311,7 +311,7 @@ export class EWSFolder extends Folder {
             let mimeBase64 = sanitize.nonemptystring(getEWSItem(result.Items).MimeContent.Value);
             email.mime = new Uint8Array(await base64ToArrayBuffer(mimeBase64, "message/rfc822"));
             await email.parseMIME();
-            await email.saveComplete();
+            await email.saveCompleteMessage();
             downloadedEmail.add(email);
           } catch (ex) {
             this.account.errorCallback(ex);

--- a/app/logic/Mail/EWS/EWSFolder.ts
+++ b/app/logic/Mail/EWS/EWSFolder.ts
@@ -311,7 +311,7 @@ export class EWSFolder extends Folder {
             let mimeBase64 = sanitize.nonemptystring(getEWSItem(result.Items).MimeContent.Value);
             email.mime = new Uint8Array(await base64ToArrayBuffer(mimeBase64, "message/rfc822"));
             await email.parseMIME();
-            await email.save();
+            await email.saveComplete();
             downloadedEmail.add(email);
           } catch (ex) {
             this.account.errorCallback(ex);

--- a/app/logic/Mail/IMAP/IMAPEMail.ts
+++ b/app/logic/Mail/IMAP/IMAPEMail.ts
@@ -40,7 +40,7 @@ export class IMAPEMail extends EMail {
     });
     this.fromFlow(msgInfo);
     await this.parseMIME();
-    await this.save();
+    await this.saveComplete();
   }
 
   fromFlow(msgInfo: any) {

--- a/app/logic/Mail/IMAP/IMAPEMail.ts
+++ b/app/logic/Mail/IMAP/IMAPEMail.ts
@@ -40,7 +40,7 @@ export class IMAPEMail extends EMail {
     });
     this.fromFlow(msgInfo);
     await this.parseMIME();
-    await this.saveComplete();
+    await this.saveCompleteMessage();
   }
 
   fromFlow(msgInfo: any) {

--- a/app/logic/Mail/IMAP/IMAPFolder.ts
+++ b/app/logic/Mail/IMAP/IMAPFolder.ts
@@ -311,7 +311,7 @@ export class IMAPFolder extends Folder {
               msg.fromFlow(msgInfo);
               this.updateModSeq(msgInfo.modseq);
               await msg.parseMIME();
-              await msg.saveComplete();
+              await msg.saveCompleteMessage();
               downloadedMsgs.add(msg);
             }
           } catch (ex) {

--- a/app/logic/Mail/IMAP/IMAPFolder.ts
+++ b/app/logic/Mail/IMAP/IMAPFolder.ts
@@ -138,7 +138,7 @@ export class IMAPFolder extends Folder {
       newMsgs.addAll(newMessages);
       this.messages.addAll(newMessages);
       //let fetchTime = Date.now() - startTime;
-      await this.saveMsgs(newMessages);
+      await this.saveNewMsgs(newMessages);
       //let saveTime = Date.now() - startTime - fetchTime;
       //console.log("  Fetched", fetchUIDs.length, ", remaining", newUIDs.length, "- Time: Fetch:", fetchTime / kBatchSize, "ms/msg, save time", saveTime / kBatchSize, "ms/msg");
     }
@@ -153,7 +153,7 @@ export class IMAPFolder extends Folder {
     let { newMessages } = await this.fetchMessageList({ all: true }, {});
     this.messages.addAll(newMessages);
     await this.storage.saveFolderProperties(this);
-    await this.saveMsgs(newMessages);
+    await this.saveNewMsgs(newMessages);
     return newMessages;
   }
 
@@ -165,7 +165,7 @@ export class IMAPFolder extends Folder {
     });
     this.messages.addAll(newMessages);
     await this.storage.saveFolderProperties(this);
-    await this.saveMsgs(newMessages);
+    await this.saveNewMsgs(newMessages);
     return newMessages;
   }
 
@@ -179,7 +179,7 @@ export class IMAPFolder extends Folder {
     let fromUID = this.highestUID ?? "1";
     let { newMessages } = await this.fetchMessageList({ uid: fromUID + ":*" }, {});
     this.messages.addAll(newMessages);
-    await this.saveMsgs(newMessages);
+    await this.saveNewMsgs(newMessages);
     await this.storage.saveFolderProperties(this);
     return newMessages;
   }
@@ -258,7 +258,7 @@ export class IMAPFolder extends Folder {
     }
     let { updatedMessages } = await this.fetchFlags(
       { uid: this.recentMsg.uid + ":" + highestUID }, {});
-    await this.saveMsgs(updatedMessages);
+    await this.saveMsgUpdates(updatedMessages);
   }
 
   /** Lists new messages, and downloads them */
@@ -311,7 +311,7 @@ export class IMAPFolder extends Folder {
               msg.fromFlow(msgInfo);
               this.updateModSeq(msgInfo.modseq);
               await msg.parseMIME();
-              await msg.save();
+              await msg.saveComplete();
               downloadedMsgs.add(msg);
             }
           } catch (ex) {
@@ -381,7 +381,7 @@ export class IMAPFolder extends Folder {
       .first as IMAPEMail; // oldest
   }
 
-  protected async saveMsgs(msgs: Collection<IMAPEMail>) {
+  protected async saveNewMsgs(msgs: Collection<IMAPEMail>) {
     //let startTime = Date.now();
     for (let email of msgs) {
       try {
@@ -394,6 +394,18 @@ export class IMAPFolder extends Folder {
     }
     //let saveTime = Date.now() - startTime;
     //console.log("  Saved", msgs.length, "msgs in", saveTime, "ms =", saveTime / msgs.length, "ms/msg");
+  }
+
+  protected async saveMsgUpdates(msgs: Collection<IMAPEMail>) {
+    for (let email of msgs) {
+      try {
+        if (email.subject) {
+          await this.storage.saveMessageWritableProps(email);
+        }
+      } catch (ex) {
+        this.account.errorCallback(ex);
+      }
+    }
   }
 
   updateModSeq(modseq: number) {
@@ -471,7 +483,7 @@ export class IMAPFolder extends Folder {
     let message = uid && this.getEMailByUID(uid);
     if (message) {
       message.setFlagsLocal(flags);
-      await this.storage.saveMessage(message);
+      await this.storage.saveMessageWritableProps(message);
       return;
     }
 
@@ -479,7 +491,7 @@ export class IMAPFolder extends Folder {
     let fromUID = updateMsgs.first?.uid ?? 1;
     let toUID = updateMsgs.last?.uid ?? this.highestUID;
     let { updatedMessages } = await this.fetchFlags({ uid: fromUID + ":" + toUID }, {});
-    await this.saveMsgs(updatedMessages);
+    await this.saveMsgUpdates(updatedMessages);
   }
 
   /** We received an event from the server that a

--- a/app/logic/Mail/OWA/OWAEMail.ts
+++ b/app/logic/Mail/OWA/OWAEMail.ts
@@ -48,7 +48,7 @@ export class OWAEMail extends EMail {
     let mimeBase64 = sanitize.nonemptystring(result.Items[0].MimeContent.Value);
     this.mime = new Uint8Array(await base64ToArrayBuffer(mimeBase64, "message/rfc822"));
     await this.parseMIME();
-    await this.save();
+    await this.saveComplete();
   }
 
   fromJSON(json) {

--- a/app/logic/Mail/OWA/OWAEMail.ts
+++ b/app/logic/Mail/OWA/OWAEMail.ts
@@ -48,7 +48,7 @@ export class OWAEMail extends EMail {
     let mimeBase64 = sanitize.nonemptystring(result.Items[0].MimeContent.Value);
     this.mime = new Uint8Array(await base64ToArrayBuffer(mimeBase64, "message/rfc822"));
     await this.parseMIME();
-    await this.saveComplete();
+    await this.saveCompleteMessage();
   }
 
   fromJSON(json) {

--- a/app/logic/Mail/OWA/OWAFolder.ts
+++ b/app/logic/Mail/OWA/OWAFolder.ts
@@ -316,7 +316,7 @@ export class OWAFolder extends Folder {
             let mimeBase64 = sanitize.nonemptystring(item.MimeContent.Value);
             email.mime = new Uint8Array(await base64ToArrayBuffer(mimeBase64, "message/rfc822"));
             await email.parseMIME();
-            await email.save();
+            await email.saveComplete();
             downloadedEmail.add(email);
           } catch (ex) {
             this.account.errorCallback(ex);

--- a/app/logic/Mail/OWA/OWAFolder.ts
+++ b/app/logic/Mail/OWA/OWAFolder.ts
@@ -316,7 +316,7 @@ export class OWAFolder extends Folder {
             let mimeBase64 = sanitize.nonemptystring(item.MimeContent.Value);
             email.mime = new Uint8Array(await base64ToArrayBuffer(mimeBase64, "message/rfc822"));
             await email.parseMIME();
-            await email.saveComplete();
+            await email.saveCompleteMessage();
             downloadedEmail.add(email);
           } catch (ex) {
             this.account.errorCallback(ex);

--- a/app/logic/Mail/SQL/SQLEMail.ts
+++ b/app/logic/Mail/SQL/SQLEMail.ts
@@ -17,6 +17,7 @@ export class SQLEMail {
    * Save only fully downloaded emails
    */
   static async save(email: EMail) {
+    assert(!(email.downloadComplete && email.rawText == null && email.rawHTMLDangerous == null), "An email without body is not complete");
     if (!email.folder.dbID) {
       await email.folder.save();
     }

--- a/app/logic/Mail/Store/MailZIP.ts
+++ b/app/logic/Mail/Store/MailZIP.ts
@@ -71,7 +71,7 @@ export class MailZIP implements MailContentStorage {
         email.mime = await zip.readFile(file) as Uint8Array;
         console.log("email.mime (should be Uint8array)", email.mime);
         await email.parseMIME();
-        await email.saveComplete();
+        await email.saveCompleteMessage();
       } catch (ex) {
         folder.account.errorCallback(ex);
       }

--- a/app/logic/Mail/Store/MailZIP.ts
+++ b/app/logic/Mail/Store/MailZIP.ts
@@ -71,7 +71,7 @@ export class MailZIP implements MailContentStorage {
         email.mime = await zip.readFile(file) as Uint8Array;
         console.log("email.mime (should be Uint8array)", email.mime);
         await email.parseMIME();
-        await email.save();
+        await email.saveComplete();
       } catch (ex) {
         folder.account.errorCallback(ex);
       }


### PR DESCRIPTION
Fixes MIME source not yet downloaded #188

`downloadCompleted` is true, but the body fields are empty in the DB.

We do a `save()` of that half-loaded message. And that save is overwriting the complete msg in the DB with the half-loaded one.

It appears there are at least 2 code paths that do that: `IMAPFolder.updateNewFlags()` and `IMAPFolder.messageFlagsChanged()`. They are called e.g. when the read status changes, or flags are added. Both call `await this.saveMsgs(updatedMessages)` (not new msgs). `SQLEMail.save()` then overwrites the existing message. That's the bug.

That's because `SQLEMail.readAll()` reads the headers, but not the body. So, `downloadComplete` will be read as `true`, but the body will still be empty - in memory. Doing `SQLEMail.save()` will the save a broken and inconsistent state back into the DB.