### PR TITLE
Fix race condition in makeSyncRequest

### DIFF
--- a/app/logic/Calendar/ActiveSync/ActiveSyncCalendar.ts
+++ b/app/logic/Calendar/ActiveSync/ActiveSyncCalendar.ts
@@ -89,7 +89,7 @@ export class ActiveSyncCalendar extends Calendar implements ActiveSyncPingable {
       if (response.Collections.Collection.Status != "1") {
         throw new EASError("Sync", response.Collections.Collection.Status);
       }
-      responseFunc?.(response.Collections.Collection);
+      await responseFunc?.(response.Collections.Collection);
       this.syncState = response.Collections.Collection.SyncKey;
       await this.save();
     } while (responseFunc && response.Collections.Collection.MoreAvailable == "");

--- a/app/logic/Contacts/ActiveSync/ActiveSyncAddressbook.ts
+++ b/app/logic/Contacts/ActiveSync/ActiveSyncAddressbook.ts
@@ -92,7 +92,7 @@ export class ActiveSyncAddressbook extends Addressbook implements ActiveSyncPing
       if (response.Collections.Collection.Status != "1") {
         throw new EASError("Sync", response.Collections.Collection.Status);
       }
-      responseFunc?.(response.Collections.Collection);
+      await responseFunc?.(response.Collections.Collection);
       this.syncState = response.Collections.Collection.SyncKey;
       await this.save();
     } while (responseFunc && response.Collections.Collection.MoreAvailable == "");

--- a/app/logic/Mail/ActiveSync/ActiveSyncFolder.ts
+++ b/app/logic/Mail/ActiveSync/ActiveSyncFolder.ts
@@ -148,7 +148,7 @@ export class ActiveSyncFolder extends Folder implements ActiveSyncPingable {
       if (response.Collections.Collection.Status != "1") {
         throw new EASError("Sync", response.Collections.Collection.Status);
       }
-      responseFunc?.(response.Collections.Collection);
+      await responseFunc?.(response.Collections.Collection);
       this.syncState = response.Collections.Collection.SyncKey;
       await this.storage.saveFolder(this);
     } while (responseFunc && response.Collections.Collection.MoreAvailable == "");


### PR DESCRIPTION
`makeSyncRequest` fails to wait for its callback to complete. In the case of calendar and contacts, this means that it saves the new sync key without checking that the callback was successful. In the case of email, this means that new messages don't get added to the folder correctly.