### PR TITLE
EWS, OWA: Fix for when folders are moved on other clients

### DIFF
--- a/app/logic/Mail/EWS/EWSAccount.ts
+++ b/app/logic/Mail/EWS/EWSAccount.ts
@@ -519,7 +519,8 @@ export class EWSAccount extends MailAccount {
         let parentFolders = parent ? parent.subFolders : this.rootFolders;
         let ewsFolder = parentFolders.find(ewsFolder => ewsFolder.id == folder.FolderId.Id) as EWSFolder;
         if (!ewsFolder) {
-          ewsFolder = this.findFolder(ewsFolder => ewsFolder.id == folder.FolderId.Id) as EWSFolder || this.newFolder();
+          ewsFolder = this.findFolder(ewsFolder => ewsFolder.id == folder.FolderId.Id) as EWSFolder
+            ?? this.newFolder();
           let oldParentFolders = ewsFolder.parent?.subFolders || this.rootFolders;
           oldParentFolders.remove(ewsFolder);
           ewsFolder.parent = parent || null;

--- a/app/logic/Mail/EWS/EWSAccount.ts
+++ b/app/logic/Mail/EWS/EWSAccount.ts
@@ -519,7 +519,9 @@ export class EWSAccount extends MailAccount {
         let parentFolders = parent ? parent.subFolders : this.rootFolders;
         let ewsFolder = parentFolders.find(ewsFolder => ewsFolder.id == folder.FolderId.Id) as EWSFolder;
         if (!ewsFolder) {
-          ewsFolder = this.newFolder();
+          ewsFolder = this.findFolder(ewsFolder => ewsFolder.id == folder.FolderId.Id) as EWSFolder || this.newFolder();
+          let oldParentFolders = ewsFolder.parent?.subFolders || this.rootFolders;
+          oldParentFolders.remove(ewsFolder);
           ewsFolder.parent = parent || null;
           parentFolders.push(ewsFolder);
         }

--- a/app/logic/Mail/OWA/OWAAccount.ts
+++ b/app/logic/Mail/OWA/OWAAccount.ts
@@ -250,7 +250,9 @@ export class OWAAccount extends MailAccount {
         let parentFolders = parent ? parent.subFolders : this.rootFolders;
         let owaFolder = parentFolders.find(owaFolder => owaFolder.id == folder.FolderId.Id) as OWAFolder;
         if (!owaFolder) {
-          owaFolder = this.newFolder();
+          owaFolder = this.findFolder(owaFolder => owaFolder.id == folder.FolderId.Id) as EWSFolder || this.newFolder();
+          let oldParentFolders = owaFolder.parent?.subFolders || this.rootFolders;
+          oldParentFolders.remove(owaFolder);
           owaFolder.parent = parent || null;
           parentFolders.push(owaFolder);
         }

--- a/app/logic/Mail/OWA/OWAAccount.ts
+++ b/app/logic/Mail/OWA/OWAAccount.ts
@@ -250,7 +250,8 @@ export class OWAAccount extends MailAccount {
         let parentFolders = parent ? parent.subFolders : this.rootFolders;
         let owaFolder = parentFolders.find(owaFolder => owaFolder.id == folder.FolderId.Id) as OWAFolder;
         if (!owaFolder) {
-          owaFolder = this.findFolder(owaFolder => owaFolder.id == folder.FolderId.Id) as EWSFolder || this.newFolder();
+          owaFolder = this.findFolder(owaFolder => owaFolder.id == folder.FolderId.Id) as EWSFolder
+            ?? this.newFolder();
           let oldParentFolders = owaFolder.parent?.subFolders || this.rootFolders;
           oldParentFolders.remove(owaFolder);
           owaFolder.parent = parent || null;


### PR DESCRIPTION
Ben's changes in PR #421 broke moving folders. Rather than removing those changes, I now detect the move properly so that we can remember which messages were in the folder.