### PR TITLE
Calendar: Don't try to load iTIP data through Exchange APIs #268

### DIFF
--- a/app/logic/Mail/ActiveSync/ActiveSyncEMail.ts
+++ b/app/logic/Mail/ActiveSync/ActiveSyncEMail.ts
@@ -192,6 +192,7 @@ export class ActiveSyncEMail extends EMail {
     await this.deleteMessageLocally(); // Exchange deletes the message from the inbox
   }
 
+  /* Disabling because ActiveSync does not provide complete event data.
   async loadEvent() {
     assert(this.scheduling, "This is not an invitation or response");
     assert(!this.event, "Event has already been loaded");
@@ -219,6 +220,7 @@ export class ActiveSyncEMail extends EMail {
     setPersons(event.participants, result.Response.Fetch.Properties.MeetingRequest.Organizer);
     this.event = event;
   }
+  */
 }
 
 function setPersons(targetList: ArrayColl<PersonUID>, addresses: string): void {

--- a/app/logic/Mail/EWS/EWSEMail.ts
+++ b/app/logic/Mail/EWS/EWSEMail.ts
@@ -220,8 +220,10 @@ export class EWSEMail extends EMail {
     await this.deleteMessageLocally(); // Exchange deletes the message from the inbox
   }
 
+  /* Disabling because EWS only provides event data for invitations,
+   * as opposed to EMail::loadEvent which works for all iTIP messages.
   async loadEvent() {
-    assert(this.scheduling, "This is not an invitation or response");
+    assert(this.scheduling == Scheduling.Request, "This is not an invitation");
     assert(!this.event, "Event has already been loaded");
     let request = {
       m$GetItem: {
@@ -272,6 +274,7 @@ export class EWSEMail extends EMail {
     event.fromXML(getEWSItem(result.Items));
     this.event = event;
   }
+  */
 }
 
 function setPersons(targetList: ArrayColl<PersonUID>, mailboxes: any): void {

--- a/app/logic/Mail/OWA/OWAEMail.ts
+++ b/app/logic/Mail/OWA/OWAEMail.ts
@@ -190,8 +190,10 @@ export class OWAEMail extends EMail {
     await this.deleteMessageLocally(); // Exchange deletes the message from the inbox
   }
 
+  /* Disabling because OWA only provides event data for invitations,
+   * as opposed to EMail::loadEvent which works for all iTIP messages.
   async loadEvent() {
-    assert(this.scheduling, "This is not an invitation or response");
+    assert(this.scheduling == Scheduling.Request, "This is not an invitation");
     assert(!this.event, "Event has already been loaded");
     let request = {
       __type: "GetItemJsonRequest:#Exchange",
@@ -263,6 +265,7 @@ export class OWAEMail extends EMail {
     event.fromJSON(result.Items[0]);
     this.event = event;
   }
+  */
 }
 
 function setPersons(targetList: ArrayColl<PersonUID>, mailboxes: any): void {


### PR DESCRIPTION
In the case of EWS and OWA, this only works for invitations.
In the case of ActiveSync, this doesn't provide complete data.