### PR TITLE
Build: npm rebuild for prebuilds

### DIFF
--- a/e2/electron-builder.yml
+++ b/e2/electron-builder.yml
@@ -47,7 +47,7 @@ linux:
   category: Utility
 appImage:
   artifactName: ${name}-${version}.${ext}
-npmRebuild: false
+npmRebuild: true
 publish:
   - provider: github
     protocol: https


### PR DESCRIPTION
- It was using the same prebuilds for both architectures
- https://github.com/mustang-im/mustang/actions/runs/12267607351/job/34228010683#step:11:566

Before
```
skipped dependencies rebuild  reason=npmRebuild is set to false
  • packaging       platform=darwin arch=x64 electron=32.2.7 appOutDir=dist/mac-universal-x64-temp
  • downloading     url=https://github.com/electron/electron/releases/download/v32.2.7/electron-v32.2.7-darwin-x64.zip size=104 MB parts=8
  • downloaded      url=https://github.com/electron/electron/releases/download/v32.2.7/electron-v32.2.7-darwin-x64.zip duration=1.662s
  • skipped dependencies rebuild  reason=npmRebuild is set to false
  • packaging       platform=darwin arch=arm64 electron=32.2.7 appOutDir=dist/mac-universal-arm64-temp
```

Now it gets the prebuild for each arch
```
  • rebuilding native dependencies  dependencies=better-sqlite3@11.3.0, bufferutil@4.0.8, utf-8-validate@6.0.4 platform=darwin arch=x64
  • install prebuilt binary  name=better-sqlite3 version=11.3.0 platform=darwin arch=x64 napi=
  • rebuilding native dependency  name=utf-8-validate version=6.0.4
  • rebuilding native dependency  name=bufferutil version=4.0.8
  • packaging       platform=darwin arch=x64 electron=32.2.6 appOutDir=dist/mac-universal-x64-temp
  • rebuilding native dependencies  dependencies=better-sqlite3@11.3.0, bufferutil@4.0.8, utf-8-validate@6.0.4 platform=darwin arch=arm64
  • install prebuilt binary  name=better-sqlite3 version=11.3.0 platform=darwin arch=arm64 napi=
  • rebuilding native dependency  name=bufferutil version=4.0.8
  • rebuilding native dependency  name=utf-8-validate version=6.0.4
```