### PR TITLE
Fix usage of boolean types in OWA code #278

### DIFF
--- a/app/logic/Calendar/OWA/OWAEvent.ts
+++ b/app/logic/Calendar/OWA/OWAEvent.ts
@@ -76,7 +76,7 @@ export class OWAEvent extends Event {
         }
       }
     }
-    if (json.ReminderIsSet == "true") {
+    if (json.ReminderIsSet) {
       this.alarm = new Date(this.startTime.getTime() - 60 * sanitize.integer(json.ReminderMinutesBeforeStart));
     } else {
       this.alarm = null;

--- a/app/logic/Mail/OWA/OWAFolder.ts
+++ b/app/logic/Mail/OWA/OWAFolder.ts
@@ -142,8 +142,8 @@ export class OWAFolder extends Folder {
           },
         },
       };
-      let result: any = { RootFolder: { IncludesLastItemInRange: "false" } };
-      while (result?.RootFolder?.IncludesLastItemInRange === "false") {
+      let result: any = { RootFolder: { IncludesLastItemInRange: false } };
+      while (result?.RootFolder?.IncludesLastItemInRange === false) {
         result = await this.account.callOWA(request);
         if (!result?.RootFolder?.Items?.length) {
           // This folder is empty.


### PR DESCRIPTION
Unlike ActiveSync and EWS, where data is transferred using XML, and therefore is stringly typed, OWA uses JSON, and properties actually have useful types. Unfortunately when porting EWS code I didn't always remember this. As well as the case of #278 where only 50 messages can be downloaded, I found a second instance in calendar code, which would prevent it from reading the alarm status of any event.