### PR TITLE
EWS, OWA, ActS: Use account username consistently

### DIFF
--- a/app/logic/Mail/ActiveSync/ActiveSyncAccount.ts
+++ b/app/logic/Mail/ActiveSync/ActiveSyncAccount.ts
@@ -137,7 +137,7 @@ export class ActiveSyncAccount extends MailAccount {
       await this.oAuth2.login(true);
       options.headers.Authorization = this.oAuth2.authorizationHeader;
     } else {
-      options.headers.Authorization = `Basic ${btoa(unescape(encodeURIComponent(`${this.username || this.emailAddress}:${this.password}`)))}`;
+      options.headers.Authorization = `Basic ${btoa(unescape(encodeURIComponent(`${this.username}:${this.password}`)))}`;
     }
     let response = await appGlobal.remoteApp.optionsHTTP(this.url, options);
     if (response.ok) {
@@ -188,7 +188,7 @@ export class ActiveSyncAccount extends MailAccount {
   async callEAS(aCommand: string, aRequest: any, heartbeat = 0): Promise<any> {
     let url = new URL(this.url);
     url.searchParams.append("Cmd", aCommand);
-    url.searchParams.append("User", this.username || this.emailAddress);
+    url.searchParams.append("User", this.username);
     url.searchParams.append("DeviceID", this.getDeviceID());
     url.searchParams.append("DeviceType", "UniversalOutlook");
     let options: any = {
@@ -203,7 +203,7 @@ export class ActiveSyncAccount extends MailAccount {
     if (this.oAuth2) {
       options.headers.Authorization = this.oAuth2.authorizationHeader;
     } else {
-      options.headers.Authorization = `Basic ${btoa(unescape(encodeURIComponent(`${this.username || this.emailAddress}:${this.password}`)))}`;
+      options.headers.Authorization = `Basic ${btoa(unescape(encodeURIComponent(`${this.username}:${this.password}`)))}`;
     }
     if (await this.policyKey) {
       options.headers["X-MS-PolicyKey"] = await this.policyKey;

--- a/app/logic/Mail/EWS/EWSAccount.ts
+++ b/app/logic/Mail/EWS/EWSAccount.ts
@@ -207,7 +207,7 @@ export class EWSAccount extends MailAccount {
     if (this.oAuth2) {
       options.headers.Authorization = this.oAuth2.authorizationHeader;
     } else {
-      options.headers.Authorization = `Basic ${btoa(unescape(encodeURIComponent(`${this.username || this.emailAddress}:${this.password}`)))}`;
+      options.headers.Authorization = `Basic ${btoa(unescape(encodeURIComponent(`${this.username}:${this.password}`)))}`;
     }
     return options;
   }

--- a/app/logic/Mail/OWA/OWAAccount.ts
+++ b/app/logic/Mail/OWA/OWAAccount.ts
@@ -80,7 +80,7 @@ export class OWAAccount extends MailAccount {
         if (!elements) {
           throw new Error(gt`Could not find login form`);
         }
-        let response = await OWALoginBackground.submitLoginForm(this.emailAddress, this.password, this.partition, elements);
+        let response = await OWALoginBackground.submitLoginForm(this.username, this.password, this.partition, elements);
         let formURL = new URL(elements.url);
         let responseURL = new URL(response.url);
         if (response.status == 401 || responseURL.origin == formURL.origin && responseURL.pathname == formURL.pathname && responseURL.searchParams.get("reason") == "2") {
@@ -204,7 +204,7 @@ export class OWAAccount extends MailAccount {
   async listFolders(interactive?: boolean): Promise<void> {
     let autofillJS: string | null = "";
     if (interactive) {
-      autofillJS = owaAutoFillLoginPage(this.emailAddress, this.password);
+      autofillJS = owaAutoFillLoginPage(this.username, this.password);
     }
     let sessionData = await appGlobal.remoteApp.OWA.fetchSessionData(this.partition, this.url, interactive, autofillJS);
     if (!sessionData) {

--- a/app/logic/Mail/OWA/OWALoginBackground.ts
+++ b/app/logic/Mail/OWA/OWALoginBackground.ts
@@ -1,8 +1,8 @@
 import { appGlobal } from "../../app";
 
 export class OWALoginBackground {
-  static async submitLoginForm(emailAddress: string, password: string, partition: string, elements: OWALoginFormElements) {
-    elements.username.value = emailAddress;
+  static async submitLoginForm(username: string, password: string, partition: string, elements: OWALoginFormElements) {
+    elements.username.value = username;
     elements.password.value = password;
     if ("flags" in elements.form.elements) {
       (elements.form.elements.flags as any).value |= 1;


### PR DESCRIPTION
- For EWS and ActiveSync, assume that `username` is set, without trying to fall back to `emailAddress`
- For OWA, always use `username` for logging in, not `emailAddress`