### PR TITLE
Properly check whether OAuth2 account is logged in

### DIFF
--- a/app/logic/Mail/ActiveSync/ActiveSyncAccount.ts
+++ b/app/logic/Mail/ActiveSync/ActiveSyncAccount.ts
@@ -56,7 +56,7 @@ export class ActiveSyncAccount extends MailAccount {
   }
 
   get isLoggedIn(): boolean {
-    return !this.oAuth2 || this.oAuth2.isLoggedIn;
+    return this.authMethod != AuthMethod.OAuth2 || this.oAuth2?.isLoggedIn;
   }
 
   async login(interactive: boolean): Promise<void> {

--- a/app/logic/Mail/EWS/EWSAccount.ts
+++ b/app/logic/Mail/EWS/EWSAccount.ts
@@ -38,7 +38,7 @@ export class EWSAccount extends MailAccount {
   }
 
   get isLoggedIn(): boolean {
-    return !this.oAuth2 || this.oAuth2.isLoggedIn;
+    return this.authMethod != AuthMethod.OAuth2 || this.oAuth2?.isLoggedIn;
   }
 
   async login(interactive: boolean): Promise<void> {


### PR DESCRIPTION
Since there's no `oAuth2` object by default, the account always thinks it's logged in. Switching to checking the `authMethod` fixes this.