### PR TITLE
JSON: Mail: Tags: Fix reading

### DIFF
--- a/app/logic/Mail/JSON/JSONEMail.ts
+++ b/app/logic/Mail/JSON/JSONEMail.ts
@@ -3,7 +3,7 @@ import { PersonUID, findOrCreatePersonUID, kDummyPerson } from "../../Abstract/P
 import { Attachment, ContentDisposition } from "../Attachment";
 import { getTagByName } from "../Tag";
 import { appGlobal } from "../../app";
-import { assert, fileExtensionForMIMEType } from "../../util/util";
+import { assert, fileExtensionForMIMEType, ensureArray } from "../../util/util";
 import { sanitize } from "../../../../lib/util/sanitizeDatatypes";
 import type { ArrayColl } from "svelte-collections";
 
@@ -226,6 +226,8 @@ export class JSONEMail {
       return;
     }
     email.tags.clear();
+    for (let tag of ensureArray(emailJSON.tags)) {
+      this.readTag(email, tag);
     for (let json of emailJSON.tags) {
       this.readTag(email, json);
     }
@@ -233,10 +235,10 @@ export class JSONEMail {
 
   protected static readTag(email: EMail, json: any): void {
     try {
-      if (!json.name) {
+      if (!json) {
         return;
       }
-      let name = sanitize.nonemptystring(json.name);
+      let name = sanitize.nonemptystring(json);
       let tag = getTagByName(name);
       email.tags.add(tag);
     } catch (ex) {

--- a/app/logic/Mail/JSON/JSONEMail.ts
+++ b/app/logic/Mail/JSON/JSONEMail.ts
@@ -228,8 +228,6 @@ export class JSONEMail {
     email.tags.clear();
     for (let tag of ensureArray(emailJSON.tags)) {
       this.readTag(email, tag);
-    for (let json of emailJSON.tags) {
-      this.readTag(email, json);
     }
   }
 


### PR DESCRIPTION
- `emailJSON.tags` is an array of strings, not an array of `{ name: string }` 
- `readTag()` now just reads the param directly instead of access `tag.name`