### PR TITLE
Kludge to fix recurrence rule short month bug

### DIFF
--- a/app/logic/Calendar/RecurrenceRule.test.ts
+++ b/app/logic/Calendar/RecurrenceRule.test.ts
@@ -8,6 +8,7 @@ function check(calString: string, data: RecurrenceInit, expected: [number, numbe
     let ruleFromString = RecurrenceRule.fromCalString(data.startDate, calString);
     expect(rule).toEqual(ruleFromString);
   }
+  expect(rule.getOccurrenceByIndex(2)).toEqual(new Date(...expected[1]));
   expect(rule.getOccurrencesByDate(new Date(2010, 10, 10))).toEqual(expected.map(args => new Date(...args)));
 }
 

--- a/app/logic/Calendar/RecurrenceRule.ts
+++ b/app/logic/Calendar/RecurrenceRule.ts
@@ -192,6 +192,10 @@ export class RecurrenceRule implements Readonly<RecurrenceInit> {
     let hours = startDate.getHours();
     let minutes = startDate.getMinutes();
     let seconds = startDate.getSeconds();
+    if ((this.frequency == Frequency.Yearly || this.frequency == Frequency.Monthly) && !this.weekdays) {
+      // Last occurrence might be on the wrong day; use the original day
+      day = this.startDate.getDate();
+    }
     while (this.occurrences.length < count) {
       switch (this.frequency) {
       case Frequency.Daily:

--- a/app/logic/Calendar/RecurrenceRule.ts
+++ b/app/logic/Calendar/RecurrenceRule.ts
@@ -98,7 +98,7 @@ export class RecurrenceRule implements Readonly<RecurrenceInit> {
     Object.assign(this, data);
     // EditEvent mutates the start time, so clone it to be safe.
     this.occurrences.push(this.startDate = new Date(this.startDate));
-    this.fillOccurrences(this.count, this.endDate || new Date(Date.now() + 1e11));
+    // this.fillOccurrences(this.count, this.endDate || new Date(Date.now() + 1e11));
   }
 
   static fromCalString(startDate: Date, calString: string): RecurrenceRule {


### PR DESCRIPTION
The bug occurs when we fill more occurrences (so they have to be filled twice). This doesn't normally happen because both the front and back end code try to fill a couple of years at once to avoid having to fill more occurrences. However if the last filled occurrence was moved to the last day of a short month then the fill code would erroneously continue from that day.