### PR TITLE
EWS, OWA: Custom sent folder

### DIFF
--- a/app/logic/Mail/EWS/EWSAccount.ts
+++ b/app/logic/Mail/EWS/EWSAccount.ts
@@ -1,5 +1,6 @@
 import { AuthMethod, MailAccount, TLSSocketType } from "../MailAccount";
 import type { EMail } from "../EMail";
+import { SpecialFolder } from "../Folder";
 import { EWSFolder } from "./EWSFolder";
 import EWSCreateItemRequest from "./EWSCreateItemRequest";
 import type EWSDeleteItemRequest from "./EWSDeleteItemRequest";
@@ -91,7 +92,10 @@ export class EWSAccount extends MailAccount {
   }
 
   async send(email: EMail): Promise<void> {
-    assert(email.folder.id, "Bad Sent folder");
+    if (email.folder?.account != this) {
+      // Bad sent folder. Ideally this would be an assertion...
+      email.folder = this.getSpecialFolder(SpecialFolder.Sent);
+    }
     let request = new EWSCreateItemRequest({ m$SavedItemFolderId: { t$FolderId: { Id: email.folder.id } }, MessageDisposition: "SendAndSaveCopy" });
     request.addField("Message", "ItemClass", "IPM.Note", "item:ItemClass");
     request.addField("Message", "Subject", email.subject, "item:Subject");

--- a/app/logic/Mail/EWS/EWSAccount.ts
+++ b/app/logic/Mail/EWS/EWSAccount.ts
@@ -92,9 +92,7 @@ export class EWSAccount extends MailAccount {
   }
 
   async send(email: EMail): Promise<void> {
-    if (email.folder?.account != this) {
-      email.folder = this.getSpecialFolder(SpecialFolder.Sent);
-    }
+    assert(email.folder?.id, "Need folder to save the sent email in");
     let request = new EWSCreateItemRequest({ m$SavedItemFolderId: { t$FolderId: { Id: email.folder.id } }, MessageDisposition: "SendAndSaveCopy" });
     request.addField("Message", "ItemClass", "IPM.Note", "item:ItemClass");
     request.addField("Message", "Subject", email.subject, "item:Subject");

--- a/app/logic/Mail/EWS/EWSAccount.ts
+++ b/app/logic/Mail/EWS/EWSAccount.ts
@@ -91,7 +91,8 @@ export class EWSAccount extends MailAccount {
   }
 
   async send(email: EMail): Promise<void> {
-    let request = new EWSCreateItemRequest({MessageDisposition: "SendAndSaveCopy"});
+    assert(email.folder.id, "Bad Sent folder");
+    let request = new EWSCreateItemRequest({ m$SavedItemFolderId: { t$FolderId: { Id: email.folder.id } }, MessageDisposition: "SendAndSaveCopy" });
     request.addField("Message", "ItemClass", "IPM.Note", "item:ItemClass");
     request.addField("Message", "Subject", email.subject, "item:Subject");
     request.addField("Message", "Body", {

--- a/app/logic/Mail/EWS/EWSAccount.ts
+++ b/app/logic/Mail/EWS/EWSAccount.ts
@@ -93,7 +93,6 @@ export class EWSAccount extends MailAccount {
 
   async send(email: EMail): Promise<void> {
     if (email.folder?.account != this) {
-      // Bad sent folder. Ideally this would be an assertion...
       email.folder = this.getSpecialFolder(SpecialFolder.Sent);
     }
     let request = new EWSCreateItemRequest({ m$SavedItemFolderId: { t$FolderId: { Id: email.folder.id } }, MessageDisposition: "SendAndSaveCopy" });

--- a/app/logic/Mail/OWA/OWAAccount.ts
+++ b/app/logic/Mail/OWA/OWAAccount.ts
@@ -1,5 +1,6 @@
 import { MailAccount, AuthMethod, TLSSocketType } from "../MailAccount";
 import type { EMail } from "../EMail";
+import { SpecialFolder } from "../Folder";
 import { OWAFolder } from "./OWAFolder";
 import { OWAError } from "./OWAError";
 import type { OWANotifications } from "./OWANotifications";
@@ -127,7 +128,10 @@ export class OWAAccount extends MailAccount {
   }
 
   async send(email: EMail): Promise<void> {
-    assert(email.folder.id, "Bad Sent folder");
+    if (email.folder?.account != this) {
+      // Bad sent folder. Ideally this would be an assertion...
+      email.folder = this.getSpecialFolder(SpecialFolder.Sent);
+    }
     let request = new OWACreateItemRequest({ SavedItemFolderId: { __type: "TargetFolderId:#Exchange", BaseFolderId: { __type: "FolderId:#Exchange", Id: email.folder.id } }, MessageDisposition: "SendAndSaveCopy" });
     request.addField("Message", "ItemClass", "IPM.Note", "item:ItemClass");
     request.addField("Message", "Subject", email.subject, "item:Subject");

--- a/app/logic/Mail/OWA/OWAAccount.ts
+++ b/app/logic/Mail/OWA/OWAAccount.ts
@@ -129,7 +129,6 @@ export class OWAAccount extends MailAccount {
 
   async send(email: EMail): Promise<void> {
     if (email.folder?.account != this) {
-      // Bad sent folder. Ideally this would be an assertion...
       email.folder = this.getSpecialFolder(SpecialFolder.Sent);
     }
     let request = new OWACreateItemRequest({ SavedItemFolderId: { __type: "TargetFolderId:#Exchange", BaseFolderId: { __type: "FolderId:#Exchange", Id: email.folder.id } }, MessageDisposition: "SendAndSaveCopy" });

--- a/app/logic/Mail/OWA/OWAAccount.ts
+++ b/app/logic/Mail/OWA/OWAAccount.ts
@@ -127,7 +127,8 @@ export class OWAAccount extends MailAccount {
   }
 
   async send(email: EMail): Promise<void> {
-    let request = new OWACreateItemRequest({MessageDisposition: "SendAndSaveCopy"});
+    assert(email.folder.id, "Bad Sent folder");
+    let request = new OWACreateItemRequest({ SavedItemFolderId: { __type: "TargetFolderId:#Exchange", BaseFolderId: { __type: "FolderId:#Exchange", Id: email.folder.id } }, MessageDisposition: "SendAndSaveCopy" });
     request.addField("Message", "ItemClass", "IPM.Note", "item:ItemClass");
     request.addField("Message", "Subject", email.subject, "item:Subject");
     request.addField("Message", "Body", {

--- a/app/logic/Mail/OWA/OWAAccount.ts
+++ b/app/logic/Mail/OWA/OWAAccount.ts
@@ -128,9 +128,7 @@ export class OWAAccount extends MailAccount {
   }
 
   async send(email: EMail): Promise<void> {
-    if (email.folder?.account != this) {
-      email.folder = this.getSpecialFolder(SpecialFolder.Sent);
-    }
+    assert(email.folder?.id, "Need folder to save the sent email in");
     let request = new OWACreateItemRequest({ SavedItemFolderId: { __type: "TargetFolderId:#Exchange", BaseFolderId: { __type: "FolderId:#Exchange", Id: email.folder.id } }, MessageDisposition: "SendAndSaveCopy" });
     request.addField("Message", "ItemClass", "IPM.Note", "item:ItemClass");
     request.addField("Message", "Subject", email.subject, "item:Subject");


### PR DESCRIPTION
This turned out to be harder to test than necessary, because if you have multiple accounts, and try to send messages between them, Mustang will always set the `From` email address to the first account, and changing the identity doesn't change the `From` address...