### PR TITLE
Webview: Electron context menu fix common actions (#110)

### DIFF
--- a/app/frontend/Shared/ContextMenu.ts
+++ b/app/frontend/Shared/ContextMenu.ts
@@ -34,9 +34,8 @@ export function buildContextMenu(context: ContextInfo, win: any): ArrayColl<Menu
   context.isLink = !!context.linkURL;
 
   let menuItems = new ArrayColl<MenuItem>();
-  function add(id: string, label, icon: string, action: string | Function, disabled: boolean = false) {
-    action = typeof action === 'string' ? action : () => action(context, win);
-    let menuItem = new MenuItem(id, label, icon, action);
+  function add(id: string, label, icon: string, action: Function, disabled: boolean = false) {
+    let menuItem = new MenuItem(id, label, icon, () => action(context, win));
     menuItem.disabled = disabled;
     menuItems.add(menuItem);
   }
@@ -50,11 +49,11 @@ export function buildContextMenu(context: ContextInfo, win: any): ArrayColl<Menu
     add("saveLink", gt`Save link target as…`, null, saveLinkAs);
   }
   if (context.isText || context.isEditable) {
-    add("copy", gt`Copy`, null, "copy", context.isText && context.editFlags.canCopy);
+    add("copy", gt`Copy`, null, copyText, context.isText && context.editFlags.canCopy);
   }
   if (context.isEditable) {
-    add("cut", gt`Cut`, null, "cut", context.editFlags.canCut);
-    add("paste", gt`Paste`, null, "paste", context.editFlags.canPaste);
+    add("cut", gt`Cut`, null, cutText, context.editFlags.canCut);
+    add("paste", gt`Paste`, null, pasteText, context.editFlags.canPaste);
   }
   if (context.isText && !context.isLink) {
     add("search", gt`Search the web`, null, searchWeb);
@@ -80,11 +79,7 @@ export class MenuItem {
   id: string;
   label: string;
   icon: string;
-  /** 
-   * String can be used for predefined actions, functions for custom actions
-   * @see <https://www.electronjs.org/docs/latest/api/menu-item#roles> 
-   */
-  action: string | Function;
+  action: Function;
   /** Menu item should show up, but cannot be invoked.
    * When to use:
    * - Use `disabled = true` for menu items that apply, but cannot be used, for whatever reason.
@@ -92,7 +87,7 @@ export class MenuItem {
    *   should not be listed at all. */
   disabled: boolean = false;
 
-  constructor(id: string, label: string, icon: string, action: string | Function) {
+  constructor(id: string, label: string, icon: string, action: Function) {
     this.id = id;
     this.label = label;
     this.icon = icon;

--- a/app/frontend/Shared/ContextMenu.ts
+++ b/app/frontend/Shared/ContextMenu.ts
@@ -268,7 +268,7 @@ export function copyToClipboard(text: string | Object) {
 }
 
 export async function openBrowser(url: URLString) {
-  await appGlobal.remoteApp.shell.shell.openExternal(url);
+  await appGlobal.remoteApp.shell.openExternal(url);
 }
 
 export function download(url: URLString, window: any, howSaveAsDialog: boolean, filename?: string) {

--- a/app/frontend/Shared/WebView.svelte
+++ b/app/frontend/Shared/WebView.svelte
@@ -136,7 +136,7 @@
 
   let contextMenuItems: ArrayColl<MenuItem>;
   async function onContextMenu(contextInfo: ContextInfo) {
-    contextMenuItems = buildContextMenu(contextInfo, webviewE.contentWindow);
+    contextMenuItems = buildContextMenu(contextInfo, webviewE);
     console.log("Context menu items:", contextMenuItems.contents.map(i => i.id).join(", "), contextMenuItems.contents);
     await appGlobal.remoteApp.openMenu(contextMenuItems.contents.map(item => ({
       id: item.id,

--- a/app/frontend/Shared/WebView.svelte
+++ b/app/frontend/Shared/WebView.svelte
@@ -142,8 +142,7 @@
       id: item.id,
       label: item.label,
       icon: item.icon,
-      role: typeof item.action == "string" ? item.action : undefined,
-      click: typeof item.action == "function" ? () => catchErrors(item.action) : undefined,
+      click: () => catchErrors(item.action),
     })));
   }
 


### PR DESCRIPTION
- PR #335 fixed the ⁠`RangeError: Maximum call stack size exceeded ⁠` error on the backend, when the `click()` function is called
- Webview methods(`copy()`, `cut()`) should called on `<webview>` instead of `<webview>.contentWindow`
- `shell.shell` is undefined
- What works? All methods supported here https://www.electronjs.org/docs/latest/api/webview-tag#methods e.g. copy(), cut(), paste() and any that doesn't require `webcontents`
- What doesn't work yet? Functions only supported by `webcontents` e.g. copyImageAt(), 