### PR TITLE
Revert "WebView: Context menu roles for predefined actions (#334)"(#110)

### DIFF
--- a/app/frontend/Shared/ContextMenu.ts
+++ b/app/frontend/Shared/ContextMenu.ts
@@ -34,9 +34,8 @@ export function buildContextMenu(context: ContextInfo, win: any): ArrayColl<Menu
   context.isLink = !!context.linkURL;
 
   let menuItems = new ArrayColl<MenuItem>();
-  function add(id: string, label, icon: string, action: string | Function, disabled: boolean = false) {
-    action = typeof action === 'string' ? action : () => action(context, win);
-    let menuItem = new MenuItem(id, label, icon, action);
+  function add(id: string, label, icon: string, action: Function, disabled: boolean = false) {
+    let menuItem = new MenuItem(id, label, icon, () => action(context, win));
     menuItem.disabled = disabled;
     menuItems.add(menuItem);
   }
@@ -50,11 +49,11 @@ export function buildContextMenu(context: ContextInfo, win: any): ArrayColl<Menu
     add("saveLink", gt`Save link target as…`, null, saveLinkAs);
   }
   if (context.isText || context.isEditable) {
-    add("copy", gt`Copy`, null, "copy", context.isText && context.editFlags.canCopy);
+    add("copy", gt`Copy`, null, copyText, context.isText && context.editFlags.canCopy);
   }
   if (context.isEditable) {
-    add("cut", gt`Cut`, null, "cut", context.editFlags.canCut);
-    add("paste", gt`Paste`, null, "paste", context.editFlags.canPaste);
+    add("cut", gt`Cut`, null, cutText, context.editFlags.canCut);
+    add("paste", gt`Paste`, null, pasteText, context.editFlags.canPaste);
   }
   if (context.isText && !context.isLink) {
     add("search", gt`Search the web`, null, searchWeb);
@@ -80,11 +79,7 @@ export class MenuItem {
   id: string;
   label: string;
   icon: string;
-  /** 
-   * String can be used for predefined actions, functions for custom actions
-   * @see <https://www.electronjs.org/docs/latest/api/menu-item#roles> 
-   */
-  action: string | Function;
+  action: Function;
   /** Menu item should show up, but cannot be invoked.
    * When to use:
    * - Use `disabled = true` for menu items that apply, but cannot be used, for whatever reason.
@@ -92,7 +87,7 @@ export class MenuItem {
    *   should not be listed at all. */
   disabled: boolean = false;
 
-  constructor(id: string, label: string, icon: string, action: string | Function) {
+  constructor(id: string, label: string, icon: string, action: Function) {
     this.id = id;
     this.label = label;
     this.icon = icon;

--- a/app/frontend/Shared/WebView.svelte
+++ b/app/frontend/Shared/WebView.svelte
@@ -142,8 +142,7 @@
       id: item.id,
       label: item.label,
       icon: item.icon,
-      role: typeof item.action == "string" ? item.action : undefined,
-      click: typeof item.action == "function" ? () => catchErrors(item.action) : undefined,
+      click: () => catchErrors(item.action),
     })));
   }
 


### PR DESCRIPTION
This reverts commit db21fea03d1045a4137835511ab184c055521ac3.

PR https://github.com/mustang-im/mustang/pull/334 is a regression since SvelteUI menu doesn't have access to "electron menu roles". We would have revert it to how it was before where each menu action is a function and not have any roles.