### PR TITLE
 Mail viewer: Allow external images and css, on user request (#140)

### DIFF
--- a/app/frontend/Mail/Message/MessageBody.svelte
+++ b/app/frontend/Mail/Message/MessageBody.svelte
@@ -14,8 +14,10 @@
 
   {#if $message.needToLoadBody}
     <hbox></hbox>
-  {:else if mode == DisplayMode.HTML || mode == DisplayMode.HTMLWithExternal}
-    <HTMLDisplay html={$message.html} allowExternalImages={mode == DisplayMode.HTMLWithExternal} />
+  {:else if mode == DisplayMode.HTML}
+    <HTMLDisplay html={$message.html} allowExternalImages={false} />
+  {:else if mode == DisplayMode.HTMLWithExternal}
+    <HTMLDisplay html={$message.htmlWithExternal} allowExternalImages={true} />
   {:else if mode == DisplayMode.Plaintext}
     <PlaintextDisplay plaintext={$message.text} />
     <!--<HTMLDisplay html={convertTextToHTML($message.text)} />-->

--- a/app/frontend/Mail/Message/MessageBody.svelte
+++ b/app/frontend/Mail/Message/MessageBody.svelte
@@ -17,7 +17,7 @@
   {:else if mode == DisplayMode.HTML}
     <HTMLDisplay html={$message.html} allowExternalImages={false} />
   {:else if mode == DisplayMode.HTMLWithExternal}
-    <HTMLDisplay html={$message.htmlWithExternal} allowExternalImages={true} />
+    <HTMLDisplay html={$message.html} allowExternalImages={true} />
   {:else if mode == DisplayMode.Plaintext}
     <PlaintextDisplay plaintext={$message.text} />
     <!--<HTMLDisplay html={convertTextToHTML($message.text)} />-->
@@ -48,6 +48,8 @@
 
   let modeSetting = getLocalStorage("mail.contentRendering", "html");
   $: mode = $modeSetting.value as DisplayMode;
+
+  $: message.loadExternalImages = mode == DisplayMode.HTMLWithExternal;
 
   function getSource(message: EMail): string {
     if (!message.mime) {

--- a/app/frontend/Shared/WebView.svelte
+++ b/app/frontend/Shared/WebView.svelte
@@ -75,7 +75,7 @@
       }
     </style>`;
     let servers = allowServerCalls === true ? "* 'unsafe-inline'" :
-      allowServerCalls === false ? "'self' 'unsafe-inline'" : allowServerCalls;
+      allowServerCalls === false ? "'unsafe-inline'" : allowServerCalls;
     const head = `<meta http-equiv="Content-Security-Policy" content="default-src 'none';
       style-src ${servers}; img-src ${servers}">\n\n` + headHTML + `\n\n`;
     let displayHTML = html;

--- a/app/frontend/Shared/WebView.svelte
+++ b/app/frontend/Shared/WebView.svelte
@@ -74,9 +74,10 @@
         over-flow: visible !important;
       }
     </style>`;
-    const head = headHTML; /*`<meta http-equiv="Content-Security-Policy" content="default-src '${
-      allowServerCalls === true ? "*" : allowServerCalls === false ? "none" : allowServerCalls
-    }'">\n\n` + headHTML + `\n\n`; */
+    let servers = allowServerCalls === true ? "*" :
+      allowServerCalls === false ? "'none'" : allowServerCalls;
+    const head = `<meta http-equiv="Content-Security-Policy" content="default-src 'none';
+      style-src ${servers}; img-src ${servers}">\n\n` + headHTML + `\n\n`;
     let displayHTML = html;
     let headPos = displayHTML.indexOf("<head>");
     headPos = headPos < 0 ? 0 : headPos + 6;

--- a/app/frontend/Shared/WebView.svelte
+++ b/app/frontend/Shared/WebView.svelte
@@ -74,8 +74,7 @@
         over-flow: visible !important;
       }
     </style>`;
-    let servers = allowServerCalls === true ? "* 'unsafe-inline'" :
-      allowServerCalls === false ? "'unsafe-inline'" : allowServerCalls;
+    let servers = allowServerCalls ? `* 'unsafe-inline'` : `'unsafe-inline'` ;
     const head = `<meta http-equiv="Content-Security-Policy" content="default-src 'none';
       style-src ${servers}; img-src ${servers}">\n\n` + headHTML + `\n\n`;
     let displayHTML = html;

--- a/app/frontend/Shared/WebView.svelte
+++ b/app/frontend/Shared/WebView.svelte
@@ -74,8 +74,8 @@
         over-flow: visible !important;
       }
     </style>`;
-    let servers = allowServerCalls === true ? "*" :
-      allowServerCalls === false ? "'none'" : allowServerCalls;
+    let servers = allowServerCalls === true ? "* 'unsafe-inline'" :
+      allowServerCalls === false ? "'self' 'unsafe-inline'" : allowServerCalls;
     const head = `<meta http-equiv="Content-Security-Policy" content="default-src 'none';
       style-src ${servers}; img-src ${servers}">\n\n` + headHTML + `\n\n`;
     let displayHTML = html;

--- a/app/logic/util/convertHTML.ts
+++ b/app/logic/util/convertHTML.ts
@@ -151,7 +151,7 @@ DOMPurify.addHook('afterSanitizeAttributes', node => {
           node.setAttribute("title", ex.message ?? ex + "");
         }
       } else if ((node.tagName.toLocaleLowerCase() == "img" && attribute == "src") ||
-          (node.tagName.toLocaleLowerCase() == "link" && node.getAttribute("rel") == "stylesheet" && attribute =="href")
+          (node.tagName.toLocaleLowerCase() == "link" && node.getAttribute("rel") == "stylesheet" && attribute == "href")
           && includeExternal) {
         let url = node.getAttribute(attribute);
         let newURL = externalSrc(url);


### PR DESCRIPTION
- CSP scope `'unsafe-inline'` is used in all cases because without it inline CSS would not load but `unsafe-inline` is not recommended
- `default-src 'none'` is used in all cases because it's also the fallback directive for scripts, workers and iframes
- It only allows all sources for `img-src` and `style-src` on user request
- For sanitizeHTML I just added an extra condition to add `src` or `href` attribute if it's an image or external css