### PR TITLE
ActiveSync: Remove stale folders after a full resync #420

### DIFF
--- a/app/logic/Mail/ActiveSync/ActiveSyncAccount.ts
+++ b/app/logic/Mail/ActiveSync/ActiveSyncAccount.ts
@@ -394,7 +394,7 @@ export class ActiveSyncAccount extends MailAccount {
     }
 
     let missingFolders = new ArrayColl<Folder>();
-    await this.queuedRequest("FolderSync", {}, async (response) => {
+    await this.queuedRequest("FolderSync", {}, async response => {
       if (response.errorCode == kFolderSyncKeyError) {
         missingFolders = this.getAllFolders();
       }


### PR DESCRIPTION
Normally we automatically sync folder deletions from the server but if a full resync is triggered for some reason then we need to clean up any stale folders.