### PR TITLE
FastList: Register observer after component loads - fixes #289

### DIFF
--- a/app/frontend/Shared/FastList.svelte
+++ b/app/frontend/Shared/FastList.svelte
@@ -153,6 +153,7 @@
   }
 
   onMount(() => {
+    selectedItems.registerObserver(singleSelectionObserver);
     if (selectedItem) {
       selectedItems.add(selectedItem);
     }
@@ -323,7 +324,6 @@
   singleSelectionObserver.onSelectedItem = item => {
     selectedItem = item;
   };
-  selectedItems.registerObserver(singleSelectionObserver);
 </script>
 
 <style>


### PR DESCRIPTION
- The observer was registered before the component mounted thus it was cleared when the component mounted which caused the UI to not update