### PR TITLE
IMAP/SMTP: Set OAuth2 when logging in and verifying login

### DIFF
--- a/app/logic/Mail/AutoConfig/checkConfig.ts
+++ b/app/logic/Mail/AutoConfig/checkConfig.ts
@@ -15,6 +15,9 @@ export async function checkConfig(config: MailAccount, emailAddress: string, pas
     try {
       await config.outgoing.verifyLogin();
     } catch (ex) {
+      if (config.isLoggedIn) {
+        await config.logout();        
+      }
       config.outgoing.fatalError = ex;
       throw ex;
     }

--- a/app/logic/Mail/IMAP/IMAPAccount.ts
+++ b/app/logic/Mail/IMAP/IMAPAccount.ts
@@ -46,7 +46,8 @@ export class IMAPAccount extends MailAccount {
 
   async verifyLogin(): Promise<void> {
     await this.connection(true);
-    await this.logout();
+    this.stopPolling();
+    await this._connection?.logout();
   }
 
   async connection(interactive = false): Promise<ImapFlow> {

--- a/app/logic/Mail/JSON/JSONMailAccount.ts
+++ b/app/logic/Mail/JSON/JSONMailAccount.ts
@@ -39,7 +39,7 @@ export class JSONMailAccount {
     acc.userRealname = sanitize.label(json.userRealname, appGlobal.me.name);
     acc.name = sanitize.label(json.name, acc.emailAddress);
 
-    acc.fromConfigJSON(json.config ?? {});
+    acc.fromConfigJSON(json.configJSON ?? {});
     acc.workspace = json.workspace
       ? appGlobal.workspaces.find(w => w.id == sanitize.string(json.workspace, null))
       : null;

--- a/app/logic/Mail/JSON/JSONMailAccount.ts
+++ b/app/logic/Mail/JSON/JSONMailAccount.ts
@@ -39,7 +39,7 @@ export class JSONMailAccount {
     acc.userRealname = sanitize.label(json.userRealname, appGlobal.me.name);
     acc.name = sanitize.label(json.name, acc.emailAddress);
 
-    acc.fromConfigJSON(json.configJSON ?? {});
+    acc.fromConfigJSON(json.config ?? {});
     acc.workspace = json.workspace
       ? appGlobal.workspaces.find(w => w.id == sanitize.string(json.workspace, null))
       : null;

--- a/app/logic/Mail/SQL/SQLMailAccount.ts
+++ b/app/logic/Mail/SQL/SQLMailAccount.ts
@@ -83,7 +83,7 @@ export class SQLMailAccount {
       `) as any;
     acc.dbID = dbID;
     row.id = row.idStr;
-    row.configJSON = JSON.parse(sanitize.nonemptystring(row.configJSON, "{}"));
+    row.config = JSON.parse(sanitize.nonemptystring(row.configJSON, "{}"));
     JSONMailAccount.read(acc, row);
     acc.password = await getPassword("mail." + acc.id);
     acc.storage = new SQLMailStorage();


### PR DESCRIPTION
**Problems**

1. IMAP logs out of OAuth2 in `verifylogin()` thus OAuth2 is `undefined` when verifying for SMTP
2. OAuth2 config is not set in the constructor or login for IMAP login

**Error**

```
SetupMail.svelte:216 Error: Google Mail  SMTP: Need OAuth2 login from IMAP
    at assert (util.ts:4:11)
    at SMTPAccount.getTransportOptions (SMTPAccount.ts:27:7)
    at SMTPAccount.verifyLogin (SMTPAccount.ts:100:61)
    at checkConfig (checkConfig.ts:16:29)
    at async CheckConfig.svelte:19:3
```

I've added the code for setting the config for IMAP but I'm not sure about the fix for SMTP verify login because I understand we need to logout in case SMTP is not successful.