### PR TITLE
Webview: Context Menu: Copy link and *URLs (#110)

### DIFF
--- a/app/frontend/Shared/ContextMenu.ts
+++ b/app/frontend/Shared/ContextMenu.ts
@@ -223,8 +223,8 @@ export function saveVideoAs(context: ContextInfo, win: any) {
   download(context.srcURL, win, true);
 }
 
-export function copyLink(context: ContextInfo, win: any) {
-  copyToClipboard(context.linkURL);
+export async function copyLink(context: ContextInfo, win: any) {
+  await copyToClipboard(context.linkURL);
   /* or:
   copyToClipboard({
     bookmark: context.linkText,
@@ -242,12 +242,12 @@ export async function copyImage(context: ContextInfo, win: any) {
   win.copyImageAt(context.x, context.y);
 }
 
-export function copyImageURL(context: ContextInfo, win: any) {
-  copyToClipboard(context.srcURL);
+export async function copyImageURL(context: ContextInfo, win: any) {
+  await copyToClipboard(context.srcURL);
 }
 
-export function copyVideoURL(context: ContextInfo, win: any) {
-  copyToClipboard(context.srcURL);
+export async function copyVideoURL(context: ContextInfo, win: any) {
+  await copyToClipboard(context.srcURL);
 }
 
 export function learnSpelling(context: ContextInfo, win: any) {
@@ -261,9 +261,9 @@ export function inspect(context: ContextInfo, win: any) {
   }
 }
 
-export function copyToClipboard(text: string | Object) {
+export async function copyToClipboard(text: string | Object) {
   if (typeof (text) == "string") {
-    navigator.clipboard.writeText(text);
+    await appGlobal.remoteApp.writeTextToClipboard(text);
   } else {
     throw new NotImplemented();
   }

--- a/backend/backend.ts
+++ b/backend/backend.ts
@@ -7,7 +7,7 @@ import { ImapFlow } from 'imapflow';
 import { Database } from "@radically-straightforward/sqlite"; // formerly @leafac/sqlite
 import Zip from "adm-zip";
 import ky from 'ky';
-import { shell, nativeTheme, Notification, Tray, nativeImage, app, BrowserWindow, webContents, Menu, MenuItemConstructorOptions } from "electron";
+import { shell, nativeTheme, Notification, Tray, nativeImage, app, BrowserWindow, webContents, Menu, MenuItemConstructorOptions, clipboard } from "electron";
 import nodemailer from 'nodemailer';
 import MailComposer from 'nodemailer/lib/mail-composer';
 import { createType1Message, decodeType2Message, createType3Message } from "./ntlm";
@@ -47,6 +47,7 @@ async function createSharedAppObject() {
     unminimizeMainWindow,
     addEventListenerWebContents,
     getWebContents,
+    writeTextToClipboard,
     shell,
     restartApp,
     setTheme,
@@ -347,6 +348,15 @@ function getWebContents(webContentsID: number) {
   const win = webContents.fromId(webContentsID);
   assert(win, `WebContents ID ${webContentsID} not found`);
   return new WebContents(win);
+}
+
+/**
+ * Writes to system clipboard
+ * Don't expose reading the clipboard because the user may have sensitive data
+ * on their system clipboard e.g. passwords
+ */
+function writeTextToClipboard(text: string) {
+  clipboard.writeText(text);
 }
 
 function setBadgeCount(count: number) {


### PR DESCRIPTION
- There's this `Failed to execute 'writeText' on 'Clipboard': Document is not focused` error when using the `navigator.clipboard` so I decided to use the one provided by electron
- The `read()` functions aren't exposed in the renderer process because it poses a security threat where the some code could be used to check what is on the users system clipboard
- So far I haven't found any way to fix `Failed to execute 'writeText' on 'Clipboard': Document is not focused` error to avoid using this method