### PR TITLE
OWA, EAS: Fix type errors after #422 #424

### DIFF
--- a/app/logic/Mail/ActiveSync/ActiveSyncAccount.ts
+++ b/app/logic/Mail/ActiveSync/ActiveSyncAccount.ts
@@ -1,5 +1,6 @@
 import { AuthMethod, MailAccount, TLSSocketType } from "../MailAccount";
 import type { EMail } from "../EMail";
+import type { Folder } from "../Folder";
 import { kMaxCount, ActiveSyncFolder, FolderType } from "./ActiveSyncFolder";
 import { ActiveSyncError } from "./ActiveSyncError";
 import { CreateMIME } from "../SMTP/CreateMIME";

--- a/app/logic/Mail/OWA/OWAAccount.ts
+++ b/app/logic/Mail/OWA/OWAAccount.ts
@@ -250,7 +250,7 @@ export class OWAAccount extends MailAccount {
         let parentFolders = parent ? parent.subFolders : this.rootFolders;
         let owaFolder = parentFolders.find(owaFolder => owaFolder.id == folder.FolderId.Id) as OWAFolder;
         if (!owaFolder) {
-          owaFolder = this.findFolder(owaFolder => owaFolder.id == folder.FolderId.Id) as EWSFolder
+          owaFolder = this.findFolder(owaFolder => owaFolder.id == folder.FolderId.Id) as OWAFolder
             ?? this.newFolder();
           let oldParentFolders = owaFolder.parent?.subFolders || this.rootFolders;
           oldParentFolders.remove(owaFolder);


### PR DESCRIPTION
I missed these type errors in #426 because I'd forgotten to pull latest `master` first.

The OWA error is because I copied and pasted too much in #424.

The ActiveSync error is because I forgot to import the `Folder` type in #422.