### PR TITLE
Fix loadEvent not awaiting properly

### DIFF
--- a/app/logic/Mail/EMail.ts
+++ b/app/logic/Mail/EMail.ts
@@ -202,7 +202,11 @@ export class EMail extends Message {
   async loadEvent() {
     assert(this.scheduling, "This is not an invitation or response");
     assert(!this.event, "Event has already been loaded");
-    await this.mime ? this.parseMIME() : this.loadMIME();
+    if (this.mime) {
+      await this.parseMIME();
+    } else {
+      await this.loadMIME();
+    }
   }
 
   async parseMIME() {


### PR DESCRIPTION
`await` has quite high precedence (I'm probably confusing it with `yield` which has very low precedence) so this wasn't doing what I intended; I think this is the clearest way of rewriting it.