### PR TITLE
JSON: MailAccount: Values maybe null

### DIFF
--- a/app/logic/Mail/JSON/JSONMailAccount.ts
+++ b/app/logic/Mail/JSON/JSONMailAccount.ts
@@ -22,8 +22,8 @@ export class JSONMailAccount {
     json.hostname = acc.hostname;
     json.port = acc.port;
     json.tls = acc.tls;
-    json.outgoingAccountID = acc.outgoing.id;
-    json.workspaceID = acc.workspace.id;
+    json.outgoingAccountID = acc.outgoing?.id;
+    json.workspaceID = acc.workspace?.id;
     json.config = acc.toConfigJSON();
     return json;
   }


### PR DESCRIPTION
I missed the `?` when I adding the outgoingID and workspaceID to JSONMailAccount.
```
SetupMail.svelte:216 TypeError: Cannot read properties of null (reading 'id')
    at JSONMailAccount.save (JSONMailAccount.ts:25:43)
    at _AceMailAccount.save (AceMailAccount.ts:26:32)
    at AceMailStorage.saveAccount (AceMailStorage.ts:11:26)
    at EWSAccount.save (MailAccount.ts:95:25)
    at saveConfig (saveConfig.ts:35:16)
    at saveAndInitConfig (saveConfig.ts:14:9)
    at onSave (SetupMail.svelte:233:11)
    at onContinue (SetupMail.svelte:183:13)
```