### PR TITLE
Build: Generate and upload source map for Sentry

### DIFF
--- a/.github/workflows/installer-linux-parula.yml
+++ b/.github/workflows/installer-linux-parula.yml
@@ -28,6 +28,8 @@ jobs:
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+        # For Vite build out of memory error when building
+        # sourcemap for Sentry
         NODE_OPTIONS: '--max-old-space-size=32768'
     - name: Upload
       uses: actions/upload-artifact@v4

--- a/.github/workflows/installer-linux-parula.yml
+++ b/.github/workflows/installer-linux-parula.yml
@@ -28,8 +28,7 @@ jobs:
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
-        # For Vite build out of memory error when building
-        # sourcemap for Sentry
+        # For Sentry source maps. Otherwise, vite build is out of memory
         NODE_OPTIONS: '--max-old-space-size=32768'
     - name: Upload
       uses: actions/upload-artifact@v4

--- a/.github/workflows/installer-linux-parula.yml
+++ b/.github/workflows/installer-linux-parula.yml
@@ -28,6 +28,7 @@ jobs:
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+        NODE_OPTIONS: --max-old-space-size=32768
     - name: Upload
       uses: actions/upload-artifact@v4
       with:

--- a/.github/workflows/installer-linux-parula.yml
+++ b/.github/workflows/installer-linux-parula.yml
@@ -27,6 +27,7 @@ jobs:
     - run: cd e2; npm run build:release:linux
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
     - name: Upload
       uses: actions/upload-artifact@v4
       with:

--- a/.github/workflows/installer-linux-parula.yml
+++ b/.github/workflows/installer-linux-parula.yml
@@ -28,7 +28,7 @@ jobs:
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
-        NODE_OPTIONS: --max-old-space-size=32768
+        NODE_OPTIONS: '--max-old-space-size=32768'
     - name: Upload
       uses: actions/upload-artifact@v4
       with:

--- a/.github/workflows/installer-linux.yml
+++ b/.github/workflows/installer-linux.yml
@@ -28,6 +28,8 @@ jobs:
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+        # For Vite build out of memory error when building
+        # sourcemap for Sentry
         NODE_OPTIONS: '--max-old-space-size=32768'
     - name: Upload
       uses: actions/upload-artifact@v4

--- a/.github/workflows/installer-linux.yml
+++ b/.github/workflows/installer-linux.yml
@@ -28,8 +28,7 @@ jobs:
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
-        # For Vite build out of memory error when building
-        # sourcemap for Sentry
+        # For Sentry source maps. Otherwise, vite build is out of memory
         NODE_OPTIONS: '--max-old-space-size=32768'
     - name: Upload
       uses: actions/upload-artifact@v4

--- a/.github/workflows/installer-linux.yml
+++ b/.github/workflows/installer-linux.yml
@@ -28,6 +28,7 @@ jobs:
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+        NODE_OPTIONS: --max-old-space-size=32768
     - name: Upload
       uses: actions/upload-artifact@v4
       with:

--- a/.github/workflows/installer-linux.yml
+++ b/.github/workflows/installer-linux.yml
@@ -27,6 +27,7 @@ jobs:
     - run: cd e2; npm run build:release:linux
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
     - name: Upload
       uses: actions/upload-artifact@v4
       with:

--- a/.github/workflows/installer-linux.yml
+++ b/.github/workflows/installer-linux.yml
@@ -28,7 +28,7 @@ jobs:
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
-        NODE_OPTIONS: --max-old-space-size=32768
+        NODE_OPTIONS: '--max-old-space-size=32768'
     - name: Upload
       uses: actions/upload-artifact@v4
       with:

--- a/.github/workflows/installer-mac-parula.yml
+++ b/.github/workflows/installer-mac-parula.yml
@@ -36,6 +36,8 @@ jobs:
         APPLE_API_KEY_ID: ${{ secrets.APPLE_API_KEY_ID }}
         APPLE_API_ISSUER: ${{ secrets.APPLE_API_ISSUER }}
         SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+        # For Vite build out of memory error when building
+        # sourcemap for Sentry
         NODE_OPTIONS: '--max-old-space-size=32768'
     - name: Upload
       uses: actions/upload-artifact@v4

--- a/.github/workflows/installer-mac-parula.yml
+++ b/.github/workflows/installer-mac-parula.yml
@@ -36,7 +36,7 @@ jobs:
         APPLE_API_KEY_ID: ${{ secrets.APPLE_API_KEY_ID }}
         APPLE_API_ISSUER: ${{ secrets.APPLE_API_ISSUER }}
         SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
-        NODE_OPTIONS: --max-old-space-size=32768
+        NODE_OPTIONS: '--max-old-space-size=32768'
     - name: Upload
       uses: actions/upload-artifact@v4
       with:

--- a/.github/workflows/installer-mac-parula.yml
+++ b/.github/workflows/installer-mac-parula.yml
@@ -36,8 +36,7 @@ jobs:
         APPLE_API_KEY_ID: ${{ secrets.APPLE_API_KEY_ID }}
         APPLE_API_ISSUER: ${{ secrets.APPLE_API_ISSUER }}
         SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
-        # For Vite build out of memory error when building
-        # sourcemap for Sentry
+        # For Sentry source maps. Otherwise, vite build is out of memory
         NODE_OPTIONS: '--max-old-space-size=32768'
     - name: Upload
       uses: actions/upload-artifact@v4

--- a/.github/workflows/installer-mac-parula.yml
+++ b/.github/workflows/installer-mac-parula.yml
@@ -36,6 +36,7 @@ jobs:
         APPLE_API_KEY_ID: ${{ secrets.APPLE_API_KEY_ID }}
         APPLE_API_ISSUER: ${{ secrets.APPLE_API_ISSUER }}
         SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+        NODE_OPTIONS: --max-old-space-size=32768
     - name: Upload
       uses: actions/upload-artifact@v4
       with:

--- a/.github/workflows/installer-mac-parula.yml
+++ b/.github/workflows/installer-mac-parula.yml
@@ -35,6 +35,7 @@ jobs:
         APPLE_API_KEY: ~/private_keys/AuthKey_${{ secrets.APPLE_API_KEY_ID }}.p8
         APPLE_API_KEY_ID: ${{ secrets.APPLE_API_KEY_ID }}
         APPLE_API_ISSUER: ${{ secrets.APPLE_API_ISSUER }}
+        SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
     - name: Upload
       uses: actions/upload-artifact@v4
       with:

--- a/.github/workflows/installer-mac.yml
+++ b/.github/workflows/installer-mac.yml
@@ -36,6 +36,8 @@ jobs:
         APPLE_API_KEY_ID: ${{ secrets.APPLE_API_KEY_ID }}
         APPLE_API_ISSUER: ${{ secrets.APPLE_API_ISSUER }}
         SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+        # For Vite build out of memory error when building
+        # sourcemap for Sentry
         NODE_OPTIONS: '--max-old-space-size=32768'
     - name: Upload
       uses: actions/upload-artifact@v4

--- a/.github/workflows/installer-mac.yml
+++ b/.github/workflows/installer-mac.yml
@@ -36,7 +36,7 @@ jobs:
         APPLE_API_KEY_ID: ${{ secrets.APPLE_API_KEY_ID }}
         APPLE_API_ISSUER: ${{ secrets.APPLE_API_ISSUER }}
         SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
-        NODE_OPTIONS: --max-old-space-size=32768
+        NODE_OPTIONS: '--max-old-space-size=32768'
     - name: Upload
       uses: actions/upload-artifact@v4
       with:

--- a/.github/workflows/installer-mac.yml
+++ b/.github/workflows/installer-mac.yml
@@ -36,8 +36,7 @@ jobs:
         APPLE_API_KEY_ID: ${{ secrets.APPLE_API_KEY_ID }}
         APPLE_API_ISSUER: ${{ secrets.APPLE_API_ISSUER }}
         SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
-        # For Vite build out of memory error when building
-        # sourcemap for Sentry
+        # For Sentry source maps. Otherwise, vite build is out of memory
         NODE_OPTIONS: '--max-old-space-size=32768'
     - name: Upload
       uses: actions/upload-artifact@v4

--- a/.github/workflows/installer-mac.yml
+++ b/.github/workflows/installer-mac.yml
@@ -36,6 +36,7 @@ jobs:
         APPLE_API_KEY_ID: ${{ secrets.APPLE_API_KEY_ID }}
         APPLE_API_ISSUER: ${{ secrets.APPLE_API_ISSUER }}
         SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+        NODE_OPTIONS: --max-old-space-size=32768
     - name: Upload
       uses: actions/upload-artifact@v4
       with:

--- a/.github/workflows/installer-mac.yml
+++ b/.github/workflows/installer-mac.yml
@@ -35,6 +35,7 @@ jobs:
         APPLE_API_KEY: ~/private_keys/AuthKey_${{ secrets.APPLE_API_KEY_ID }}.p8
         APPLE_API_KEY_ID: ${{ secrets.APPLE_API_KEY_ID }}
         APPLE_API_ISSUER: ${{ secrets.APPLE_API_ISSUER }}
+        SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
     - name: Upload
       uses: actions/upload-artifact@v4
       with:

--- a/.github/workflows/installer-windows-parula.yml
+++ b/.github/workflows/installer-windows-parula.yml
@@ -27,8 +27,7 @@ jobs:
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
-        # For Vite build out of memory error when building
-        # sourcemap for Sentry
+        # For Sentry source maps. Otherwise, vite build is out of memory
         NODE_OPTIONS: '--max-old-space-size=32768'
     - name: Upload
       uses: actions/upload-artifact@v4

--- a/.github/workflows/installer-windows-parula.yml
+++ b/.github/workflows/installer-windows-parula.yml
@@ -27,6 +27,7 @@ jobs:
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+        NODE_OPTIONS: --max-old-space-size=32768
     - name: Upload
       uses: actions/upload-artifact@v4
       with:

--- a/.github/workflows/installer-windows-parula.yml
+++ b/.github/workflows/installer-windows-parula.yml
@@ -27,7 +27,7 @@ jobs:
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
-        NODE_OPTIONS: --max-old-space-size=32768
+        NODE_OPTIONS: '--max-old-space-size=32768'
     - name: Upload
       uses: actions/upload-artifact@v4
       with:

--- a/.github/workflows/installer-windows-parula.yml
+++ b/.github/workflows/installer-windows-parula.yml
@@ -27,6 +27,8 @@ jobs:
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+        # For Vite build out of memory error when building
+        # sourcemap for Sentry
         NODE_OPTIONS: '--max-old-space-size=32768'
     - name: Upload
       uses: actions/upload-artifact@v4

--- a/.github/workflows/installer-windows-parula.yml
+++ b/.github/workflows/installer-windows-parula.yml
@@ -26,6 +26,7 @@ jobs:
     - run: cd e2; npm run build:release:win
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
     - name: Upload
       uses: actions/upload-artifact@v4
       with:

--- a/.github/workflows/installer-windows.yml
+++ b/.github/workflows/installer-windows.yml
@@ -27,8 +27,7 @@ jobs:
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
-        # For Vite build out of memory error when building
-        # sourcemap for Sentry
+        # For Sentry source maps. Otherwise, vite build is out of memory
         NODE_OPTIONS: '--max-old-space-size=32768'
     - name: Upload
       uses: actions/upload-artifact@v4

--- a/.github/workflows/installer-windows.yml
+++ b/.github/workflows/installer-windows.yml
@@ -27,6 +27,7 @@ jobs:
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+        NODE_OPTIONS: --max-old-space-size=32768
     - name: Upload
       uses: actions/upload-artifact@v4
       with:

--- a/.github/workflows/installer-windows.yml
+++ b/.github/workflows/installer-windows.yml
@@ -27,7 +27,7 @@ jobs:
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
-        NODE_OPTIONS: --max-old-space-size=32768
+        NODE_OPTIONS: '--max-old-space-size=32768'
     - name: Upload
       uses: actions/upload-artifact@v4
       with:

--- a/.github/workflows/installer-windows.yml
+++ b/.github/workflows/installer-windows.yml
@@ -27,6 +27,8 @@ jobs:
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+        # For Vite build out of memory error when building
+        # sourcemap for Sentry
         NODE_OPTIONS: '--max-old-space-size=32768'
     - name: Upload
       uses: actions/upload-artifact@v4

--- a/.github/workflows/installer-windows.yml
+++ b/.github/workflows/installer-windows.yml
@@ -26,6 +26,7 @@ jobs:
     - run: cd e2; npm run build:release:win
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
     - name: Upload
       uses: actions/upload-artifact@v4
       with:

--- a/e2/electron.vite.config.ts
+++ b/e2/electron.vite.config.ts
@@ -3,6 +3,7 @@ import { nodePolyfills } from "vite-plugin-node-polyfills";
 import { svelte } from '@sveltejs/vite-plugin-svelte';
 import { sentryVitePlugin } from "@sentry/vite-plugin";
 import replace from '@rollup/plugin-replace';
+import { production } from '../app/logic/build';
 
 export default defineConfig({
   main: {
@@ -20,7 +21,7 @@ export default defineConfig({
   },
   renderer: {
     build: {
-      sourcemap: true,
+      sourcemap: production,
     },
     plugins: [
       nodePolyfills({include: ['buffer'], globals: {global: false, process: false}}),
@@ -29,6 +30,7 @@ export default defineConfig({
         org: "mustang-jq",
         project: "mustang",
         authToken: process.env.SENTRY_AUTH_TOKEN,
+        disable: !production,
       }),
     ],
   }

--- a/e2/electron.vite.config.ts
+++ b/e2/electron.vite.config.ts
@@ -1,6 +1,7 @@
 import { defineConfig, externalizeDepsPlugin } from 'electron-vite';
 import { nodePolyfills } from "vite-plugin-node-polyfills";
 import { svelte } from '@sveltejs/vite-plugin-svelte';
+import { sentryVitePlugin } from "@sentry/vite-plugin";
 import replace from '@rollup/plugin-replace';
 
 export default defineConfig({
@@ -18,6 +19,17 @@ export default defineConfig({
     ],
   },
   renderer: {
-    plugins: [nodePolyfills({include: ['buffer'], globals: {global: false, process: false}}), svelte()]
+    build: {
+      sourcemap: true,
+    },
+    plugins: [
+      nodePolyfills({include: ['buffer'], globals: {global: false, process: false}}),
+      svelte(),
+      sentryVitePlugin({
+        org: "mustang-jq",
+        project: "mustang",
+        authToken: process.env.SENTRY_AUTH_TOKEN,
+      }),
+    ],
   }
 })

--- a/e2/package.json
+++ b/e2/package.json
@@ -37,6 +37,7 @@
     "@electron-toolkit/eslint-config-ts": "^1.0.0",
     "@electron-toolkit/tsconfig": "^1.0.1",
     "@rollup/plugin-replace": "^5.0.7",
+    "@sentry/vite-plugin": "^2.22.7",
     "@sveltejs/vite-plugin-svelte": "^3.0.1",
     "@types/node": "^18.17.5",
     "electron": "^32.0.1",


### PR DESCRIPTION
- Vite was not generating a source map because it was not configured in electron vite