### PR TITLE
Mail: SQL: Use transactions without async

### DIFF
--- a/app/logic/Mail/SQL/SQLDatabase.ts
+++ b/app/logic/Mail/SQL/SQLDatabase.ts
@@ -18,7 +18,6 @@ export async function getDatabase(): Promise<Database> {
   mailDatabase = await getDatabase("mail.db");
   await mailDatabase.migrate(mailDatabaseSchema);
   await mailDatabase.pragma('foreign_keys = true');
-  await mailDatabase.pragma('synchronous = NORMAL');
   await mailDatabase.pragma('journal_mode = WAL');
   return mailDatabase;
 }

--- a/app/logic/Mail/SQL/SQLDatabase.ts
+++ b/app/logic/Mail/SQL/SQLDatabase.ts
@@ -18,7 +18,7 @@ export async function getDatabase(): Promise<Database> {
   mailDatabase = await getDatabase("mail.db");
   await mailDatabase.migrate(mailDatabaseSchema);
   await mailDatabase.pragma('foreign_keys = true');
-  await mailDatabase.pragma('journal_mode = WAL');
+  await mailDatabase.pragma('journal_mode = DELETE');
   return mailDatabase;
 }
 

--- a/app/logic/Mail/SQL/SQLDatabase.ts
+++ b/app/logic/Mail/SQL/SQLDatabase.ts
@@ -18,6 +18,7 @@ export async function getDatabase(): Promise<Database> {
   mailDatabase = await getDatabase("mail.db");
   await mailDatabase.migrate(mailDatabaseSchema);
   await mailDatabase.pragma('foreign_keys = true');
+  await mailDatabase.pragma('synchronous = NORMAL');
   await mailDatabase.pragma('journal_mode = WAL');
   return mailDatabase;
 }

--- a/app/logic/Mail/SQL/SQLDatabase.ts
+++ b/app/logic/Mail/SQL/SQLDatabase.ts
@@ -18,7 +18,7 @@ export async function getDatabase(): Promise<Database> {
   mailDatabase = await getDatabase("mail.db");
   await mailDatabase.migrate(mailDatabaseSchema);
   await mailDatabase.pragma('foreign_keys = true');
-  await mailDatabase.pragma('journal_mode = DELETE');
+  await mailDatabase.pragma('journal_mode = WAL');
   return mailDatabase;
 }
 

--- a/app/logic/Mail/SQL/SQLEMail.ts
+++ b/app/logic/Mail/SQL/SQLEMail.ts
@@ -223,6 +223,8 @@ export class SQLEMail {
   static async saveMultiple(emails: Collection<EMail>) {
     let lock = await this.transactionLock.lock();
     try {
+      // We need to save all persons before the email transaction
+      // otherwise it will not appear in the database
       await (await getDatabase()).executeTransaction(() => {
         for (let email of emails) {
           if (!email.subject) {

--- a/app/logic/Mail/SQL/createDatabase.ts
+++ b/app/logic/Mail/SQL/createDatabase.ts
@@ -83,6 +83,7 @@ export const mailDatabaseSchema = sql`
     "isDraft" BOOLEAN default false,
     "isSpam" BOOLEAN default false,
     "downloadComplete" BOOLEAN default false,
+    UNIQUE("messageID", "pID", "folderID"),
     -- FOREIGN KEY (parentMsgID)
     --   REFERENCES email (messageID)
     --   ON DELETE SET NULL,


### PR DESCRIPTION
- journal_mode is set to WAL
- use `executeTransaction()` provided by `@radically-straightforward/sqlite`
- We have to save all persons before saving the email because when we do it while in the transaction the insert doesn't appear in the database until the entire transaction is completed so our query for selecting the personID is always null the first time
- setting `UNIQUE("messageID", "pID", "folderID")` just a little bit faster