### PR TITLE
Activesync: Save sync key later

### DIFF
--- a/app/logic/Contacts/ActiveSync/ActiveSyncAddressbook.ts
+++ b/app/logic/Contacts/ActiveSync/ActiveSyncAddressbook.ts
@@ -28,9 +28,14 @@ export class ActiveSyncAddressbook extends Addressbook implements ActiveSyncPing
   }
 
   /**
-   * Queues a `Sync` request locally. It waits until the server is available.
-   * @param data 
-   * @param responseFunc 
+   * Queues a `Sync` (synchronization) request locally. It waits until the server is available.
+   * @param data information about the request
+   * @param responseFunc
+   * - It performs actions using the parameter `response.Collections.Collection`.
+   * - It is called when the response is not null.
+   * - It will be repeatedly called while `response.Collections.Collection.MoreAvailable` is 
+   * equal to an empty string.
+   * - It may be called many times.
    */
   async queuedSyncRequest(data: any, responseFunc?: (response: any) => Promise<void>): Promise<any> {
     if (!this.syncState && !this.syncKeyBusy) try {
@@ -54,10 +59,15 @@ export class ActiveSyncAddressbook extends Addressbook implements ActiveSyncPing
   }
 
   /**
-   * Makes a `Sync` request to the server. It is called by `queuedSyncRequest`
-   * and it may be called multiple times.
-   * @param data 
-   * @param responseFunc 
+   * Makes a `Sync` (synchronization) request to the server.
+   * You probably want to call it using the wrapper `queuedSyncRequest()`.
+   * @param data information about the request
+   * @param responseFunc
+   * - It performs actions using the parameter `response.Collections.Collection`.
+   * - It is called when the response is not null.
+   * - It will be repeatedly called while `response.Collections.Collection.MoreAvailable` is 
+   * equal to an empty string.
+   * - It may be called many times.
    */
   protected async makeSyncRequest(data?: any, responseFunc?: (response: any) => Promise<void>): Promise<any> {
     let response;

--- a/app/logic/Mail/ActiveSync/ActiveSyncFolder.ts
+++ b/app/logic/Mail/ActiveSync/ActiveSyncFolder.ts
@@ -81,12 +81,17 @@ export class ActiveSyncFolder extends Folder implements ActiveSyncPingable {
   }
 
   /**
-   * Queues `Sync` requests locally and waits until the 
+   * Queues `Sync` (synchronization) requests locally and waits until the 
    * server is available.
    * Sync requests for a given folder must be serialised,
    * because they all use the same per-folder sync key.
    * @param data information about the request
-   * @param responseFunc callback for processing the response
+   * @param responseFunc
+   * - It performs actions using the parameter `response.Collections.Collection`.
+   * - It is called when the response is not null.
+   * - It will be repeatedly called while `response.Collections.Collection.MoreAvailable` is 
+   * equal to an empty string.
+   * - It may be called many times.
    */
   async queuedSyncRequest(data: any, responseFunc?: (response: any) => Promise<void>): Promise<any> {
     if (!this.syncState && !this.syncKeyBusy) try {
@@ -110,10 +115,15 @@ export class ActiveSyncFolder extends Folder implements ActiveSyncPingable {
   }
 
   /**
-   * Makes a `Sync` request to the server. It is called by
-   * `queuedSyncRequest()` and it may be called multiple times.
+   * Makes a `Sync` (synchronization) request to the server.
+   * You probably want to call it using the wrapper `queuedSyncRequest()`.
    * @param data information about the request
-   * @param responseFunc callback function for processing the response
+   * @param responseFunc
+   * - It performs actions using the parameter `response.Collections.Collection`.
+   * - It is called when the response is not null.
+   * - It will be repeatedly called while `response.Collections.Collection.MoreAvailable` is 
+   * equal to an empty string.
+   * - It may be called many times.
    */
   protected async makeSyncRequest(data?: any, responseFunc?: (response: any) => Promise<void>): Promise<any> {
     let response;

--- a/app/logic/Mail/ActiveSync/WBXML.ts
+++ b/app/logic/Mail/ActiveSync/WBXML.ts
@@ -29,7 +29,7 @@ const kTags = [
   [],
   [,,,,, "ItemOperations", "Fetch", "Store", "Options",,, "Properties",, "Status", "Response",,,, "EmptyFolderContents", "DeleteSubFolders"],
   [,,,,, "SendMail",,, "SaveInSentItems",,,,,,,, "Mime", "ClientId", "Status"],
-  [,,,,,,,,, "ConversationId", "ConversationIndex", "LastVerbExecuted", "LastVerbExecutionTime",, "Sender",,,,"FirstDayOfWeek", "MeetingMessageType"],
+  [,,,,,,,,, "ConversationId", "ConversationIndex", "LastVerbExecuted", "LastVerbExecutionTime",, "Sender",,,,, "MeetingMessageType"],
 ];
 
 /**

--- a/app/logic/Mail/ActiveSync/WBXML.ts
+++ b/app/logic/Mail/ActiveSync/WBXML.ts
@@ -29,7 +29,7 @@ const kTags = [
   [],
   [,,,,, "ItemOperations", "Fetch", "Store", "Options",,, "Properties",, "Status", "Response",,,, "EmptyFolderContents", "DeleteSubFolders"],
   [,,,,, "SendMail",,, "SaveInSentItems",,,,,,,, "Mime", "ClientId", "Status"],
-  [,,,,,,,,, "ConversationId", "ConversationIndex", "LastVerbExecuted", "LastVerbExecutionTime",, "Sender",,,,, "MeetingMessageType"],
+  [,,,,,,,,, "ConversationId", "ConversationIndex", "LastVerbExecuted", "LastVerbExecutionTime",, "Sender",,,,"FirstDayOfWeek", "MeetingMessageType"],
 ];
 
 /**


### PR DESCRIPTION
Commit 893ad47 is the main part of the PR, it moves processing of received data to a callback which is called before the sync key is saved, so if there is an error processing we can retry.

Commit 520f29b is because I decided that the looping to obtain additional results was awkward. Instead of having a clunky while loop which checks for `MoreAvailable`, I moved the loop into the `makeSyncRequest` functions.

Commit 5a595d3 just fixes a console warning I happened to notice at the time.

Note that you may find it easier to view the commits with whitespace hidden.