### PR TITLE
ActiveSync: Custom sent folder #431

### DIFF
--- a/app/logic/Mail/ActiveSync/ActiveSyncFolder.ts
+++ b/app/logic/Mail/ActiveSync/ActiveSyncFolder.ts
@@ -174,6 +174,17 @@ export class ActiveSyncFolder extends Folder implements ActiveSyncPingable {
     });
     this.messages.addAll(newMsgs);
     this.account.addPingable(this);
+    if (this.specialFolder == SpecialFolder.Sent) {
+      for (let email of newMsgs) {
+        let customSentFolder = this.account.customSentFolders.shift();
+        if (!customSentFolder) {
+          break;
+        }
+        if (customSentFolder != this) {
+          customSentFolder.moveMessageHere(email).catch(this.account.errorCallback);
+        }
+      }
+    }
     return newMsgs;
   }
 

--- a/app/logic/Mail/ActiveSync/ActiveSyncFolder.ts
+++ b/app/logic/Mail/ActiveSync/ActiveSyncFolder.ts
@@ -31,6 +31,8 @@ export enum FolderType {
 export class ActiveSyncFolder extends Folder implements ActiveSyncPingable {
   account: ActiveSyncAccount;
   messages: EMailCollection<ActiveSyncEMail>;
+  /** Callbacks that are called when new messages arrive in this folder.
+   * If the callback returns true, it will be removed and not be called anymore. */
   readonly newMessageCallbacks = new ArrayColl<{(message: ActiveSyncEMail): boolean}>();
   readonly folderClass = "Email";
 
@@ -177,7 +179,8 @@ export class ActiveSyncFolder extends Folder implements ActiveSyncPingable {
     this.account.addPingable(this);
     for (let email of newMsgs) {
       for (let callback of this.newMessageCallbacks) {
-        if (callback(email)) {
+        let done = callback(email);
+        if (done) {
           this.newMessageCallbacks.remove(callback);
           break; // out of inner loop only
         }


### PR DESCRIPTION
Note that the `SendMail` API doesn't actually send the mail, it only queues it to the Outbox, so we have to rely on a subsequent `Ping` to tell us that the mail got sent.