### PR TITLE
Responses should be based on ResponseType, not Scheduling

### DIFF
--- a/app/frontend/Calendar/EditEvent/EditEvent.svelte
+++ b/app/frontend/Calendar/EditEvent/EditEvent.svelte
@@ -147,7 +147,7 @@
   import type { Event } from "../../../logic/Calendar/Event";
   import { Frequency, RecurrenceRule, type RecurrenceInit } from "../../../logic/Calendar/RecurrenceRule";
   import { EventEditMustangApp, calendarMustangApp } from "../CalendarMustangApp";
-  import { Scheduling, ResponseType, type Responses } from "../../../logic/Calendar/Invitation";
+  import { ResponseType, type Responses } from "../../../logic/Calendar/Invitation";
   import PersonsAutocomplete from "../../Shared/PersonAutocomplete/PersonsAutocomplete.svelte";
   import PersonAvailability from "./PersonAvailability.svelte";
   import DateInput from "./DateInput.svelte";
@@ -323,13 +323,13 @@
     event.respondToInvitation(response).catch(backgroundError);
   }
   function onAccept() {
-    respond(Scheduling.Accepted);
+    respond(ResponseType.Accept);
   }
   function onTentative() {
-    respond(Scheduling.Tentative);
+    respond(ResponseType.Tentative);
   }
   function onDecline() {
-    respond(Scheduling.Declined);
+    respond(ResponseType.Decline);
   }
 
   function onClose() {

--- a/app/frontend/Calendar/Invitation.svelte
+++ b/app/frontend/Calendar/Invitation.svelte
@@ -25,7 +25,7 @@
 
 <script lang="ts">
   import type { EMail } from "../../logic/Mail/EMail";
-  import { Scheduling, type Responses } from "../../logic/Calendar/Invitation";
+  import { Scheduling, ResponseType, type Responses } from "../../logic/Calendar/Invitation";
   import DisplayEvent from "./DisplayEvent.svelte";
   import Button from "../Shared/Button.svelte";
   import { t } from "../../l10n/l10n";
@@ -36,13 +36,13 @@
     await message.respondToInvitation(response);
   }
   async function onAccept() {
-    await respond(Scheduling.Accepted);
+    await respond(ResponseType.Accept);
   }
   async function onTentative() {
-    await respond(Scheduling.Tentative);
+    await respond(ResponseType.Tentative);
   }
   async function onDecline() {
-    await respond(Scheduling.Declined);
+    await respond(ResponseType.Decline);
   }
 </script>
 

--- a/app/logic/Calendar/ActiveSync/ActiveSyncEvent.ts
+++ b/app/logic/Calendar/ActiveSync/ActiveSyncEvent.ts
@@ -1,5 +1,5 @@
 import { Event } from "../Event";
-import { Scheduling, ResponseType, type Responses } from "../Invitation";
+import { ResponseType, type Responses } from "../Invitation";
 import { Frequency, Weekday, RecurrenceRule } from "../RecurrenceRule";
 import type { ActiveSyncCalendar } from "./ActiveSyncCalendar";
 import WindowsTimezones from "../EWS/WindowsTimezones";
@@ -13,9 +13,9 @@ const kRequiredAttendee = "1";
 const kRecurrenceTypes = [Frequency.Daily, Frequency.Weekly, Frequency.Monthly, Frequency.Monthly, /* don't know why Microsoft left this one out */, Frequency.Yearly, Frequency.Yearly];
 
 const ActiveSyncResponse: Record<Responses, number> = {
-  [Scheduling.Accepted]: 1,
-  [Scheduling.Tentative]: 2,
-  [Scheduling.Declined]: 3,
+  [ResponseType.Accept]: 1,
+  [ResponseType.Tentative]: 2,
+  [ResponseType.Decline]: 3,
 };
 
 export class ActiveSyncEvent extends Event {

--- a/app/logic/Calendar/EWS/EWSEvent.ts
+++ b/app/logic/Calendar/EWS/EWSEvent.ts
@@ -1,5 +1,5 @@
 import { Event } from "../Event";
-import { Scheduling, ResponseType, type Responses } from "../Invitation";
+import { ResponseType, type Responses } from "../Invitation";
 import { Frequency, Weekday, RecurrenceRule } from "../RecurrenceRule";
 import type { EWSCalendar } from "./EWSCalendar";
 import WindowsTimezones from "./WindowsTimezones";
@@ -12,9 +12,9 @@ import { assert, ensureArray } from "../../util/util";
 import type { ArrayColl } from "svelte-collections";
 
 const ResponseTypes: Record<Responses, string> = {
-  [Scheduling.Accepted]: "AcceptItem",
-  [Scheduling.Tentative]: "TentativelyAcceptItem",
-  [Scheduling.Declined]: "DeclineItem",
+  [ResponseType.Accept]: "AcceptItem",
+  [ResponseType.Tentative]: "TentativelyAcceptItem",
+  [ResponseType.Decline]: "DeclineItem",
 };
 
 enum WeekOfMonth {

--- a/app/logic/Calendar/Invitation.ts
+++ b/app/logic/Calendar/Invitation.ts
@@ -12,9 +12,6 @@ export enum Scheduling {
   Cancellation = 5,
 }
 
-/** Just the values used by meeting responses. */
-export type Responses = Scheduling.Accepted | Scheduling.Tentative | Scheduling.Declined;
-
 /* Note: These are EWS/OWA names and ActiveSync values. */
 export enum ResponseType {
   Unknown = 0,
@@ -24,3 +21,6 @@ export enum ResponseType {
   Decline = 4,
   NoResponseReceived = 5,
 }
+
+/** Just the values used by meeting responses. */
+export type Responses = ResponseType.Accept | ResponseType.Tentative | ResponseType.Decline;

--- a/app/logic/Calendar/OWA/OWAEvent.ts
+++ b/app/logic/Calendar/OWA/OWAEvent.ts
@@ -1,5 +1,5 @@
 import { Event } from "../Event";
-import { Scheduling, ResponseType, type Responses } from "../Invitation";
+import { ResponseType, type Responses } from "../Invitation";
 import { Frequency, Weekday, RecurrenceRule } from "../RecurrenceRule";
 import type { OWACalendar } from "./OWACalendar";
 import WindowsTimezones from "../EWS/WindowsTimezones";
@@ -12,9 +12,9 @@ import { sanitize } from "../../../../lib/util/sanitizeDatatypes";
 import { assert } from "../../util/util";
 
 const ResponseTypes: Record<Responses, string> = {
-  [Scheduling.Accepted]: "AcceptItem",
-  [Scheduling.Tentative]: "TentativelyAcceptItem",
-  [Scheduling.Declined]: "DeclineItem",
+  [ResponseType.Accept]: "AcceptItem",
+  [ResponseType.Tentative]: "TentativelyAcceptItem",
+  [ResponseType.Decline]: "DeclineItem",
 };
 
 const gTimeZone = WindowsTimezones[Intl.DateTimeFormat().resolvedOptions().timeZone] || "UTC";

--- a/app/logic/Mail/ActiveSync/ActiveSyncEMail.ts
+++ b/app/logic/Mail/ActiveSync/ActiveSyncEMail.ts
@@ -4,7 +4,7 @@ import { ActiveSyncError } from "./ActiveSyncError";
 import { ActiveSyncEvent } from "../../Calendar/ActiveSync/ActiveSyncEvent";
 import { type Tag, getTagByName } from "../Tag";
 import { PersonUID, findOrCreatePersonUID } from "../../Abstract/PersonUID";
-import { Scheduling, type Responses } from "../../Calendar/Invitation";
+import { Scheduling, ResponseType, type Responses } from "../../Calendar/Invitation";
 import { ensureArray, assert, NotSupported } from "../../util/util";
 import { appGlobal } from "../../app";
 import { sanitize } from "../../../../lib/util/sanitizeDatatypes";
@@ -20,9 +20,9 @@ const ExchangeScheduling: Record<string, number> = {
 };
 
 const ActiveSyncResponse: Record<Responses, number> = {
-  [Scheduling.Accepted]: 1,
-  [Scheduling.Tentative]: 2,
-  [Scheduling.Declined]: 3,
+  [ResponseType.Accept]: 1,
+  [ResponseType.Tentative]: 2,
+  [ResponseType.Decline]: 3,
 };
 
 export class ActiveSyncEMail extends EMail {

--- a/app/logic/Mail/EWS/EWSEMail.ts
+++ b/app/logic/Mail/EWS/EWSEMail.ts
@@ -7,7 +7,7 @@ import EWSCreateItemRequest from "./EWSCreateItemRequest";
 import EWSDeleteItemRequest from "./EWSDeleteItemRequest";
 import EWSUpdateItemRequest from "./EWSUpdateItemRequest";
 import { PersonUID, findOrCreatePersonUID } from "../../Abstract/PersonUID";
-import { Scheduling, type Responses } from "../../Calendar/Invitation";
+import { Scheduling, ResponseType, type Responses } from "../../Calendar/Invitation";
 import { appGlobal } from "../../app";
 import { sanitize } from "../../../../lib/util/sanitizeDatatypes";
 import { base64ToArrayBuffer, assert, ensureArray } from "../../util/util";
@@ -22,9 +22,9 @@ const ExchangeScheduling: Record<string, number> = {
 };
 
 const ResponseTypes: Record<Responses, string> = {
-  [Scheduling.Accepted]: "AcceptItem",
-  [Scheduling.Tentative]: "TentativelyAcceptItem",
-  [Scheduling.Declined]: "DeclineItem",
+  [ResponseType.Accept]: "AcceptItem",
+  [ResponseType.Tentative]: "TentativelyAcceptItem",
+  [ResponseType.Decline]: "DeclineItem",
 };
 
 export class EWSEMail extends EMail {

--- a/app/logic/Mail/OWA/OWAEMail.ts
+++ b/app/logic/Mail/OWA/OWAEMail.ts
@@ -6,7 +6,7 @@ import OWACreateItemRequest from "./OWACreateItemRequest";
 import OWADeleteItemRequest from "./OWADeleteItemRequest";
 import OWAUpdateItemRequest from "./OWAUpdateItemRequest";
 import { PersonUID, findOrCreatePersonUID } from "../../Abstract/PersonUID";
-import { Scheduling, type Responses } from "../../Calendar/Invitation";
+import { Scheduling, ResponseType, type Responses } from "../../Calendar/Invitation";
 import { appGlobal } from "../../app";
 import { base64ToArrayBuffer, assert } from "../../util/util";
 import { sanitize } from "../../../../lib/util/sanitizeDatatypes";
@@ -21,9 +21,9 @@ const ExchangeScheduling: Record<string, number> = {
 };
 
 const ResponseTypes: Record<Responses, string> = {
-  [Scheduling.Accepted]: "AcceptItem",
-  [Scheduling.Tentative]: "TentativelyAcceptItem",
-  [Scheduling.Declined]: "DeclineItem",
+  [ResponseType.Accept]: "AcceptItem",
+  [ResponseType.Tentative]: "TentativelyAcceptItem",
+  [ResponseType.Decline]: "DeclineItem",
 };
 
 export class OWAEMail extends EMail {


### PR DESCRIPTION
This will allow them to be used for participant response status.