### PR TITLE
Make ICS processor run

### DIFF
--- a/app/logic/Calendar/ICSProcessor.ts
+++ b/app/logic/Calendar/ICSProcessor.ts
@@ -9,7 +9,7 @@ import PostalMime from "postal-mime";
 import ical from "node-ical";
 
 export class ICSProcessor extends EMailProcessor {
-  runOn: ProcessingStartOn.Parse;
+  runOn = ProcessingStartOn.Parse;
   process(email: EMail, postalMIME: any) {
     if (email.event && !postalMIME.textContent?.calendar) {
       return;


### PR DESCRIPTION
Unfortunately the old code is valid TypeScript; all it does is declare that `runOn` will always have the value `1`, without actually setting it...