### PR TITLE
Webview: Make necessary only WebContents API available in the frontend (#110)

### DIFF
--- a/app/frontend/Shared/ContextMenu.ts
+++ b/app/frontend/Shared/ContextMenu.ts
@@ -29,11 +29,9 @@ import { appGlobal } from "../../logic/app";
  * });
  * ```
  */
-export async function buildContextMenu(context: ContextInfo, webview: any): Promise<ArrayColl<MenuItem>> {
+export async function buildContextMenu(context: ContextInfo, win: any): Promise<ArrayColl<MenuItem>> {
   context.isText = context.selectionText?.length > 0;
   context.isLink = !!context.linkURL;
-
-  const win = await appGlobal.remoteApp.getWebContents(webview.getWebContentsId());
 
   let menuItems = new ArrayColl<MenuItem>();
   function add(id: string, label, icon: string, action: Function, disabled: boolean = false) {
@@ -239,7 +237,8 @@ export function saveLinkAs(context: ContextInfo, win: any) {
   download(context.linkURL, win, true, context.suggestedFilename);
 }
 
-export function copyImage(context: ContextInfo, win: any) {
+export async function copyImage(context: ContextInfo, win: any) {
+  win = await appGlobal.remoteApp.getWebContents(win.getWebContentsId());
   win.copyImageAt(context.x, context.y);
 }
 
@@ -255,9 +254,9 @@ export function learnSpelling(context: ContextInfo, win: any) {
   win.session.addWordToSpellCheckerDictionary(context.misspelledWord);
 }
 
-export async function inspect(context: ContextInfo, win: any) {
+export function inspect(context: ContextInfo, win: any) {
   win.inspectElement(context.x, context.y);
-  if (await win.isDevToolsOpened()) {
+  if (win.isDevToolsOpened()) {
     win.devToolsWebContents.focus();
   }
 }

--- a/app/frontend/Shared/ContextMenu.ts
+++ b/app/frontend/Shared/ContextMenu.ts
@@ -64,6 +64,7 @@ export async function buildContextMenu(context: ContextInfo, webview: any): Prom
     } */
   }
   if (context.mediaType == "image") {
+    add("copyImage", gt`Copy image`, null, copyImage);
     add("copyImageURL", gt`Copy image address`, null, copyImageURL);
     add("saveImage", gt`Save image`, null, saveImage);
     add("saveImageAs", gt`Save image as…`, null, saveImageAs);

--- a/app/frontend/Shared/ContextMenu.ts
+++ b/app/frontend/Shared/ContextMenu.ts
@@ -29,9 +29,11 @@ import { appGlobal } from "../../logic/app";
  * });
  * ```
  */
-export function buildContextMenu(context: ContextInfo, win: any): ArrayColl<MenuItem> {
+export async function buildContextMenu(context: ContextInfo, webview: any): Promise<ArrayColl<MenuItem>> {
   context.isText = context.selectionText?.length > 0;
   context.isLink = !!context.linkURL;
+
+  const win = await appGlobal.remoteApp.getWebContents(webview.getWebContentsId());
 
   let menuItems = new ArrayColl<MenuItem>();
   function add(id: string, label, icon: string, action: Function, disabled: boolean = false) {
@@ -252,9 +254,9 @@ export function learnSpelling(context: ContextInfo, win: any) {
   win.session.addWordToSpellCheckerDictionary(context.misspelledWord);
 }
 
-export function inspect(context: ContextInfo, win: any) {
+export async function inspect(context: ContextInfo, win: any) {
   win.inspectElement(context.x, context.y);
-  if (win.isDevToolsOpened()) {
+  if (await win.isDevToolsOpened()) {
     win.devToolsWebContents.focus();
   }
 }

--- a/app/frontend/Shared/WebView.svelte
+++ b/app/frontend/Shared/WebView.svelte
@@ -136,7 +136,7 @@
 
   let contextMenuItems: ArrayColl<MenuItem>;
   async function onContextMenu(contextInfo: ContextInfo) {
-    contextMenuItems = buildContextMenu(contextInfo, webviewE);
+    contextMenuItems = await buildContextMenu(contextInfo, webviewE);
     console.log("Context menu items:", contextMenuItems.contents.map(i => i.id).join(", "), contextMenuItems.contents);
     await appGlobal.remoteApp.openMenu(contextMenuItems.contents.map(item => ({
       id: item.id,

--- a/backend/WebContents.ts
+++ b/backend/WebContents.ts
@@ -1,0 +1,54 @@
+/**
+ * Delegator object
+ * This is for security purposes only because `win.session.setPreloads()`
+ * sets the preload script which is dangerous and `win.session.loadExtensions()`
+ * loads extensions which could load also malicious extensions. There maybe other
+ * methods that may also be dangerous so it's best to just expose the necessary ones.
+ * 
+ * Preferably, only the methods that appear in <webview> should be exposed
+ * because Electron likely exposes only those because they are safe for the renderer
+ * process.
+ * 
+ * - https://www.electronjs.org/docs/latest/api/webview-tag
+ * - https://www.electronjs.org/docs/latest/api/session#sessetpreloadspreloads
+ * - https://www.electronjs.org/docs/latest/api/session#sesloadextensionpath-options
+ */
+export class WebContents {
+  private _win: Electron.WebContents;
+
+  constructor(win: Electron.WebContents) {
+    this._win = win;
+  }
+
+  copy() {
+    this._win.copy();
+  }
+
+  cut() {
+    this._win.cut();
+  }
+
+  paste() {
+    this._win.paste();
+  }
+
+  selectAll() {
+    this._win.selectAll();
+  }
+
+  copyImageAt(x: number, y: number ) {
+    this._win.copyImageAt(x, y);
+  }
+
+  showDefinitionForSelection() {
+    this._win.showDefinitionForSelection();
+  }
+
+  inspectElement(x: number, y: number) {
+    this._win.inspectElement(x, y);
+  }
+  
+  isDevToolsOpened() {
+    return this._win.isDevToolsOpened();
+  }
+}

--- a/backend/backend.ts
+++ b/backend/backend.ts
@@ -342,6 +342,21 @@ function addEventListenerWebContents(webContentsID: number, webviewEvent: string
   });
 }
 
+/**
+ * Delegator object
+ * This is for security purposes only because `win.session.setPreloads()`
+ * sets the preload script which is dangerous and `win.session.loadExtensions()`
+ * loads extensions which could load also malicious extensions. There maybe other
+ * methods that may also be dangerous so it's best to just expose the necessary ones.
+ * 
+ * Preferably, only the methods that appear in <webview> should be exposed
+ * because Electron likely exposes only those because they are safe for the renderer
+ * process.
+ * 
+ * - https://www.electronjs.org/docs/latest/api/webview-tag
+ * - https://www.electronjs.org/docs/latest/api/session#sessetpreloadspreloads
+ * - https://www.electronjs.org/docs/latest/api/session#sesloadextensionpath-options
+ */
 class WebContents {
   private _win: Electron.WebContents;
 

--- a/backend/backend.ts
+++ b/backend/backend.ts
@@ -45,6 +45,7 @@ async function createSharedAppObject() {
     minimizeMainWindow,
     unminimizeMainWindow,
     addEventListenerWebContents,
+    getWebContents,
     shell,
     restartApp,
     setTheme,
@@ -339,6 +340,45 @@ function addEventListenerWebContents(webContentsID: number, webviewEvent: string
   win.on(webviewEvent as any, (_: any, event: Event) => {
     eventHandler(event);
   });
+}
+
+class WebContents {
+  private _win: Electron.WebContents;
+
+  constructor(win: Electron.WebContents) {
+    this._win = win;
+  }
+
+  copy() {
+    this._win.copy();
+  }
+  cut() {
+    this._win.cut();
+  }
+  paste() {
+    this._win.paste();
+  }
+  selectAll() {
+    this._win.selectAll();
+  }
+  copyImageAt(x: number, y: number ) {
+    this._win.copyImageAt(x, y);
+  }
+  showDefinitionForSelection() {
+    this._win.showDefinitionForSelection();
+  }
+  inspectElement(x: number, y: number) {
+    this._win.inspectElement(x, y);
+  }
+  isDevToolsOpened() {
+    return this._win.isDevToolsOpened();
+  }
+}
+
+function getWebContents(webContentsID: number) {
+  const win = webContents.fromId(webContentsID);
+  assert(win, `WebContents ID ${webContentsID} not found`);
+  return new WebContents(win);
 }
 
 function setBadgeCount(count: number) {

--- a/backend/backend.ts
+++ b/backend/backend.ts
@@ -2,6 +2,7 @@ import { HTTPServer } from './HTTPServer';
 import JPCWebSocket from '../lib/jpc-ws';
 import * as OWA from './owa';
 import { appName, production } from '../app/logic/build';
+import { WebContents } from './WebContents';
 import { ImapFlow } from 'imapflow';
 import { Database } from "@radically-straightforward/sqlite"; // formerly @leafac/sqlite
 import Zip from "adm-zip";
@@ -340,54 +341,6 @@ function addEventListenerWebContents(webContentsID: number, webviewEvent: string
   win.on(webviewEvent as any, (_: any, event: Event) => {
     eventHandler(event);
   });
-}
-
-/**
- * Delegator object
- * This is for security purposes only because `win.session.setPreloads()`
- * sets the preload script which is dangerous and `win.session.loadExtensions()`
- * loads extensions which could load also malicious extensions. There maybe other
- * methods that may also be dangerous so it's best to just expose the necessary ones.
- * 
- * Preferably, only the methods that appear in <webview> should be exposed
- * because Electron likely exposes only those because they are safe for the renderer
- * process.
- * 
- * - https://www.electronjs.org/docs/latest/api/webview-tag
- * - https://www.electronjs.org/docs/latest/api/session#sessetpreloadspreloads
- * - https://www.electronjs.org/docs/latest/api/session#sesloadextensionpath-options
- */
-class WebContents {
-  private _win: Electron.WebContents;
-
-  constructor(win: Electron.WebContents) {
-    this._win = win;
-  }
-
-  copy() {
-    this._win.copy();
-  }
-  cut() {
-    this._win.cut();
-  }
-  paste() {
-    this._win.paste();
-  }
-  selectAll() {
-    this._win.selectAll();
-  }
-  copyImageAt(x: number, y: number ) {
-    this._win.copyImageAt(x, y);
-  }
-  showDefinitionForSelection() {
-    this._win.showDefinitionForSelection();
-  }
-  inspectElement(x: number, y: number) {
-    this._win.inspectElement(x, y);
-  }
-  isDevToolsOpened() {
-    return this._win.isDevToolsOpened();
-  }
 }
 
 function getWebContents(webContentsID: number) {


### PR DESCRIPTION
- We need access to some WebContents in the frontend for some of the context menu actions e.g. `copyImageAt()`
- The change wraps the original WebContents so only the necessary methods are exposed but this is only possible for some of the methods e.g. `win.session.addWordToSpellCheckerDictionary()` is not possible since we'll have to expose the entire `win.session`
- Exposing `win.session` maybe dangerous since there's a methods called `ses.setPreloads(preloads)` which runs node-level scripts