### PR TITLE
Week views should not scroll to clicked date

### DIFF
--- a/app/frontend/Calendar/CalendarApp.svelte
+++ b/app/frontend/Calendar/CalendarApp.svelte
@@ -1,6 +1,6 @@
 <vbox flex class="calendar-app">
   <vbox flex class="main">
-    <MainView {events} bind:start={$selectedDate} {dateInterval}>
+    <MainView {events} bind:start={$startDate} {dateInterval}>
       <TitleBarLeft on:addEvent={() => catchErrors(addEvent)} slot="top-left" />
       <ViewSelector bind:dateInterval slot="top-right" />
     </MainView>
@@ -9,7 +9,7 @@
 
 <script lang="ts">
   import { Event } from "../../logic/Calendar/Event";
-  import { selectedCalendar, selectedDate, selectedDateInterval } from "./selected";
+  import { selectedCalendar, selectedDate, selectedDateInterval, startDate } from "./selected";
   import { calendarMustangApp } from "./CalendarMustangApp";
   import { appGlobal } from "../../logic/app";
   import MainView from "./MainView.svelte";

--- a/app/frontend/Calendar/DualView.svelte
+++ b/app/frontend/Calendar/DualView.svelte
@@ -1,8 +1,8 @@
 <hbox flex class="dual-view">
-  <WeekView bind:start {events} showDays={2}>
+  <WeekView bind:start={$selectedDate} {events} showDays={2}>
     <slot name="top-left" slot="top-left" />
   </WeekView>
-  <MonthView start={monthStart} {events} showDays={35}>
+  <MonthView {start} {events} showDays={35}>
     <slot name="top-right" slot="top-right" />
   </MonthView>
 </hbox>
@@ -12,16 +12,10 @@
   import type { Collection } from "svelte-collections";
   import WeekView from "./WeekView.svelte";
   import MonthView from "./MonthView.svelte";
+  import { selectedDate } from "./selected";
 
   export let start: Date;
   export let events: Collection<Event>;
-
-  let monthStart: Date;
-
-  $: start, syncMonth();
-  function syncMonth() {
-    monthStart = start;
-  }
 </script>
 
 <style>

--- a/app/frontend/Calendar/selected.ts
+++ b/app/frontend/Calendar/selected.ts
@@ -5,9 +5,8 @@ import { writable, type Writable } from "svelte/store";
 /** Which event is highlighted right now. */
 export let selectedEvent: Writable<Event> = writable(null);
 
-// TODO Move into observable prefs?
-export let startDate = writable(new Date());
 export let selectedDate = writable(new Date());
 export type DateInterval = 0 | 1 | 2 | 7 | 31 | 28;
 export let selectedDateInterval = writable(2 as DateInterval);
+export let startDate = writable(new Date());
 export let selectedCalendar = writable<Calendar | null>(null);

--- a/app/frontend/Calendar/selected.ts
+++ b/app/frontend/Calendar/selected.ts
@@ -6,6 +6,7 @@ import { writable, type Writable } from "svelte/store";
 export let selectedEvent: Writable<Event> = writable(null);
 
 // TODO Move into observable prefs?
+export let startDate = writable(new Date());
 export let selectedDate = writable(new Date());
 export type DateInterval = 0 | 1 | 2 | 7 | 31 | 28;
 export let selectedDateInterval = writable(2 as DateInterval);


### PR DESCRIPTION
When clicking on a day in the week or four week view, the view will scroll, sometimes unhelpfully actually past the clicked date. This fixes this by separating the date viewed from the date clicked. (This ends up simplifying the dual view slightly.)