### PR TITLE
Build: Mac Universal build with ARM and x86 binaries

### DIFF
--- a/e2/electron-builder.yml
+++ b/e2/electron-builder.yml
@@ -31,6 +31,10 @@ mac:
     - NSDocumentsFolderUsageDescription: Application requests access to the user's Documents folder.
     - NSDownloadsFolderUsageDescription: Application requests access to the user's Downloads folder.
   notarize: true
+  target:
+    target: default
+    arch:
+      - universal
 dmg:
   artifactName: ${name}-${version}.${ext}
 linux:


### PR DESCRIPTION
- Our build for mac was not set to universal
- `target: default` is mandatory
- This was the reason for the slow startup on MacOS
- https://github.com/mustang-im/mustang/actions/runs/12248650829/job/34168650435#step:11:568