### PR TITLE
Allow JPC to work with Stanza

### DIFF
--- a/lib/jpc/obj.js
+++ b/lib/jpc/obj.js
@@ -173,8 +173,10 @@ export default class BaseProtocol {
       proto = await proto;
     }
     let stub = Object.create(proto);
+    this._recursiveObjects.set(objDescrJSON.idSender, stub);
     stub._jpc_id = objDescrJSON.idSender;
     await this.updateObjectProperties(stub, objDescrJSON.properties);
+    this._recursiveObjects.delete(objDescrJSON.idSender);
     // Timing issue: This needs to happen after the caller sets the
     // Promise it gets from calling us into the remote object map.
     this.addRemoteObject(objDescrJSON.idSender, stub);
@@ -291,7 +293,7 @@ export default class BaseProtocol {
         return new Uint8Array(obj.uint8array);
       }
       if (obj.idSender) {
-        let stub = this.getRemoteObject(obj.idSender);
+        let stub = this._recursiveObjects.get(obj.idSender) || this.getRemoteObject(obj.idSender);
         if (stub) {
           if (stub instanceof Promise) {
             stub = await stub;

--- a/lib/jpc/protocol.test.js
+++ b/lib/jpc/protocol.test.js
@@ -39,6 +39,7 @@ class LPCProtocol extends JPCProtocol {
 }
 
 class Collection {
+  self = this;
   _array = [];
   add(item) {
     this._array.push(item);
@@ -87,6 +88,7 @@ test('Protocol', async () => {
   await expect(start.callable(true)).resolves.toBe(false);
   expect(start).toHaveProperty("makeCollection");
   let collection = await start.makeCollection();
+  expect(collection).toHaveProperty("self", collection);
   await expect(collection.isEmpty).resolves.toBe(true);
   await collection.add(0);
   await collection.add("");
@@ -123,6 +125,7 @@ test('Protocol', async () => {
 });
 
 class ObservableCollection extends Collection {
+  self = null;
   _subscribers = new Set();
   subscribe(subscriber) {
     subscriber(this);


### PR DESCRIPTION
There were some issues here:
- Stanza's client object defines an own `subscribe` function which means that we don't send any properties because we assume observing it will achieve this.
- Stanza's client object contains recursive references to itself.

Thus I have created three commits:
- 8c0729a adds support for objects with recursive references, although I'm not entirely sure this works, I should write a test for it and then let you know.
- 6e445e4 requires the `subscribe` function to be on a prototype rather than an own property, although I'm not sure how many Svelte subscribers we actually send over JPC.
- c91bece actually adds support for own method properties on objects.