### PR TITLE
Fix missed instance of change to collection from #172

### DIFF
--- a/app/logic/Calendar/Event.ts
+++ b/app/logic/Calendar/Event.ts
@@ -162,7 +162,7 @@ export class Event extends Observable {
     if (this.parentEvent) {
       let pos = this.parentEvent.instances.indexOf(this);
       if (pos >= 0) {
-        this.parentEvent.instances[pos] = null;
+        this.parentEvent.instances.set(pos, null);
         await this.calendar.storage.saveEvent(this.parentEvent);
       }
     }


### PR DESCRIPTION
#172 changed `instances` from an array to a `Collection` but I spotted a use that was missed. (And my TypeScript did't complain either...)