### PR TITLE
ActiveSync: React to hierarchy change ping status

### DIFF
--- a/app/logic/Mail/ActiveSync/ActiveSyncAccount.ts
+++ b/app/logic/Mail/ActiveSync/ActiveSyncAccount.ts
@@ -529,6 +529,9 @@ export class ActiveSyncAccount extends MailAccount {
           this.maxPings = sanitize.integer(response.MaxFolders);
           this.trimPings();
           continue;
+        case "7":
+          await this.listFolders();
+          continue;
         default:
           throw new ActiveSyncError("Ping", response.Status, this);
         }


### PR DESCRIPTION
This obviously helps in the case of a simultaneous client making a hierarchy change, but could also help in the case where we are the client making the change (although I would still probably want to keep our explicit `listFolders` calls).