### PR TITLE
Fix broken sanitisation regex

### DIFF
--- a/lib/util/sanitizeDatatypes.ts
+++ b/lib/util/sanitizeDatatypes.ts
@@ -143,7 +143,7 @@ class Sanitize {
    * but there are many others. */
   filename(unchecked: string | null, fallback: string | null | Symbol = throwErrors): string {
     let filename = this.nonemptystring(unchecked, fallback);
-    filename = filename.replace(/[^\p{Letter}\p{Number}\.\-\_] /g, "").trim();
+    filename = filename.replace(/[^\p{Letter}\p{Number}\.\-_ ]/gu, "").trim();
     if (!filename) {
       return haveError("Filename cannot have punctuation and control characters", unchecked, fallback);
     }


### PR DESCRIPTION
You forgot the `u` flag, and also you probably meant to put the space inside the character class? As such, you're actually removing anything with a following space other than the characters `-.LN_bemprtu{}`.