### PR TITLE
Fix empty MailZip files #391

### DIFF
--- a/app/test/logic/Mail/Store/MailZIP.test.ts
+++ b/app/test/logic/Mail/Store/MailZIP.test.ts
@@ -12,7 +12,7 @@ test("Create ZIP", async () => {
   let zip = await appGlobal.remoteApp.newAdmZIP(filename);
 
   // Test that the file exists
-  await fs.access(filename); // throws when it doesn't exist
+  await fs.rm(filename); // throws when it doesn't exist
 });
 
 test("Write email to ZIP", async () => {
@@ -26,13 +26,13 @@ test("Write email to ZIP", async () => {
   email.subject = "Info";
   email.sent = new Date();
   email.dbID = 1234;
-  email.mime = new TextEncoder().encode("Hello World");
+  email.mime = Buffer.from("Hello World");
 
   let zipper = new MailZIP();
   await zipper.save(email);
 
   let zip = await zipper.getFolderZIP(folder);
-  let filename = zipper.getEMailFilename(email);
+  let filename = await zipper.getFolderZIPFilePath(folder);
   await zipper.writeZip(zip, filename);
   // Now it should be written to disk
 
@@ -42,5 +42,6 @@ test("Write email to ZIP", async () => {
   let file = await zipFile.getEntry(zipper.getEMailFilename(email));
   let mime = await zipFile.readFile(file) as Uint8Array;
   // </copied>
-  expect(mime).toBe(email.mime);
+  expect(mime).toStrictEqual(email.mime);
+  await fs.rm(filename);
 });


### PR DESCRIPTION
Sorry if I'm stepping on someone else's toes here.

The actual problem was a missing `await`; see line 25 of `MailZIP.ts`.

However, this isn't enough to fix the test, as it has other problems:
- It's using the wrong filename to open the ZIP file (so the one it does open is still always empty)
- It's trying to compare a Buffer to a Uint8Array

Investigating the filename issue further, I noticed that `writeZip`'s `filename` is just for locking purposes... but `save` passes the wrong filename, so the locking doesn't actually work. I'm not convinced that locking on the filename is ideal; the other alternative is keying your lock and zip maps on the folder, which would at least avoid an extra call to `getFolderZIPFilePath`, but you might want to use `WeakMap`s if you do that.

While debugging I also confused myself at one point as the test was opening the file saved from the previous test. I've made the test clean up after itself, assuming it succeeds...

On a mostly unrelated note, is it worth using the `beforeAll` and `afterAll` functions to start and stop the backend automatically?