### PR TITLE
ActiveSync: No folders fix

### DIFF
--- a/app/logic/Mail/ActiveSync/ActiveSyncAccount.ts
+++ b/app/logic/Mail/ActiveSync/ActiveSyncAccount.ts
@@ -82,6 +82,8 @@ export class ActiveSyncAccount extends MailAccount {
       }
     }
 
+    await this.listFolders();
+
     for (let addressbook of appGlobal.addressbooks) {
       if (addressbook.protocol == "addressbook-activesync" && addressbook.url.startsWith(this.url + "?") && addressbook.username == this.emailAddress) {
         (addressbook as ActiveSyncAddressbook).account = this;


### PR DESCRIPTION
After logging into an ActiveSync account no folders are displayed.

- `listFolders()` was removed in `login()`