### PR TITLE
OWA: Don't throw "end of json" error for response.json() - fixes #215

### DIFF
--- a/app/logic/Mail/OWA/OWAAccount.ts
+++ b/app/logic/Mail/OWA/OWAAccount.ts
@@ -232,7 +232,8 @@ export class OWAAccount extends MailAccount {
     try {
       let url = this.url + "ev.owa2?ns=PendingRequest&ev=FinishNotificationRequest&UA=0";
       let response = await appGlobal.remoteApp.OWA.fetchJSON(this.partition, url);
-      let cid = response.json.cid;
+      let json = response.json;
+      let cid = json ? json.cid : null;
       // This loop only ends by exception (e.g. logout) or app shutdown.
       while (true) {
         url = this.url + "ev.owa2?ns=PendingRequest&ev=PendingNotificationRequest&UA=0&cid=" + cid + "&X-OWA-CANARY=";

--- a/backend/owa.ts
+++ b/backend/owa.ts
@@ -139,9 +139,8 @@ export async function fetchJSON(partition: string, url: string, action: string, 
   try {
     result.json = await response.json();
   } catch (ex) {
-    if (ex instanceof SyntaxError &&
-      ex.message == "Unexpected end of JSON input") {
-    } else {
+    if (ex !instanceof SyntaxError &&
+      ex.message != "Unexpected end of JSON input") {
       throw ex;
     }
   }

--- a/backend/owa.ts
+++ b/backend/owa.ts
@@ -136,7 +136,15 @@ export async function fetchJSON(partition: string, url: string, action: string, 
   result.statusText = response.statusText;
   result.url = response.url;
   result.contentType = response.headers.get('Content-Type');
-  result.json = await response.json();
+  try {
+    result.json = await response.json();
+  } catch (ex) {
+    if (ex instanceof SyntaxError &&
+      ex.message == "Unexpected end of JSON input") {
+    } else {
+      throw ex;
+    }
+  }
   return result;
 }
 

--- a/backend/owa.ts
+++ b/backend/owa.ts
@@ -139,8 +139,11 @@ export async function fetchJSON(partition: string, url: string, action: string, 
   try {
     result.json = await response.json();
   } catch (ex) {
-    if (ex !instanceof SyntaxError &&
-      ex.message != "Unexpected end of JSON input") {
+    if (ex instanceof SyntaxError &&
+        (ex.message == "Unexpected end of JSON input" ||
+         ex.message?.includes("DOCTYPE"))) {
+      response.json = null;
+    } else {
       throw ex;
     }
   }


### PR DESCRIPTION
- `JSON.parse()` normally throws an error when parsing an empty string or null
- `response.json()` under the hood uses `JSON.parse()` so it'll throw an error when it's empty
- `json.cid` would throw an error if json is null so we just use `json ? json.cid : null` to prevent that