### PR TITLE
Make my tsc find all the logic files again

### DIFF
--- a/app/tsconfig.json
+++ b/app/tsconfig.json
@@ -20,6 +20,7 @@
   "include": [
     "logic/util/Observable.ts",
     "logic/build.ts",
+    "logic/startup.ts",
     "lingui.config.ts",
     "frontend/**/*.d.ts",
     "frontend/**/*.ts",


### PR DESCRIPTION
For some curious reason, after the removal of the line `import { SQLMailAccount } from "../SQL/SQLMailAccount";` by commit 0056359113c4a0701d4e1c2289cb0f52e7b40008, typescript no longer bothers to check my code, which is unfortunate. I found this addition to be the simplest solution for me.