### PR TITLE
AceBase: Emails filtered

### DIFF
--- a/app/logic/Mail/AceBase/AceEMail.ts
+++ b/app/logic/Mail/AceBase/AceEMail.ts
@@ -101,8 +101,9 @@ export class AceEMail {
     await JSONEMail.init();
     let db = await getDatabase();
     let newEmails = new ArrayColl<EMail>();
-    await db.forEach(
+    await db.forEachFiltered(
       this.refBranch,
+      [{ column: "folderID", op: "==", value: folder.id}],
       { exclude: [ "*/html", "*/plaintext" ] },
       (dbID: string, json: any) => {
         let email = folder.messages.find(email => email.dbID == dbID);

--- a/app/logic/Mail/AceBase/AceEMail.ts
+++ b/app/logic/Mail/AceBase/AceEMail.ts
@@ -154,8 +154,9 @@ export class AceEMail {
     await JSONEMail.init();
     let db = await getDatabase();
     let newEmails = new ArrayColl<EMail>();
-    await db.forEach(
+    await db.forEachFiltered(
       this.refBranch,
+      [{ column: "folderID", op: "==", value: folder.id}],
       { include: this.kMainPropertiesInclude },
       (dbID: string, json: any) => {
         let email = folder.messages.find(email => email.dbID == dbID);

--- a/backend/acebase.ts
+++ b/backend/acebase.ts
@@ -49,4 +49,15 @@ export class AceBaseHandle {
       eachCallback(snapshot.key, snapshot.val());
     });
   }
+
+  async forEachFiltered(refPath: string, filters: { column: string, op: any, value: string }[],
+    include: any, eachCallback: (ref: string, value: any) => void): Promise<void> {
+    let q = this._db.query(refPath);
+    for (let filter of filters) {
+      q = q.filter(filter.column, filter.op, filter.value);
+    }
+    q.forEach(include, snapshot => {
+      eachCallback(snapshot.key, snapshot.val());
+    });
+  }
 }


### PR DESCRIPTION
All emails are iterated regardless if they belong in the folder. I add a `forEachFiltered()` method to the AceBaseHandle and used that to only iterate through emails that belong in the Folder.