### PR TITLE
Context menu roles for predefined actions

### DIFF
--- a/app/frontend/Shared/ContextMenu.ts
+++ b/app/frontend/Shared/ContextMenu.ts
@@ -81,11 +81,10 @@ export class MenuItem {
   label: string;
   icon: string;
   /** 
-   * Roles allow menu items to have predefined behaviors.
+   * String can be used for predefined actions, functions for custom actions
    * @see <https://www.electronjs.org/docs/latest/api/menu-item#roles> 
    */
-  role: string;
-  click: Function;
+  action: string | Function;
   /** Menu item should show up, but cannot be invoked.
    * When to use:
    * - Use `disabled = true` for menu items that apply, but cannot be used, for whatever reason.
@@ -97,13 +96,7 @@ export class MenuItem {
     this.id = id;
     this.label = label;
     this.icon = icon;
-    if (typeof action === 'string') {
-      this.role = action;
-    } else if ( typeof action === 'function') {
-      this.click = action;
-    } else {
-      throw new Error("Invalid action type");
-    }
+    this.action = action;
   }
 }
 

--- a/app/frontend/Shared/WebView.svelte
+++ b/app/frontend/Shared/WebView.svelte
@@ -142,7 +142,8 @@
       id: item.id,
       label: item.label,
       icon: item.icon,
-      click: () => catchErrors(item.action),
+      role: item.role,
+      click: () => catchErrors(item.click),
     })));
   }
 

--- a/app/frontend/Shared/WebView.svelte
+++ b/app/frontend/Shared/WebView.svelte
@@ -142,8 +142,8 @@
       id: item.id,
       label: item.label,
       icon: item.icon,
-      role: item.role,
-      click: () => catchErrors(item.click),
+      role: typeof item.action == "string" ? item.action : undefined,
+      click: typeof item.action == "function" ? () => catchErrors(item.action) : undefined,
     })));
   }
 


### PR DESCRIPTION
- Menu Item constructor takes a string for roles or a function for custom actions
- Copy works now
- Cut and paste actions are implemented but not tested yet