### PR TITLE
Setup: Check outgoing acc.id also

### DIFF
--- a/app/logic/Abstract/Account.ts
+++ b/app/logic/Abstract/Account.ts
@@ -116,6 +116,7 @@ function findFreeAccountID(): string {
 function getAllAccounts(): Collection<Account> {
   let allAccounts = new ArrayColl<Account>();
   allAccounts.addAll(appGlobal.emailAccounts);
+  allAccounts.addAll(appGlobal.emailAccounts.map(acc => acc.outgoing));
   allAccounts.addAll(appGlobal.chatAccounts);
   allAccounts.addAll(appGlobal.addressbooks);
   allAccounts.addAll(appGlobal.calendars);

--- a/app/logic/Abstract/Account.ts
+++ b/app/logic/Abstract/Account.ts
@@ -116,7 +116,7 @@ function findFreeAccountID(): string {
 function getAllAccounts(): Collection<Account> {
   let allAccounts = new ArrayColl<Account>();
   allAccounts.addAll(appGlobal.emailAccounts);
-  allAccounts.addAll(appGlobal.emailAccounts.filter(acc => !!acc.outgoing).map(acc => acc.outgoing));
+  allAccounts.addAll(appGlobal.emailAccounts.map(acc => acc.outgoing).filter(o => !!o));
   allAccounts.addAll(appGlobal.chatAccounts);
   allAccounts.addAll(appGlobal.addressbooks);
   allAccounts.addAll(appGlobal.calendars);

--- a/app/logic/Abstract/Account.ts
+++ b/app/logic/Abstract/Account.ts
@@ -116,7 +116,7 @@ function findFreeAccountID(): string {
 function getAllAccounts(): Collection<Account> {
   let allAccounts = new ArrayColl<Account>();
   allAccounts.addAll(appGlobal.emailAccounts);
-  allAccounts.addAll(appGlobal.emailAccounts.map(acc => acc.outgoing));
+  allAccounts.addAll(appGlobal.emailAccounts.filter(acc => !!acc.outgoing).map(acc => acc.outgoing));
   allAccounts.addAll(appGlobal.chatAccounts);
   allAccounts.addAll(appGlobal.addressbooks);
   allAccounts.addAll(appGlobal.calendars);


### PR DESCRIPTION
- I think it's reusing the same `acc.id` becuase it doesn't check the `acc.id` of outgoing accounts because it doesn't get added by `getAllAccounts()`