### PR TITLE
OWA: Properly create top level folder

### DIFF
--- a/app/logic/Mail/ActiveSync/ActiveSyncAccount.ts
+++ b/app/logic/Mail/ActiveSync/ActiveSyncAccount.ts
@@ -547,7 +547,7 @@ export class ActiveSyncAccount extends MailAccount {
 
   async createToplevelFolder(name: string): Promise<ActiveSyncFolder> {
     let request = {
-      ParentId: null,
+      ParentId: "0",
       DisplayName: name,
       Type: "1",
     };

--- a/app/logic/Mail/OWA/OWAAccount.ts
+++ b/app/logic/Mail/OWA/OWAAccount.ts
@@ -284,19 +284,19 @@ export class OWAAccount extends MailAccount {
   async createToplevelFolder(name: string): Promise<OWAFolder> {
     let request = {
       __type: "CreateFolderJsonRequest:#Exchange",
-      ParentFolderId: {
-        __type: "TargetFolderId:#Exchange",
-        FolderId: {
-          __type: "FolderId:#Exchange",
-          Id: this.msgFolderRootID,
-        },
-      },
       Header: {
         __type: "JsonRequestHeaders:#Exchange",
         RequestServerVersion: "Exchange2013",
       },
       Body: {
         __type: "CreateFolderRequest:#Exchange",
+        ParentFolderId: {
+          __type: "TargetFolderId:#Exchange",
+          BaseFolderId: {
+            __type: "DistinguishedFolderId:#Exchange",
+            Id: "msgfolderroot",
+          },
+        },
         Folders: [{
           __type: "Folder:#Exchange",
           FolderClass: "IPF.Note",

--- a/app/logic/Mail/OWA/OWAFolder.ts
+++ b/app/logic/Mail/OWA/OWAFolder.ts
@@ -486,7 +486,7 @@ export class OWAFolder extends Folder {
         __type: "CreateFolderRequest:#Exchange",
         ParentFolderId: {
           __type: "TargetFolderId:#Exchange",
-          FolderId: {
+          BaseFolderId: {
             __type: "FolderId:#Exchange",
             Id: this.id,
           },


### PR DESCRIPTION
- Moved `ParentFolderId` to the correct place
- Switched back to `DistinguishedFolderId`
- Corrected to `BaseFolderId` both there and in the subfolder code
- Also fixed ActiveSync top-level folder creation