### PR TITLE
Mail: IMAP: Fix undefined connection in reconnect - fixes #371

### DIFF
--- a/app/logic/Mail/IMAP/IMAPAccount.ts
+++ b/app/logic/Mail/IMAP/IMAPAccount.ts
@@ -208,15 +208,17 @@ export class IMAPAccount extends MailAccount {
     }
 
     let purpose = this.connections.getKeyForValue(connection);
-    if (!purpose) {
-      return;
-    }
+    assert(purpose, "Connection purpose unknown");
     this.connections.set(purpose, null);
     this.notifyObservers();
 
-    if (!(this.password || this.oAuth2?.isLoggedIn)) {
-      return;
+    if (!this.oAuth2?.isLoggedIn) {
+      await this.oAuth2.login(false);
     }
+    if (!(this.password || this.oAuth2?.isLoggedIn)) {
+      throw new LoginError(new Error(), "Reconnect failed due to missing login");
+    }
+
     return await this.connection(false, purpose);
   }
 


### PR DESCRIPTION
After sleeping, the application tried to reestablish a tcp connection and ran into a connection error. The reason for that was that IMAPAccount::reconnect() returned an undefined connection in case of an invalid connection purpose or oAuth2 login failures.