### PR TITLE
Build: Run conditionalCompile in e2 also

### DIFF
--- a/e2/electron.vite.config.ts
+++ b/e2/electron.vite.config.ts
@@ -3,7 +3,8 @@ import { nodePolyfills } from "vite-plugin-node-polyfills";
 import { svelte } from '@sveltejs/vite-plugin-svelte';
 import { sentryVitePlugin } from "@sentry/vite-plugin";
 import replace from '@rollup/plugin-replace';
-import { production } from '../app/logic/build';
+import conditionalCompile from "vite-plugin-conditional-compile";
+import { production, isWebMail } from '../app/logic/build';
 
 export default defineConfig({
   main: {
@@ -24,6 +25,13 @@ export default defineConfig({
       sourcemap: production,
     },
     plugins: [
+      conditionalCompile({
+        // <https://github.com/LZS911/vite-plugin-conditional-compile/blob/master/README.md>
+        env: {
+          // For conditional `// #if FOO` statements in the code
+          WEBMAIL: isWebMail ? true : undefined,
+        },
+      }),
       nodePolyfills({include: ['buffer'], globals: {global: false, process: false}}),
       svelte(),
       sentryVitePlugin({

--- a/e2/package.json
+++ b/e2/package.json
@@ -53,6 +53,7 @@
     "tslib": "^2.6.2",
     "typescript": "^5.1.6",
     "vite": "^5.0.0",
+    "vite-plugin-conditional-compile": "^1.4.5",
     "vite-plugin-node-polyfills": "^0.22.0"
   },
   "repository": {


### PR DESCRIPTION
### Problem
```
error during build:
[vite-plugin-svelte] [plugin vite-plugin-svelte] ../app/frontend/MainWindow/MainWindow.svelte (31:9): /home/runner/work/mustang/mustang/app/frontend/MainWindow/MainWindow.svelte:31:9 Identifier 'getStartObjects' has already been declared
file: /home/runner/work/mustang/mustang/app/frontend/MainWindow/MainWindow.svelte:31:9

 29 |  import { appGlobal } from "../../logic/app";
 30 |  import { getStartObjects, loginOnStartup } from "../../logic/WebMail/startup";
 31 |  import { getStartObjects, loginOnStartup } from "../../logic/startup";
                ^
 32 |  import { selectedAccount, selectedFolder } from "../Mail/Selected";
 33 |  import { getLocalStorage } from "../Util/LocalStorage";
```

### Cause

- the `vite-plugin-conditional-compile` plugin was never installed and added to the plugins list in `e2/electron.vite.config.ts` so it never ran

### Fix

- Add the plugin and declare it in the plugins list also