### PR TITLE
JSONEmail & JSONFolder: Read & write property names don't match

### DIFF
--- a/app/logic/Mail/JSON/JSONEMail.ts
+++ b/app/logic/Mail/JSON/JSONEMail.ts
@@ -77,7 +77,7 @@ export class JSONEMail {
     assert(this.filesDir, "Please call init() first");
     let json: any = [];
     json.filename = a.filename;
-    json.filepath = a.filepathLocal?.replace(this.filesDir + "/", "");
+    json.filepathLocal = a.filepathLocal?.replace(this.filesDir + "/", "");
     json.mimeType = a.mimeType;
     json.size = a.size;
     json.contentID = a.contentID;
@@ -203,7 +203,7 @@ export class JSONEMail {
       a.mimeType = sanitize.nonemptystring(json.mimeType, "application/octet-stream");
       a.contentID = sanitize.nonemptystring(json.contentID, "" + fallbackID);
       a.filename = sanitize.nonemptystring(json.filename, "attachment-" + fallbackID + "." + fileExtensionForMIMEType(a.mimeType));
-      let filepathLocal = sanitize.string(json.filepath, null)
+      let filepathLocal = sanitize.string(json.filepathLocal, null)
       if (filepathLocal) {
         a.filepathLocal = this.filesDir + "/" + filepathLocal;
       }

--- a/app/logic/Mail/JSON/JSONEMail.ts
+++ b/app/logic/Mail/JSON/JSONEMail.ts
@@ -101,8 +101,8 @@ export class JSONEMail {
     // .folder is set by caller when doing `email = folder.newEMail()`
     email.inReplyTo = sanitize.string(json.inReplyTo, null);
     email.size = sanitize.integer(json.size, null);
-    email.received = sanitize.date(json.dateReceived * 1000, new Date());
-    email.sent = sanitize.date(json.dateSent * 1000, email.received);
+    email.received = sanitize.date(json.received * 1000, new Date());
+    email.sent = sanitize.date(json.sent * 1000, email.received);
     email.outgoing = sanitize.boolean(!!json.outgoing);
     email.subject = sanitize.string(json.subject, null);
     if (json.plaintext != null || json.html != null) {
@@ -132,8 +132,8 @@ export class JSONEMail {
     email.id = sanitize.nonemptystring(json.id, "");
     email.inReplyTo = sanitize.string(json.inReplyTo, null);
     email.size = sanitize.integer(json.size, null);
-    email.sent = sanitize.date(json.dateSent * 1000, new Date());
-    email.received = sanitize.date(json.dateReceived * 1000, new Date());
+    email.sent = sanitize.date(json.sent * 1000, new Date());
+    email.received = sanitize.date(json.received * 1000, new Date());
     email.outgoing = sanitize.boolean(json.outgoing);
     email.subject = sanitize.string(json.subject, null);
 
@@ -141,7 +141,7 @@ export class JSONEMail {
     email.isStarred = sanitize.boolean(json.isStarred);
     email.isReplied = sanitize.boolean(json.isReplied);
     email.isSpam = sanitize.boolean(json.isSpam);
-    email.threadID = sanitize.string(json.threadID ?? json.parentMsgID, null);
+    email.threadID = sanitize.string(json.threadID ?? json.inReplyTo, null);
     email.downloadComplete = sanitize.boolean(json.downloadComplete);
 
     // email.contact = findOrCreatePersonUID("foo45@example.com", sanitize.label(json.contactName, null));
@@ -203,7 +203,7 @@ export class JSONEMail {
       a.mimeType = sanitize.nonemptystring(json.mimeType, "application/octet-stream");
       a.contentID = sanitize.nonemptystring(json.contentID, "" + fallbackID);
       a.filename = sanitize.nonemptystring(json.filename, "attachment-" + fallbackID + "." + fileExtensionForMIMEType(a.mimeType));
-      let filepathLocal = sanitize.string(json.filepathLocal, null)
+      let filepathLocal = sanitize.string(json.filepath, null)
       if (filepathLocal) {
         a.filepathLocal = this.filesDir + "/" + filepathLocal;
       }

--- a/app/logic/Mail/JSON/JSONFolder.ts
+++ b/app/logic/Mail/JSON/JSONFolder.ts
@@ -32,7 +32,7 @@ export class JSONFolder extends Folder {
     folder.countTotal = sanitize.integer(json.countTotal, 0);
     folder.countUnread = sanitize.integer(json.countUnread, 0);
     folder.countNewArrived = sanitize.integer(json.countNewArrived, 0);
-    folder.specialFolder = sanitize.alphanumdash(json.specialUse, null) as SpecialFolder;
+    folder.specialFolder = sanitize.alphanumdash(json.specialFolder, null) as SpecialFolder;
     if (json.uidvalidity !== undefined) {
       (folder as any as IMAPFolder).uidvalidity = sanitize.integer(json.uidvalidity, 0);
     }
@@ -42,8 +42,8 @@ export class JSONFolder extends Folder {
     let accountID = sanitize.alphanumdash(json.accountID);
     folder.account = appGlobal.emailAccounts.find(acc => acc.id == accountID);
     assert(folder.account, `Account ${accountID} not yet loaded`);
-    if (json.parent) {
-      let parentFolderID = sanitize.alphanumdash(json.parent);
+    if (json.parentID) {
+      let parentFolderID = sanitize.alphanumdash(json.parentID);
       folder.parent = folder.account.findFolder(folder => folder.id == parentFolderID);
       assert(folder.parent, `Parent folder ${parentFolderID} not found`);
     }


### PR DESCRIPTION
I changed property names in the `read()` methods for the `JSON*` classes because they are different than the ones in the `save()` methods making them read properties that contain `null` values.

This fixes a bug where all the emails have the date and time of the current time when viewing the emails.