### PR TITLE
ACEFolder: Fix id property names

### DIFF
--- a/app/logic/Mail/AceBase/AceFolder.ts
+++ b/app/logic/Mail/AceBase/AceFolder.ts
@@ -50,12 +50,12 @@ export class AceFolder extends Folder {
       [{ column: 'accountID', op: '==', value: account.id }],
       {});
     async function readSubFolders(parentFolderID: string | null, resultFolders: Collection<Folder>) {
-      for (let row of rows.filter(r => r.parent == parentFolderID)) {
-        if (account.findFolder(folder => folder.dbID == row.id)) {
+      for (let row of rows.filter(r => r.parentID == parentFolderID)) {
+        if (account.findFolder(folder => folder.id == row.id)) {
           continue;
         }
         let folder = account.newFolder();
-        await JSONFolder.read(folder, row);
+        JSONFolder.read(folder, row);
         resultFolders.add(folder);
         await readSubFolders(folder.id, folder.subFolders);
       }


### PR DESCRIPTION
- Use folder id instead of dbID
- The property name for the parent folder is incorrect, it should be `parentID`
- JSONFolder is not an async function