### PR TITLE
Fix type error after #419 #376

### DIFF
--- a/app/logic/Mail/OWA/OWACreateItemRequest.ts
+++ b/app/logic/Mail/OWA/OWACreateItemRequest.ts
@@ -9,7 +9,7 @@ export default class OWACreateItemRequest {
     Items: [{}],
   };
 
-  constructor(attributes?: {[key: string]: string | boolean}) {
+  constructor(attributes?: {[key: string]: string | boolean | object}) {
     Object.assign(this.Body, attributes);
   }
 


### PR DESCRIPTION
This is a port of the change to `EWSCreateItemRequest.ts` in PR #388.

I managed to temporarily switch my TypeScript to 5.4.5 so that it started working again and it picked up this type error.