### PR TITLE
Fix scrollbar styles overridden by scrollbar-color

### DIFF
--- a/app/frontend/app.css
+++ b/app/frontend/app.css
@@ -108,7 +108,6 @@ body {
   place-items: center;
   min-width: 640px;
   min-height: 100vh;
-  scrollbar-color: #22222325 transparent;
 }
 
 /* <copied from="content-body.css"> */


### PR DESCRIPTION
It seems like Chrome ignores all ::webkit-scrollbar if there's a single `scrollbar-*` css rule. So I just removed a single style in the body selector.

https://syntackle.com/blog/changes-to-scrollbar-styling-in-chrome-121/