### PR TITLE
Allow the backend to be restarted on the Mac #317

### DIFF
--- a/backend/backend.ts
+++ b/backend/backend.ts
@@ -15,10 +15,17 @@ import childProcess from 'node:child_process';
 import * as OWA from './owa';
 import { appName, production } from '../app/logic/build';
 
+let jpc: JPCWebSocket | null = null;
+
 export async function startupBackend() {
   let appGlobal = await createSharedAppObject();
-  let jpc = new JPCWebSocket(appGlobal);
+  jpc = new JPCWebSocket(appGlobal);
   await jpc.listen(kSecret, 5455, false);
+}
+
+export async function shutdownBackend() {
+  await jpc.stopListening();
+  jpc = null;
 }
 
 const kSecret = 'eyache5C'; // TODO generate, and communicate to client, or save in config files.

--- a/e2/src/main/index.ts
+++ b/e2/src/main/index.ts
@@ -1,4 +1,4 @@
-import { setMainWindow, startupBackend } from '../../../backend/backend';
+import { setMainWindow, startupBackend, shutdownBackend } from '../../../backend/backend';
 import { app, shell, BrowserWindow } from 'electron'
 import { join } from 'path'
 import electronUpdater from 'electron-updater';
@@ -36,6 +36,8 @@ function createWindow(): void {
     mainWindow.on('ready-to-show', () => {
       mainWindow.show()
     })
+
+    mainWindow.on('closed', shutdownBackend);
 
     /** Ensure that new web windows are opened in the browser, not inside our app.
      *


### PR DESCRIPTION
IMAP connections won't be closed automatically though, so either they need to be tracked and shut down by the backend or the front end should use an unload handler to close any persistent connections.