### PR TITLE
Simplify Scheduling values

### DIFF
--- a/app/frontend/Calendar/Invitation.svelte
+++ b/app/frontend/Calendar/Invitation.svelte
@@ -14,7 +14,7 @@
       {ex}
     {/await}
   {/if}
-  {#if message.scheduling == Scheduling.Request}
+  {#if message.scheduling == Scheduling.REQUEST}
     <hbox>
       <Button label={$t`Accept`} onClick={onAccept} />
       <Button label={$t`Tentative`} onClick={onTentative} />

--- a/app/logic/Calendar/ICSProcessor.ts
+++ b/app/logic/Calendar/ICSProcessor.ts
@@ -18,33 +18,12 @@ export class ICSProcessor extends EMailProcessor {
     if (!ics) {
       return;
     }
-    email.scheduling = iTIPMethod(ics);
+    email.scheduling = Scheduling[(ics.vcalendar as ical.VCalendar)?.method] || Scheduling.NONE;
     email.event = convertICSToEvent(ics);
     if (email.event && !email.event.descriptionHTML && email.html) {
       email.event.descriptionHTML = email.html;
     }
   }
-}
-
-/* Find the iTIP method from a parsed vcalendar part */
-function iTIPMethod(ics: any): Scheduling {
-  switch (ics.vcalendar.method) {
-  case "CANCEL":
-    return Scheduling.Cancellation;
-  case "REQUEST":
-    return Scheduling.Request;
-  case "REPLY":
-    let vevent = Object.values(ics).find((event: any) => event.type == "VEVENT") as any;
-    switch (vevent?.attendee?.params?.PARTSTAT) {
-    case "DECLINED":
-      return Scheduling.Declined;
-    case "TENTATIVE":
-      return Scheduling.Tentative;
-    case "ACCEPTED":
-      return Scheduling.Accepted;
-    }
-  }
-  return Scheduling.None;
 }
 
 function convertICSToEvent(ics: any): Event | null {

--- a/app/logic/Calendar/Invitation.ts
+++ b/app/logic/Calendar/Invitation.ts
@@ -1,15 +1,14 @@
 
 /**
  * For an inbox item that represents a scheduling message, the type of message:
- * Accepted/Tentative/Declined responses, invitations, or cancellations.
+ * invitations, responses or cancellations.
+ * XXX values are chosen for compatibility with existing messages.
  */
 export enum Scheduling {
-  None = 0,
-  Accepted = 1,
-  Tentative = 2,
-  Declined = 3,
-  Request = 4,
-  Cancellation = 5,
+  NONE = 0,
+  REQUEST = 4,
+  REPLY = 6,
+  CANCEL = 5,
 }
 
 /* Note: These are EWS/OWA names and ActiveSync values. */

--- a/app/logic/Mail/ActiveSync/ActiveSyncEMail.ts
+++ b/app/logic/Mail/ActiveSync/ActiveSyncEMail.ts
@@ -12,11 +12,11 @@ import type { ArrayColl } from "svelte-collections";
 import { parseOneAddress, parseAddressList, type ParsedMailbox } from "email-addresses";
 
 const ExchangeScheduling: Record<string, number> = {
-  "IPM.Schedule.Meeting.Resp.Pos": Scheduling.Accepted,
-  "IPM.Schedule.Meeting.Resp.Tent": Scheduling.Tentative,
-  "IPM.Schedule.Meeting.Resp.Neg": Scheduling.Declined,
-  "IPM.Schedule.Meeting.Request": Scheduling.Request,
-  "IPM.Schedule.Meeting.Canceled": Scheduling.Cancellation,
+  "IPM.Schedule.Meeting.Resp.Pos": Scheduling.REPLY,
+  "IPM.Schedule.Meeting.Resp.Tent": Scheduling.REPLY,
+  "IPM.Schedule.Meeting.Resp.Neg": Scheduling.REPLY,
+  "IPM.Schedule.Meeting.Request": Scheduling.REQUEST,
+  "IPM.Schedule.Meeting.Canceled": Scheduling.CANCEL,
 };
 
 const ActiveSyncResponse: Record<Responses, number> = {
@@ -71,7 +71,7 @@ export class ActiveSyncEMail extends EMail {
     setPersons(this.cc, wbxmljs.Cc);
     setPersons(this.bcc, wbxmljs.Bcc);
     this.contact = this.outgoing ? this.to.first : this.from;
-    this.scheduling = ExchangeScheduling[wbxmljs.MessageClass] || Scheduling.None;
+    this.scheduling = ExchangeScheduling[wbxmljs.MessageClass] || Scheduling.NONE;
     /* Can't use this data because the description is missing.
     if (wbxmljs.MeetingRequest) {
       let event = new ActiveSyncEvent();
@@ -182,7 +182,7 @@ export class ActiveSyncEMail extends EMail {
   }
 
   async respondToInvitation(response: Responses): Promise<void> {
-    assert(this.scheduling == Scheduling.Request, "Only invitations can be responded to");
+    assert(this.scheduling == Scheduling.REQUEST, "Only invitations can be responded to");
     let request = {
       Request: {
         UserResponse: ActiveSyncResponse[response],

--- a/app/logic/Mail/EMail.ts
+++ b/app/logic/Mail/EMail.ts
@@ -58,7 +58,7 @@ export class EMail extends Message {
   @notifyChangedProperty
   mime: Uint8Array | undefined;
   @notifyChangedProperty
-  scheduling: Scheduling = Scheduling.None;
+  scheduling: Scheduling = Scheduling.NONE;
   @notifyChangedProperty
   event: Event | null = null;
   folder: Folder;
@@ -194,7 +194,7 @@ export class EMail extends Message {
   }
 
   async respondToInvitation(response: Responses): Promise<void> {
-    assert(this.scheduling == Scheduling.Request, "Only invitations can be responded to");
+    assert(this.scheduling == Scheduling.REQUEST, "Only invitations can be responded to");
     throw new AbstractFunction();
   }
 

--- a/app/logic/Mail/OWA/OWAEMail.ts
+++ b/app/logic/Mail/OWA/OWAEMail.ts
@@ -13,11 +13,11 @@ import { sanitize } from "../../../../lib/util/sanitizeDatatypes";
 import type { ArrayColl } from "svelte-collections";
 
 const ExchangeScheduling: Record<string, number> = {
-  "IPM.Schedule.Meeting.Resp.Pos": Scheduling.Accepted,
-  "IPM.Schedule.Meeting.Resp.Tent": Scheduling.Tentative,
-  "IPM.Schedule.Meeting.Resp.Neg": Scheduling.Declined,
-  "IPM.Schedule.Meeting.Request": Scheduling.Request,
-  "IPM.Schedule.Meeting.Canceled": Scheduling.Cancellation,
+  "IPM.Schedule.Meeting.Resp.Pos": Scheduling.REPLY,
+  "IPM.Schedule.Meeting.Resp.Tent": Scheduling.REPLY,
+  "IPM.Schedule.Meeting.Resp.Neg": Scheduling.REPLY,
+  "IPM.Schedule.Meeting.Request": Scheduling.REQUEST,
+  "IPM.Schedule.Meeting.Canceled": Scheduling.CANCEL,
 };
 
 const ResponseTypes: Record<Responses, string> = {
@@ -91,7 +91,7 @@ export class OWAEMail extends EMail {
     setPersons(this.cc, json.CcRecipients);
     setPersons(this.bcc, json.BccRecipients);
     this.contact = this.outgoing ? this.to.first : this.from;
-    this.scheduling = ExchangeScheduling[json.ItemClass] || Scheduling.None;
+    this.scheduling = ExchangeScheduling[json.ItemClass] || Scheduling.NONE;
   }
 
   setFlags(json) {
@@ -169,7 +169,7 @@ export class OWAEMail extends EMail {
   }
 
   async respondToInvitation(response: Responses): Promise<void> {
-    assert(this.scheduling == Scheduling.Request, "Only invitations can be responded to");
+    assert(this.scheduling == Scheduling.REQUEST, "Only invitations can be responded to");
     let request = new OWACreateItemRequest({MessageDisposition: "SendAndSaveCopy"});
     request.addField(ResponseTypes[response], "ReferenceItemId", {
       __type: "ItemId:#Exchange",
@@ -186,7 +186,7 @@ export class OWAEMail extends EMail {
    * `EMail.loadEvent()` works for all iTIP messages.
    * By not overriding `loadEvent()` here, `EMail.loadEvent()` will be called. */
   async loadEvent_disabled() {
-    assert(this.scheduling == Scheduling.Request, "This is not an invitation");
+    assert(this.scheduling == Scheduling.REQUEST, "This is not an invitation");
     assert(!this.event, "Event has already been loaded");
     let request = {
       __type: "GetItemJsonRequest:#Exchange",

--- a/app/logic/Mail/SQL/createDatabase.ts
+++ b/app/logic/Mail/SQL/createDatabase.ts
@@ -67,11 +67,10 @@ export const mailDatabaseSchema = sql`
     -- RFC822 header Subject:
     "subject" TEXT not null,
     -- If not zero, then one of the following values:
-    -- 1 - Request - Either an update to or a new invitation
-    -- 2 - Cancellation - Organiser cancelled the event
-    -- 3 - Accepted - Attendee accepted the invitation
-    -- 4 - Tentative - Attendee acknowledged the invitation
-    -- 5 - Declined - Attendee declined the invitation
+    -- 4 - Request - Either an update to or a new invitation
+    -- 5 - Cancellation - Organiser cancelled the event
+    -- 6 - Response - Attendee accepted, acknowledged or declined the invitation
+    -- XXX values are chosen for compatibility with existing messages.
     "scheduling" INTEGER default 0,
     -- plaintext content of the email body. May be converted or post-processed.
     "plaintext" TEXT default null,


### PR DESCRIPTION
I originally provided five values because Exchange exposed them all but they're not needed.

The values are renamed so that they can be readily mapped from iMIP methods.

I used `6` for `REPLY` because in practice we only compare against `REQUEST` and `CANCEL`, but these can be changed if you must.