### PR TITLE
Fix SQL error during ActiveSync account creation - fixes #204

### DIFF
--- a/app/logic/Mail/ActiveSync/ActiveSyncAccount.ts
+++ b/app/logic/Mail/ActiveSync/ActiveSyncAccount.ts
@@ -303,7 +303,7 @@ export class ActiveSyncAccount extends MailAccount {
           folder.parent = parent;
         }
         folder.addToParent();
-        folder.save();
+        await folder.save();
         break;
       case FolderType.Tasks:
       case FolderType.UserTasks:

--- a/app/logic/Mail/IMAP/IMAPFolder.ts
+++ b/app/logic/Mail/IMAP/IMAPFolder.ts
@@ -547,7 +547,7 @@ export class IMAPFolder extends Folder {
   }
 
   async moveFolderHere(folder: IMAPFolder) {
-    assert(folder.account = this.account, "Cannot move folders between accounts yet. You can create a new folder and move the messages");
+    assert(folder.account == this.account, "Cannot move folders between accounts yet. You can create a new folder and move the messages");
     await super.moveFolderHere(folder);
     /*
     assert(folder.subFolders.isEmpty, `Folder ${folder.name} has sub-folders. Cannot yet move entire folder hierarchies. You may move the folders individually.`);

--- a/app/logic/Mail/SQL/SQLEMail.ts
+++ b/app/logic/Mail/SQL/SQLEMail.ts
@@ -264,7 +264,7 @@ export class SQLEMail {
     email.pID = typeof (row.pID) == "number"
       ? sanitize.integer(row.pID, null)
       : sanitize.string(row.pID, null);
-    email.id = sanitize.nonemptystring(row.messageID);
+    email.id = sanitize.nonemptystring(row.messageID, "");
     email.inReplyTo = sanitize.string(row.parentMsgID, null);
     email.size = sanitize.integer(row.size, null);
     email.sent = sanitize.date(row.dateSent * 1000, new Date());


### PR DESCRIPTION
This is a race condition. `listFolders` only saved the folders asynchronously, so they were still in the process of being saved when `listMessages` was called on the "Sent Items" folder. Since the folder hadn't been saved yet, `readFolder` tried to save it again, with hilarious consequences.

(See comments in #203 regarding the other two changes.)