### PR TITLE
Don't always switch back to dual view

### DIFF
--- a/app/frontend/Calendar/CalendarApp.svelte
+++ b/app/frontend/Calendar/CalendarApp.svelte
@@ -1,8 +1,8 @@
 <vbox flex class="calendar-app">
   <vbox flex class="main">
-    <MainView {events} bind:start={$selectedDate} {dateInterval}>
+    <MainView {events} bind:start={$selectedDate} dateInterval={$selectedDateInterval}>
       <TitleBarLeft on:addEvent={() => catchErrors(addEvent)} slot="top-left" />
-      <ViewSelector bind:dateInterval slot="top-right" />
+      <ViewSelector bind:dateInterval={$selectedDateInterval} slot="top-right" />
     </MainView>
   </vbox>
 </vbox>
@@ -20,7 +20,6 @@
   import { mergeColls } from "svelte-collections";
   import { t } from "../../l10n/l10n";
 
-  $: dateInterval = $selectedDateInterval;
   $: events = mergeColls(appGlobal.calendars.map(cal => cal.fillRecurrences(new Date(Date.now() + 1e11)))).sortBy(ev => ev.startTime);
   $: if (!$selectedCalendar) { $selectedCalendar = appGlobal.calendars.first; }
 


### PR DESCRIPTION
Currently the calendar always switches to dual view after viewing or editing an event or switching to another app and back. This seems unintentional, particularly after viewing an event. This makes the selected view persists throughout the session.