### PR TITLE
OWA: Move OWA JSON request literals into separate files

### DIFF
--- a/app/logic/Calendar/OWA/OWACalendar.ts
+++ b/app/logic/Calendar/OWA/OWACalendar.ts
@@ -1,7 +1,7 @@
 import { Calendar } from "../Calendar";
 import { OWAEvent } from "./OWAEvent";
-import type { OWAAccount } from "../../Mail/OWA/OWAAccount";
-import { owaFindEventsRequest, owaGetCalendarEventsRequest as owaGetCalendarEventsRequest, owaGetEventsRequest } from "./Request/OWAEventRequests";
+import { type OWAAccount, kMaxFetchCount } from "../../Mail/OWA/OWAAccount";
+import { owaFindEventsRequest, owaGetCalendarEventsRequest, owaGetEventsRequest } from "./Request/OWAEventRequests";
 import { sanitize } from "../../../../lib/util/sanitizeDatatypes";
 import { ArrayColl } from "svelte-collections";
 
@@ -38,7 +38,7 @@ export class OWACalendar extends Calendar {
   }
 
   protected async listFolder(folderID: string, events: ArrayColl<OWAEvent>) {
-    let request = owaFindEventsRequest(folderID);
+    let request = owaFindEventsRequest(folderID, kMaxFetchCount);
     let result: any = { RootFolder: { IncludesLastItemInRange: false } };
     while (result?.RootFolder?.IncludesLastItemInRange === false) {
       result = await this.account.callOWA(request);

--- a/app/logic/Calendar/OWA/OWACalendar.ts
+++ b/app/logic/Calendar/OWA/OWACalendar.ts
@@ -1,7 +1,7 @@
 import { Calendar } from "../Calendar";
 import { OWAEvent } from "./OWAEvent";
 import type { OWAAccount } from "../../Mail/OWA/OWAAccount";
-import { kMaxFetchCount } from "../../Mail/OWA/OWAFolder";
+import { owaFindEventsRequest, owaGetCalendarEventsRequest as owaGetCalendarEventsRequest, owaGetEventsRequest } from "./Request/OWAEventRequests";
 import { sanitize } from "../../../../lib/util/sanitizeDatatypes";
 import { ArrayColl } from "svelte-collections";
 
@@ -37,32 +37,8 @@ export class OWACalendar extends Calendar {
     this.events.replaceAll(events);
   }
 
-  protected async listFolder(folder: string, events: ArrayColl<OWAEvent>) {
-    let request = {
-      __type: "FindItemJsonRequest:#Exchange",
-      Header: {
-        __type: "JsonRequestHeaders:#Exchange",
-        RequestServerVersion: "Exchange2013",
-      },
-      Body: {
-        __type: "FindItemRequest:#Exchange",
-        ItemShape: {
-          __type: "ItemResponseShape:#Exchange",
-          BaseShape: "IdOnly",
-        },
-        ParentFolderIds: [{
-          __type: "DistinguishedFolderId:#Exchange",
-          Id: folder,
-        }],
-        Traversal: "Shallow",
-        Paging: {
-          __type: "IndexedPageView:#Exchange",
-          BasePoint: "Beginning",
-          Offset: 0,
-          MaxEntriesReturned: kMaxFetchCount,
-        },
-      },
-    };
+  protected async listFolder(folderID: string, events: ArrayColl<OWAEvent>) {
+    let request = owaFindEventsRequest(folderID);
     let result: any = { RootFolder: { IncludesLastItemInRange: false } };
     while (result?.RootFolder?.IncludesLastItemInRange === false) {
       result = await this.account.callOWA(request);
@@ -78,100 +54,11 @@ export class OWACalendar extends Calendar {
     if (!eventIDs.length) {
       return;
     }
-    let request = {
-      __type: "GetItemJsonRequest:#Exchange",
-      Header: {
-        __type: "JsonRequestHeaders:#Exchange",
-        RequestServerVersion: "Exchange2013",
-      },
-      Body: {
-        __type: "GetItemRequest:#Exchange",
-        ItemShape: {
-          __type: "ItemResponseShape:#Exchange",
-          BaseShape: "Default",
-          BodyType: "Best",
-          AdditionalProperties: [{
-            __type: "PropertyUri:#Exchange",
-            FieldURI: "item:Body",
-          }, {
-            __type: "PropertyUri:#Exchange",
-            FieldURI: "item:ReminderIsSet",
-          }, {
-            __type: "PropertyUri:#Exchange",
-            FieldURI: "item:ReminderMinutesBeforeStart",
-          }, {
-            __type: "PropertyUri:#Exchange",
-            FieldURI: "item:LastModifiedTime",
-          }, {
-            __type: "PropertyUri:#Exchange",
-            FieldURI: "item:TextBody",
-          }, {
-            __type: "PropertyUri:#Exchange",
-            FieldURI: "calendar:IsAllDayEvent",
-          }, {
-            __type: "PropertyUri:#Exchange",
-            FieldURI: "calendar:EnhancedLocation",
-          }, {
-            __type: "PropertyUri:#Exchange",
-            FieldURI: "calendar:MyResponseType",
-          }, {
-            __type: "PropertyUri:#Exchange",
-            FieldURI: "calendar:RequiredAttendees",
-          }, {
-            __type: "PropertyUri:#Exchange",
-            FieldURI: "calendar:OptionalAttendees",
-          }, {
-            __type: "PropertyUri:#Exchange",
-            FieldURI: "calendar:Recurrence",
-          }, {
-            __type: "PropertyUri:#Exchange",
-            FieldURI: "calendar:ModifiedOccurrences",
-          }, {
-            __type: "PropertyUri:#Exchange",
-            FieldURI: "calendar:DeletedOccurrences",
-          }, {
-            __type: "PropertyUri:#Exchange",
-            FieldURI: "calendar:UID",
-          }, {
-            __type: "PropertyUri:#Exchange",
-            FieldURI: "calendar:RecurrenceId",
-          }, {
-            __type: "PropertyUri:#Exchange",
-            FieldURI: "calendar:IsOnlineMeeting",
-          }, {
-            __type: "PropertyUri:#Exchange",
-            FieldURI: "task:Recurrence",
-          }],
-        },
-        ItemIds: eventIDs.map(id => ({
-          __type: "ItemId:#Exchange",
-          Id: id,
-        })),
-      },
-    };
-    let results = await this.account.callOWA(request);
+    let results = await this.account.callOWA(owaGetEventsRequest(eventIDs));
     let items = results.ResponseMessages ? results.ResponseMessages.Items.map(item => item.Items[0]) : results.Items;
     let online = items.filter(item => item.IsOnlineMeeting);
     if (online.length) {
-      let request = {
-        __type: "GetCalendarEventJsonRequest:#Exchange",
-        Header: {
-          __type: "JsonRequestHeaders:#Exchange",
-          RequestServerVersion: "Exchange2013",
-        },
-        Body: {
-          __type: "GetCalendarEventRequest:#Exchange",
-          EventIds: online.map(item => ({
-            __type: "ItemId:#Exchange",
-            Id: item.ItemId.Id,
-          })),
-          ItemShape: {
-          __type: "ItemResponseShape:#Exchange",
-            BaseShape: "IdOnly",
-          },
-        }
-      };
-      let results = await this.account.callOWA(request);
+      let results = await this.account.callOWA(owaGetCalendarEventsRequest(online.map(item => item.ItemId.Id)));
       let items = results.ResponseMessages ? results.ResponseMessages.Items.map(item => item.Items[0]) : results.Items;
       for (let i = 0; i < items.length; i++) {
         online[i].OnlineMeetingJoinUrl = items[i].OnlineMeetingJoinUrl;

--- a/app/logic/Calendar/OWA/OWAEvent.ts
+++ b/app/logic/Calendar/OWA/OWAEvent.ts
@@ -11,7 +11,7 @@ import OWAUpdateOffice365OccurrenceRequest from "./Request/OWAUpdateOffice365Occ
 import OWACreateItemRequest from "../../Mail/OWA/Request/OWACreateItemRequest";
 import OWADeleteItemRequest from "../../Mail/OWA/Request/OWADeleteItemRequest";
 import OWAUpdateItemRequest from "../../Mail/OWA/Request/OWAUpdateItemRequest";
-import { owaCreateExclusionRequest, owaGetEventUIDRequest, owaOnlineMeetingDescriptionRequest, owaOnlineMeetingURLRequest } from "./Request/OWAEventRequests";
+import { owaCreateExclusionRequest, owaGetEventUIDsRequest, owaOnlineMeetingDescriptionRequest, owaOnlineMeetingURLRequest } from "./Request/OWAEventRequests";
 import type { ArrayColl } from "svelte-collections";
 import { sanitize } from "../../../../lib/util/sanitizeDatatypes";
 import { assert } from "../../util/util";
@@ -204,7 +204,7 @@ export class OWAEvent extends Event {
   }
 
   protected async getOnlineMeetingDescription() {
-    let response = await this.calendar.account.callOWA(owaOnlineMeetingDescriptionRequest(this.itemID));
+    let response = await this.calendar.account.callOWA(owaOnlineMeetingDescriptionRequest([ this.itemID ]));
     let item = response.Items[0];
     this.calUID = sanitize.nonemptystring(item.UID);
     this.location = sanitize.nonemptystring(item.Location?.DisplayName, "");
@@ -219,12 +219,12 @@ export class OWAEvent extends Event {
   }
 
   protected async getOnlineMeetingURL() {
-    let response = await this.calendar.account.callOWA(owaOnlineMeetingURLRequest(this.itemID));
+    let response = await this.calendar.account.callOWA(owaOnlineMeetingURLRequest([ this.itemID ]));
     this.onlineMeetingURL = sanitize.url(response.Items[0].OnlineMeetingJoinUrl, null);
   }
 
   protected async updateUID() {
-    let response = await this.calendar.account.callOWA(owaGetEventUIDRequest(this.itemID));
+    let response = await this.calendar.account.callOWA(owaGetEventUIDsRequest([ this.itemID ]));
     this.calUID = sanitize.nonemptystring(response.Items[0].UID);
   }
 
@@ -305,7 +305,7 @@ export class OWAEvent extends Event {
       let request = new OWADeleteItemRequest(this.itemID, {SendMeetingCancellations: "SendToAllAndSaveCopy"});
       await this.calendar.account.callOWA(request);
     } else if (this.parentEvent) {
-      await this.calendar.account.callOWA(owaCreateExclusionRequest(this.parentEvent));
+      await this.calendar.account.callOWA(owaCreateExclusionRequest(this, this.parentEvent));
     }
   }
 

--- a/app/logic/Calendar/OWA/Request/OWAEventRequests.ts
+++ b/app/logic/Calendar/OWA/Request/OWAEventRequests.ts
@@ -1,4 +1,3 @@
-import { kMaxFetchCount } from "../../../Mail/OWA/OWAFolder";
 import OWARequest from "../../../Mail/OWA/Request/OWARequest";
 import type { OWAEvent } from "../OWAEvent";
 
@@ -83,7 +82,7 @@ export function owaGetCalendarEventsRequest(eventIDs: string[]): OWARequest {
   });
 }
 
-export function owaFindEventsRequest(folderID: string): OWARequest {
+export function owaFindEventsRequest(folderID: string, maxFetchCount: number): OWARequest {
   return new OWARequest("FindItemJsonRequest", {
     __type: "FindItemRequest:#Exchange",
     ItemShape: {
@@ -99,13 +98,12 @@ export function owaFindEventsRequest(folderID: string): OWARequest {
       __type: "IndexedPageView:#Exchange",
       BasePoint: "Beginning",
       Offset: 0,
-      MaxEntriesReturned: kMaxFetchCount,
+      MaxEntriesReturned: maxFetchCount,
     },
   });
 }
 
-
-export function owaOnlineMeetingDescriptionRequest(eventID: string): OWARequest {
+export function owaOnlineMeetingDescriptionRequest(eventIDs: string[]): OWARequest {
   return new OWARequest("GetItemJsonRequest", {
     __type: "GetItemRequest:#Exchange",
     ItemShape: {
@@ -125,28 +123,28 @@ export function owaOnlineMeetingDescriptionRequest(eventID: string): OWARequest 
         FieldURI: "calendar:UID",
       }],
     },
-    ItemIds: [{
+    ItemIds: eventIDs.map(id => ({
       __type: "ItemId:#Exchange",
-      Id: eventID,
-    }],
+      Id: id,
+    })),
   });
 }
 
-export function owaOnlineMeetingURLRequest(eventID: string): OWARequest {
+export function owaOnlineMeetingURLRequest(eventIDs: string[]): OWARequest {
   return new OWARequest("GetCalendarEventJsonRequest", {
     __type: "GetCalendarEventRequest:#Exchange",
     ItemShape: {
       __type: "ItemResponseShape:#Exchange",
       BaseShape: "IdOnly",
     },
-    EventIds: [{
+    EventIds: eventIDs.map(id => ({
       __type: "ItemId:#Exchange",
-      Id: eventID,
-    }],
+      Id: id,
+    })),
   });
 }
 
-export function owaGetEventUIDRequest(eventID: string): OWARequest {
+export function owaGetEventUIDsRequest(eventIDs: string[]): OWARequest {
   return new OWARequest("GetItemJsonRequest", {
     __type: "GetItemRequest:#Exchange",
     ItemShape: {
@@ -157,20 +155,20 @@ export function owaGetEventUIDRequest(eventID: string): OWARequest {
         FieldURI: "calendar:UID",
       }],
     },
-    ItemIds: [{
+    ItemIds: eventIDs.map(id => ({
       __type: "ItemId:#Exchange",
-      Id: eventID,
-    }],
+      Id: id,
+    })),
   });
 }
 
-export function owaCreateExclusionRequest(parentEvent: OWAEvent): OWARequest {
+export function owaCreateExclusionRequest(excludeEvent: OWAEvent, parentEvent: OWAEvent): OWARequest {
   return new OWARequest("DeleteItemJsonRequest", {
     __type: "DeleteItemRequest:#Exchange",
     ItemIds: [{
       __type: "OccurrenceItemId:#Exchange",
       RecurringMasterId: parentEvent.itemID,
-      InstanceIndex: parentEvent.instances.indexOf(this) + 1,
+      InstanceIndex: parentEvent.instances.indexOf(excludeEvent) + 1,
     }],
     DeleteType: "MoveToDeletedItems",
     SendMeetingCancellations: "SendToAllAndSaveCopy",

--- a/app/logic/Calendar/OWA/Request/OWAEventRequests.ts
+++ b/app/logic/Calendar/OWA/Request/OWAEventRequests.ts
@@ -1,0 +1,178 @@
+import { kMaxFetchCount } from "../../../Mail/OWA/OWAFolder";
+import OWARequest from "../../../Mail/OWA/Request/OWARequest";
+import type { OWAEvent } from "../OWAEvent";
+
+export function owaGetEventsRequest(eventIDs: string[]): OWARequest {
+  return new OWARequest("GetItemJsonRequest", {
+    __type: "GetItemJsonRequest:#Exchange",
+    ItemShape: {
+      __type: "ItemResponseShape:#Exchange",
+      BaseShape: "Default",
+      BodyType: "Best",
+      AdditionalProperties: [{
+        __type: "PropertyUri:#Exchange",
+        FieldURI: "item:Body",
+      }, {
+        __type: "PropertyUri:#Exchange",
+        FieldURI: "item:ReminderIsSet",
+      }, {
+        __type: "PropertyUri:#Exchange",
+        FieldURI: "item:ReminderMinutesBeforeStart",
+      }, {
+        __type: "PropertyUri:#Exchange",
+        FieldURI: "item:LastModifiedTime",
+      }, {
+        __type: "PropertyUri:#Exchange",
+        FieldURI: "item:TextBody",
+      }, {
+        __type: "PropertyUri:#Exchange",
+        FieldURI: "calendar:IsAllDayEvent",
+      }, {
+        __type: "PropertyUri:#Exchange",
+        FieldURI: "calendar:EnhancedLocation",
+      }, {
+        __type: "PropertyUri:#Exchange",
+        FieldURI: "calendar:MyResponseType",
+      }, {
+        __type: "PropertyUri:#Exchange",
+        FieldURI: "calendar:RequiredAttendees",
+      }, {
+        __type: "PropertyUri:#Exchange",
+        FieldURI: "calendar:OptionalAttendees",
+      }, {
+        __type: "PropertyUri:#Exchange",
+        FieldURI: "calendar:Recurrence",
+      }, {
+        __type: "PropertyUri:#Exchange",
+        FieldURI: "calendar:ModifiedOccurrences",
+      }, {
+        __type: "PropertyUri:#Exchange",
+        FieldURI: "calendar:DeletedOccurrences",
+      }, {
+        __type: "PropertyUri:#Exchange",
+        FieldURI: "calendar:UID",
+      }, {
+        __type: "PropertyUri:#Exchange",
+        FieldURI: "calendar:RecurrenceId",
+      }, {
+        __type: "PropertyUri:#Exchange",
+        FieldURI: "calendar:IsOnlineMeeting",
+      }, {
+        __type: "PropertyUri:#Exchange",
+        FieldURI: "task:Recurrence",
+      }],
+    },
+    ItemIds: eventIDs.map(id => ({
+      __type: "ItemId:#Exchange",
+      Id: id,
+    })),
+  });
+}
+
+export function owaGetCalendarEventsRequest(eventIDs: string[]): OWARequest {
+  return new OWARequest("GetCalendarEventJsonRequest", {
+    __type: "GetCalendarEventRequest:#Exchange",
+    EventIds: eventIDs.map(id => ({
+      __type: "ItemId:#Exchange",
+      Id: id,
+    })),
+    ItemShape: {
+      __type: "ItemResponseShape:#Exchange",
+      BaseShape: "IdOnly",
+    },
+  });
+}
+
+export function owaFindEventsRequest(folderID: string): OWARequest {
+  return new OWARequest("FindItemJsonRequest", {
+    __type: "FindItemRequest:#Exchange",
+    ItemShape: {
+      __type: "ItemResponseShape:#Exchange",
+      BaseShape: "IdOnly",
+    },
+    ParentFolderIds: [{
+      __type: "DistinguishedFolderId:#Exchange",
+      Id: folderID,
+    }],
+    Traversal: "Shallow",
+    Paging: {
+      __type: "IndexedPageView:#Exchange",
+      BasePoint: "Beginning",
+      Offset: 0,
+      MaxEntriesReturned: kMaxFetchCount,
+    },
+  });
+}
+
+
+export function owaOnlineMeetingDescriptionRequest(eventID: string): OWARequest {
+  return new OWARequest("GetItemJsonRequest", {
+    __type: "GetItemRequest:#Exchange",
+    ItemShape: {
+      __type: "ItemResponseShape:#Exchange",
+      BaseShape: "IdOnly",
+      AdditionalProperties: [{
+        __type: "PropertyUri:#Exchange",
+        FieldURI: "item:Body",
+      }, {
+        __type: "PropertyUri:#Exchange",
+        FieldURI: "item:TextBody",
+      }, {
+        __type: "PropertyUri:#Exchange",
+        FieldURI: "calendar:EnhancedLocation",
+      }, { // Might as well include this in case we don't have it yet
+        __type: "PropertyUri:#Exchange",
+        FieldURI: "calendar:UID",
+      }],
+    },
+    ItemIds: [{
+      __type: "ItemId:#Exchange",
+      Id: eventID,
+    }],
+  });
+}
+
+export function owaOnlineMeetingURLRequest(eventID: string): OWARequest {
+  return new OWARequest("GetCalendarEventJsonRequest", {
+    __type: "GetCalendarEventRequest:#Exchange",
+    ItemShape: {
+      __type: "ItemResponseShape:#Exchange",
+      BaseShape: "IdOnly",
+    },
+    EventIds: [{
+      __type: "ItemId:#Exchange",
+      Id: eventID,
+    }],
+  });
+}
+
+export function owaGetEventUIDRequest(eventID: string): OWARequest {
+  return new OWARequest("GetItemJsonRequest", {
+    __type: "GetItemRequest:#Exchange",
+    ItemShape: {
+      __type: "ItemResponseShape:#Exchange",
+      BaseShape: "IdOnly",
+      AdditionalProperties: [{
+        __type: "PropertyUri:#Exchange",
+        FieldURI: "calendar:UID",
+      }],
+    },
+    ItemIds: [{
+      __type: "ItemId:#Exchange",
+      Id: eventID,
+    }],
+  });
+}
+
+export function owaCreateExclusionRequest(parentEvent: OWAEvent): OWARequest {
+  return new OWARequest("DeleteItemJsonRequest", {
+    __type: "DeleteItemRequest:#Exchange",
+    ItemIds: [{
+      __type: "OccurrenceItemId:#Exchange",
+      RecurringMasterId: parentEvent.itemID,
+      InstanceIndex: parentEvent.instances.indexOf(this) + 1,
+    }],
+    DeleteType: "MoveToDeletedItems",
+    SendMeetingCancellations: "SendToAllAndSaveCopy",
+  });
+}

--- a/app/logic/Contacts/OWA/OWAAddressbook.ts
+++ b/app/logic/Contacts/OWA/OWAAddressbook.ts
@@ -1,11 +1,9 @@
 import { Addressbook } from "../Addressbook";
 import { OWAPerson } from "./OWAPerson";
 import { OWAGroup } from "./OWAGroup";
-import type { OWAAccount } from "../../Mail/OWA/OWAAccount";
-import { owaFindPersonsRequest, owaGetPersonasRequest } from "./Request/OWAPersonRequests";
-import { kMaxFetchCount } from "../../Mail/OWA/OWAFolder";
+import { type OWAAccount, kMaxFetchCount } from "../../Mail/OWA/OWAAccount";
+import { owaFindPersonsRequest, owaGetPersonaRequest } from "./Request/OWAPersonRequests";
 import type { ArrayColl } from "svelte-collections";
-
 
 export class OWAAddressbook extends Addressbook {
   readonly protocol: string = "addressbook-owa";
@@ -37,7 +35,7 @@ export class OWAAddressbook extends Addressbook {
 
     let persons = [];
     let groups = [];
-    let request = owaFindPersonsRequest(contacts.FolderId);
+    let request = owaFindPersonsRequest(contacts.FolderId, kMaxFetchCount);
     do {
       response = await this.account.callOWA(request);
       for (let result of response.ResultSet) {
@@ -62,7 +60,7 @@ export class OWAAddressbook extends Addressbook {
     }
     for (let result of persons) {
       try {
-        let request = owaGetPersonasRequest(result.PersonaId.Id);
+        let request = owaGetPersonaRequest(result.PersonaId.Id);
         let response = await this.account.callOWA(request);
         Object.assign(result, response.Persona);
         let requestNotes = new OWAGetNotesForPersonaRequest(result.PersonaId.Id);

--- a/app/logic/Contacts/OWA/Request/OWAPersonRequests.ts
+++ b/app/logic/Contacts/OWA/Request/OWAPersonRequests.ts
@@ -1,0 +1,65 @@
+import OWARequest from "../../../Mail/OWA/Request/OWARequest";
+import { kMaxFetchCount } from "../../../Mail/OWA/OWAFolder";
+
+export function owaFindPersonsRequest(folderID: string): OWARequest {
+  return new OWARequest("FindPeopleJsonRequest", {
+    __type: "FindPeopleRequest:#Exchange",
+    IndexedPageItemView: {
+      __type: "IndexedPageView:#Exchange",
+      BasePoint: "Beginning",
+      Offset: 0,
+      MaxEntriesReturned: kMaxFetchCount,
+    },
+    ParentFolderId: {
+      __type: "TargetFolderId:#Exchange",
+      BaseFolderId: folderID,
+    },
+    PersonaShape: {
+      __type: "PersonaResponseShape:#Exchange",
+      BaseShape: "Default",
+    },
+    QueryString: null,
+    SearchPeopleSuggestionIndex: false,
+    ShouldResolveOneOffEmailAddress: false,
+  });
+}
+
+export function owaGetPersonasRequest(personaIDs: string[]): OWARequest {
+  return new OWARequest("GetPersonaJsonRequest", {
+    __type: "GetPersonaRequest:#Exchange",
+    PersonaId: {
+      __type: "ItemId:#Exchange",
+      Id: personaIDs,
+    },
+  });
+}
+
+export function owaPersonRequest(folderID: string): OWARequest {
+  return new OWARequest("", {
+  });
+}
+
+export function owaPersonRequest(folderID: string): OWARequest {
+  return new OWARequest("", {
+  });
+}
+
+export function owaPersonRequest(folderID: string): OWARequest {
+  return new OWARequest("", {
+  });
+}
+
+export function owaPersonRequest(folderID: string): OWARequest {
+  return new OWARequest("", {
+  });
+}
+
+export function owaPersonRequest(folderID: string): OWARequest {
+  return new OWARequest("", {
+  });
+}
+
+export function owaPersonRequest(folderID: string): OWARequest {
+  return new OWARequest("", {
+  });
+}

--- a/app/logic/Contacts/OWA/Request/OWAPersonRequests.ts
+++ b/app/logic/Contacts/OWA/Request/OWAPersonRequests.ts
@@ -1,14 +1,13 @@
 import OWARequest from "../../../Mail/OWA/Request/OWARequest";
-import { kMaxFetchCount } from "../../../Mail/OWA/OWAFolder";
 
-export function owaFindPersonsRequest(folderID: string): OWARequest {
+export function owaFindPersonsRequest(folderID: string, maxFetchCount: number): OWARequest {
   return new OWARequest("FindPeopleJsonRequest", {
     __type: "FindPeopleRequest:#Exchange",
     IndexedPageItemView: {
       __type: "IndexedPageView:#Exchange",
       BasePoint: "Beginning",
       Offset: 0,
-      MaxEntriesReturned: kMaxFetchCount,
+      MaxEntriesReturned: maxFetchCount,
     },
     ParentFolderId: {
       __type: "TargetFolderId:#Exchange",
@@ -24,12 +23,12 @@ export function owaFindPersonsRequest(folderID: string): OWARequest {
   });
 }
 
-export function owaGetPersonasRequest(personaIDs: string[]): OWARequest {
+export function owaGetPersonaRequest(personaID: string): OWARequest {
   return new OWARequest("GetPersonaJsonRequest", {
     __type: "GetPersonaRequest:#Exchange",
     PersonaId: {
       __type: "ItemId:#Exchange",
-      Id: personaIDs,
+      Id: personaID,
     },
   });
 }

--- a/app/logic/Contacts/OWA/Request/OWAPersonRequests.ts
+++ b/app/logic/Contacts/OWA/Request/OWAPersonRequests.ts
@@ -33,33 +33,3 @@ export function owaGetPersonasRequest(personaIDs: string[]): OWARequest {
     },
   });
 }
-
-export function owaPersonRequest(folderID: string): OWARequest {
-  return new OWARequest("", {
-  });
-}
-
-export function owaPersonRequest(folderID: string): OWARequest {
-  return new OWARequest("", {
-  });
-}
-
-export function owaPersonRequest(folderID: string): OWARequest {
-  return new OWARequest("", {
-  });
-}
-
-export function owaPersonRequest(folderID: string): OWARequest {
-  return new OWARequest("", {
-  });
-}
-
-export function owaPersonRequest(folderID: string): OWARequest {
-  return new OWARequest("", {
-  });
-}
-
-export function owaPersonRequest(folderID: string): OWARequest {
-  return new OWARequest("", {
-  });
-}

--- a/app/logic/Mail/OWA/OWAAccount.ts
+++ b/app/logic/Mail/OWA/OWAAccount.ts
@@ -10,6 +10,7 @@ import type { OWAAddressbook } from "../../Contacts/OWA/OWAAddressbook";
 import { newCalendarForProtocol} from "../../Calendar/AccountsList/Calendars";
 import type { OWACalendar } from "../../Calendar/OWA/OWACalendar";
 import OWACreateItemRequest from "./Request/OWACreateItemRequest";
+import OWASubscribeToNotificationRequest from "./Request/OWASubscribeToNotificationRequest";
 import { OWALoginBackground } from "./Login/OWALoginBackground";
 import { owaAutoFillLoginPage } from "./Login/OWALoginAutoFill";
 import type { PersonUID } from "../../Abstract/PersonUID";
@@ -110,8 +111,7 @@ export class OWAAccount extends MailAccount {
     calendar.account = this;
     await calendar.listEvents();
 
-    let request = new OWASubscribeToNotificationRequest();
-    await this.callOWA(request);
+    await this.callOWA(new OWASubscribeToNotificationRequest());
 
     this.notifications = this.isOffice365()
       ? new OWAOffice365Notifications(this)
@@ -347,7 +347,7 @@ export class OWAAccount extends MailAccount {
     }
   }
 
-  handleHierarchyNotification(notification: any) {
+  protected handleHierarchyNotification(notification: any) {
     try {
       let parent = this.folderMap.get(notification.parentFolderId);
       if (!parent && notification.parentFolderId != this.msgFolderRootID) {
@@ -384,33 +384,4 @@ function addRecipients(aRequest: any, aType: string, aRecipients: PersonUID[]): 
     Name: recipient.name,
     EmailAddress: recipient.emailAddress,
   })), "message:" + aType);
-}
-
-class OWASubscribeToNotificationRequest {
-  readonly request = {
-    __type: "NotificationSubscribeJsonRequest:#Exchange",
-    Header: {
-      __type: "JsonRequestHeaders:#Exchange",
-      RequestServerVersion: "Exchange2013",
-    },
-  };
-  readonly subscriptionData = [{
-    __type: "SubscriptionData:#Exchange",
-    SubscriptionId: "HierarchyNotification",
-    Parameters: {
-      __type: "SubscriptionParameters:#Exchange",
-      NotificationType: "HierarchyNotification",
-    },
-  }, {
-    __type: "SubscriptionData:#Exchange",
-    SubscriptionId: "NewMailNotification",
-    Parameters: {
-      __type: "SubscriptionParameters:#Exchange",
-      NotificationType: "NewMailNotification",
-    },
-  }];
-
-  get type() {
-    return "SubscribeToNotification";
-  }
 }

--- a/app/logic/Mail/OWA/OWAAccount.ts
+++ b/app/logic/Mail/OWA/OWAAccount.ts
@@ -23,6 +23,7 @@ import { notifyChangedProperty } from "../../util/Observable";
 import { sanitize } from "../../../../lib/util/sanitizeDatatypes";
 import { assert, blobToBase64 } from "../../util/util";
 import { gt } from "../../../l10n/l10n";
+import { owaCreateNewTopLevelFolderRequest } from "./Request/OWAFolderRequests";
 
 export class OWAAccount extends MailAccount {
   readonly protocol: string = "owa";
@@ -292,29 +293,7 @@ export class OWAAccount extends MailAccount {
   }
 
   async createToplevelFolder(name: string): Promise<OWAFolder> {
-    let request = {
-      __type: "CreateFolderJsonRequest:#Exchange",
-      Header: {
-        __type: "JsonRequestHeaders:#Exchange",
-        RequestServerVersion: "Exchange2013",
-      },
-      Body: {
-        __type: "CreateFolderRequest:#Exchange",
-        ParentFolderId: {
-          __type: "TargetFolderId:#Exchange",
-          BaseFolderId: {
-            __type: "DistinguishedFolderId:#Exchange",
-            Id: "msgfolderroot",
-          },
-        },
-        Folders: [{
-          __type: "Folder:#Exchange",
-          FolderClass: "IPF.Note",
-          DisplayName: name,
-        }],
-      },
-    };
-    let result = await this.callOWA(request);
+    let result = await this.callOWA(owaCreateNewTopLevelFolderRequest(name));
     let folder = await super.createToplevelFolder(name) as OWAFolder;
     folder.id = sanitize.nonemptystring(result.Folders[0].FolderId.Id);
     this.folderMap.set(folder.id, folder);

--- a/app/logic/Mail/OWA/OWAAccount.ts
+++ b/app/logic/Mail/OWA/OWAAccount.ts
@@ -11,6 +11,7 @@ import { newCalendarForProtocol} from "../../Calendar/AccountsList/Calendars";
 import type { OWACalendar } from "../../Calendar/OWA/OWACalendar";
 import OWACreateItemRequest from "./Request/OWACreateItemRequest";
 import OWASubscribeToNotificationRequest from "./Request/OWASubscribeToNotificationRequest";
+import { owaCreateNewTopLevelFolderRequest } from "./Request/OWAFolderRequests";
 import { OWALoginBackground } from "./Login/OWALoginBackground";
 import { owaAutoFillLoginPage } from "./Login/OWALoginAutoFill";
 import type { PersonUID } from "../../Abstract/PersonUID";
@@ -23,7 +24,6 @@ import { notifyChangedProperty } from "../../util/Observable";
 import { sanitize } from "../../../../lib/util/sanitizeDatatypes";
 import { assert, blobToBase64 } from "../../util/util";
 import { gt } from "../../../l10n/l10n";
-import { owaCreateNewTopLevelFolderRequest } from "./Request/OWAFolderRequests";
 
 export class OWAAccount extends MailAccount {
   readonly protocol: string = "owa";
@@ -364,3 +364,5 @@ function addRecipients(aRequest: any, aType: string, aRecipients: PersonUID[]): 
     EmailAddress: recipient.emailAddress,
   })), "message:" + aType);
 }
+
+export const kMaxFetchCount = 50;

--- a/app/logic/Mail/OWA/OWAEMail.ts
+++ b/app/logic/Mail/OWA/OWAEMail.ts
@@ -5,7 +5,7 @@ import { Tag, getTagByName } from "../Tag";
 import OWACreateItemRequest from "./Request/OWACreateItemRequest";
 import OWADeleteItemRequest from "./Request/OWADeleteItemRequest";
 import OWAUpdateItemRequest from "./Request/OWAUpdateItemRequest";
-import { owaDownloadMsgsInFolderRequest } from "./Request/OWAFolderRequests";
+import { owaDownloadMsgsRequest } from "./Request/OWAFolderRequests";
 import { owaGetEventsRequest } from "../../Calendar/OWA/Request/OWAEventRequests";
 import { PersonUID, findOrCreatePersonUID } from "../../Abstract/PersonUID";
 import { Scheduling, ResponseType, type Responses } from "../../Calendar/Invitation";
@@ -25,7 +25,7 @@ export class OWAEMail extends EMail {
   }
 
   async download() {
-    let result = await this.folder.account.callOWA(owaDownloadMsgsInFolderRequest([ this ]));
+    let result = await this.folder.account.callOWA(owaDownloadMsgsRequest([ this ]));
     let mimeBase64 = sanitize.nonemptystring(result.Items[0].MimeContent.Value);
     this.mime = new Uint8Array(await base64ToArrayBuffer(mimeBase64, "message/rfc822"));
     await this.parseMIME();
@@ -151,7 +151,7 @@ export class OWAEMail extends EMail {
   async loadEvent_disabled() {
     assert(this.scheduling == Scheduling.Request, "This is not an invitation");
     assert(!this.event, "Event has already been loaded");
-    let result = await this.folder.account.callOWA(owaGetEventsRequest([this.itemID ]));
+    let result = await this.folder.account.callOWA(owaGetEventsRequest([ this.itemID ]));
     let event = new OWAEvent();
     event.fromJSON(result.Items[0]);
     this.event = event;

--- a/app/logic/Mail/OWA/OWAFolder.ts
+++ b/app/logic/Mail/OWA/OWAFolder.ts
@@ -3,7 +3,7 @@ import type { EMail } from "../EMail";
 import { OWAEMail } from "./OWAEMail";
 import type { OWAAccount } from "./OWAAccount";
 import OWACreateItemRequest from "./Request/OWACreateItemRequest";
-import { owaCreateNewFolderRequest, owaDeleteFolderRequest, owaDownloadMsgsInFolderRequest, owaFindMsgsInFolderRequest, owaFolderCountsRequests, owaFolderMarkAllMsgsReadRequest, owaGetNewMessageHeadersInFolderRequest as owaGetNewMsgHeadersInFolderRequest, owaMoveEntireFolderRequest, owaMoveOrCopyMsgsIntoFolderRequest, owaRenameFolderRequest } from "./Request/OWAFolderRequests";
+import { owaCreateNewSubFolderRequest, owaDeleteFolderRequest, owaDownloadMsgsInFolderRequest, owaFindMsgsInFolderRequest, owaFolderCountsRequests, owaFolderMarkAllMsgsReadRequest, owaGetNewMessageHeadersInFolderRequest as owaGetNewMsgHeadersInFolderRequest, owaMoveEntireFolderRequest, owaMoveOrCopyMsgsIntoFolderRequest, owaRenameFolderRequest } from "./Request/OWAFolderRequests";
 import { base64ToArrayBuffer, blobToBase64, assert } from "../../util/util";
 import { sanitize } from "../../../../lib/util/sanitizeDatatypes";
 import { ArrayColl, Collection } from "svelte-collections";
@@ -228,7 +228,7 @@ export class OWAFolder extends Folder {
 
   async createSubFolder(name: string): Promise<OWAFolder> {
     let folder = await super.createSubFolder(name) as OWAFolder;
-    let result = await this.account.callOWA(owaCreateNewFolderRequest(name, this.id));
+    let result = await this.account.callOWA(owaCreateNewSubFolderRequest(name, this.id));
     folder.id = sanitize.nonemptystring(result.Folders[0].FolderId.Id);
     this.account.folderMap.set(folder.id, folder);
     return folder;

--- a/app/logic/Mail/OWA/OWAFolder.ts
+++ b/app/logic/Mail/OWA/OWAFolder.ts
@@ -3,6 +3,7 @@ import type { EMail } from "../EMail";
 import { OWAEMail } from "./OWAEMail";
 import type { OWAAccount } from "./OWAAccount";
 import OWACreateItemRequest from "./Request/OWACreateItemRequest";
+import { owaCreateNewFolderRequest, owaDeleteFolderRequest, owaDownloadMsgsInFolderRequest, owaFindMsgsInFolderRequest, owaFolderCountsRequests, owaFolderMarkAllMsgsReadRequest, owaGetNewMessageHeadersInFolderRequest as owaGetNewMsgHeadersInFolderRequest, owaMoveEntireFolderRequest, owaMoveOrCopyMsgsIntoFolderRequest, owaRenameFolderRequest } from "./Request/OWAFolderRequests";
 import { base64ToArrayBuffer, blobToBase64, assert } from "../../util/util";
 import { sanitize } from "../../../../lib/util/sanitizeDatatypes";
 import { ArrayColl, Collection } from "svelte-collections";
@@ -51,32 +52,7 @@ export class OWAFolder extends Folder {
       this.dirty = false;
       return true;
     }
-    let request = {
-      __type: "GetFolderJsonRequest:#Exchange",
-      Header: {
-        __type: "JsonRequestHeaders:#Exchange",
-        RequestServerVersion: "Exchange2013",
-      },
-      Body: {
-        __type: "GetFolderRequest:#Exchange",
-        FolderShape: {
-          __type: "FolderResponseShape:#Exchange",
-          BaseShape: "IdOnly",
-          AdditionalProperties: [{
-            __type: "PropertyUri:#Exchange",
-            FieldURI: "folder:UnreadCount",
-          }, {
-            __type: "PropertyUri:#Exchange",
-            FieldURI: "folder:TotalCount",
-          }],
-        },
-        FolderIds: [{
-          __type: "FolderId:#Exchange",
-          Id: this.id,
-        }],
-      },
-    };
-    let result = await this.account.callOWA(request);
+    let result = await this.account.callOWA(owaFolderCountsRequests(this.id));
     let countTotal = sanitize.integer(result.Folders[0].TotalCount);
     let countUnread = sanitize.integer(result.Folders[0].UnreadCount);
     if (this.countTotal == countTotal && this.countUnread == countUnread) {
@@ -99,50 +75,7 @@ export class OWAFolder extends Folder {
 
       let allMsgs = new ArrayColl<OWAEMail>();
       let newMsgs = new ArrayColl<OWAEMail>();
-      let request = {
-        __type: "FindItemJsonRequest:#Exchange",
-        Header: {
-          __type: "JsonRequestHeaders:#Exchange",
-          RequestServerVersion: "Exchange2013",
-        },
-        Body: {
-          __type: "FindItemRequest:#Exchange",
-          ItemShape: {
-            __type: "ItemResponseShape:#Exchange",
-            BaseShape: "IdOnly",
-            AdditionalProperties: [{
-              __type: "PropertyUri:#Exchange",
-              FieldURI: "message:IsRead",
-            }, {
-              __type: "PropertyUri:#Exchange",
-              FieldURI: "item:IsDraft",
-            }, {
-              __type: "PropertyUri:#Exchange",
-              FieldURI: "item:Categories",
-            }, {
-              __type: "PropertyUri:#Exchange",
-              FieldURI: "item:Flag",
-              /*}, {
-                __type: "PropertyUri:#Exchange",
-                ExtendedFieldURI: {
-                  PropertyTag: "0x1080",
-                  PropertyType: "Integer",
-                },*/
-            }],
-          },
-          ParentFolderIds: [{
-            __type: "FolderId:#Exchange",
-            Id: this.id,
-          }],
-          Traversal: "Shallow",
-          Paging: {
-            __type: "IndexedPageView:#Exchange",
-            BasePoint: "Beginning",
-            Offset: 0,
-            MaxEntriesReturned: kMaxFetchCount,
-          },
-        },
-      };
+      let request = owaFindMsgsInFolderRequest(this.id);
       let result: any = { RootFolder: { IncludesLastItemInRange: false } };
       while (result?.RootFolder?.IncludesLastItemInRange === false) {
         result = await this.account.callOWA(request);
@@ -181,98 +114,7 @@ export class OWAFolder extends Folder {
   async getNewMessageHeaders(newMessageIDs: string[]): Promise<ArrayColl<OWAEMail>> {
     let newMsgs = new ArrayColl<OWAEMail>();
     if (newMessageIDs.length) {
-      let request = {
-        __type: "GetItemJsonRequest:#Exchange",
-        Header: {
-          __type: "JsonRequestHeaders:#Exchange",
-          RequestServerVersion: "Exchange2013",
-        },
-        Body: {
-          __type: "GetItemRequest:#Exchange",
-          ItemShape: {
-            __type: "ItemResponseShape:#Exchange",
-            BaseShape: "IdOnly",
-            AdditionalProperties: [{
-              __type: "PropertyUri:#Exchange",
-              FieldURI: "message:InternetMessageId",
-            }, {
-              __type: "PropertyUri:#Exchange",
-              FieldURI: "message:IsRead",
-            }, {
-              __type: "PropertyUri:#Exchange",
-              FieldURI: "message:References",
-            }, {
-              __type: "PropertyUri:#Exchange",
-              FieldURI: "message:ReplyTo",
-            }, {
-              __type: "PropertyUri:#Exchange",
-              FieldURI: "message:From",
-            }, {
-              __type: "PropertyUri:#Exchange",
-              FieldURI: "message:Sender",
-            }, {
-              __type: "PropertyUri:#Exchange",
-              FieldURI: "message:ToRecipients",
-            }, {
-              __type: "PropertyUri:#Exchange",
-              FieldURI: "message:CcRecipients",
-            }, {
-              __type: "PropertyUri:#Exchange",
-              FieldURI: "message:BccRecipients",
-            }, {
-              __type: "PropertyUri:#Exchange",
-              FieldURI: "item:ItemClass",
-            /* Non-MIME @see OWAEMail.bodyAndAttachmentsFromJson()
-            }, {
-              __type: "PropertyUri:#Exchange",
-              FieldURI: "item:Attachments",
-            */
-            }, {
-              __type: "PropertyUri:#Exchange",
-              FieldURI: "item:Subject",
-            }, {
-              __type: "PropertyUri:#Exchange",
-              FieldURI: "item:DateTimeReceived",
-            }, {
-              __type: "PropertyUri:#Exchange",
-              FieldURI: "item:InReplyTo",
-            }, {
-              __type: "PropertyUri:#Exchange",
-              FieldURI: "item:IsDraft",
-            }, {
-              __type: "PropertyUri:#Exchange",
-              FieldURI: "item:DateTimeSent",
-            /* Non-MIME
-            }, {
-              __type: "PropertyUri:#Exchange",
-              FieldURI: "item:Body",
-            */
-            }, {
-              __type: "PropertyUri:#Exchange",
-              FieldURI: "item:Categories",
-            }, {
-              __type: "PropertyUri:#Exchange",
-              FieldURI: "item:Flag",
-            /* Non-MIME
-            }, {
-              __type: "PropertyUri:#Exchange",
-              FieldURI: "item:TextBody",
-            */
-            /*}, {
-              __type: "PropertyUri:#Exchange",
-              ExtendedFieldURI: {
-                PropertyTag: "0x1080",
-                PropertyType: "Integer",
-              },*/
-            }],
-          },
-          ItemIds: newMessageIDs.map(id => ({
-            __type: "ItemId:#Exchange",
-            Id: id,
-          })),
-        },
-      };
-      let results = await this.account.callOWA(request);
+      let results = await this.account.callOWA(owaGetNewMsgHeadersInFolderRequest(newMessageIDs));
       let items = results.ResponseMessages ? results.ResponseMessages.Items.map(item => item.Items[0]) : results.Items;
       for (let item of items) {
         try {
@@ -293,30 +135,7 @@ export class OWAFolder extends Folder {
     let emailsToDownload = emails.contents;
     for (let i = 0; i < emailsToDownload.length; i += kMaxFetchCount) {
       let batch = emailsToDownload.slice(i, i + kMaxFetchCount);
-      let request = {
-        __type: "GetItemJsonRequest:#Exchange",
-        Header: {
-          __type: "JsonRequestHeaders:#Exchange",
-          RequestServerVersion: "Exchange2013",
-        },
-        Body: {
-          __type: "GetItemRequest:#Exchange",
-          ItemShape: {
-            __type: "ItemResponseShape:#Exchange",
-            BaseShape: "IdOnly",
-            AdditionalProperties: [{ // Work around Office365 bug
-              __type: "PropertyUri:#Exchange",
-              FieldURI: "item:Size"
-            }],
-            IncludeMimeContent: true,
-          },
-          ItemIds: batch.map(message => ({
-            __type: "ItemId:#Exchange",
-            Id: message.itemID,
-          })),
-        },
-      };
-      let results = await this.account.callOWA(request);
+      let results = await this.account.callOWA(owaDownloadMsgsInFolderRequest(batch));
       let items = results.ResponseMessages ? results.ResponseMessages.Items.map(item => item.Items[0]) : results.Items;
       for (let item of items) {
         let email = emailsToDownload.find(email => email.itemID == item.ItemId.Id);
@@ -376,29 +195,7 @@ export class OWAFolder extends Folder {
   }
 
   async moveOrCopyMessagesOnServer(action: "Move" | "Copy", messages: Collection<OWAEMail>) {
-    let request = {
-      __type: action + "ItemJsonRequest:#Exchange",
-      Header: {
-        __type: "JsonRequestHeaders:#Exchange",
-        RequestServerVersion: "Exchange2013",
-      },
-      Body: {
-        __type: action + "ItemRequest:#Exchange",
-        ItemIds: messages.contents.map(message => ({
-          __type: "ItemId:#Exchange",
-          Id: message.itemID,
-        })),
-        ToFolderId: {
-          __type: "TargetFolderId:#Exchange",
-          BaseFolderId: {
-            __type: "FolderId:#Exchange",
-            Id: this.id,
-          },
-        },
-        // ReturnNewItemIds: false,
-      },
-    };
-    await this.account.callOWA(request);
+    await this.account.callOWA(owaMoveOrCopyMsgsIntoFolderRequest(action, this.id, messages.contents));
   }
 
   async addMessage(message: EMail) {
@@ -426,57 +223,12 @@ export class OWAFolder extends Folder {
 
   async moveFolderHere(folder: OWAFolder) {
     await super.moveFolderHere(folder);
-    let request = {
-      __type: "MoveFolderJsonRequest:#Exchange",
-      Header: {
-        __type: "JsonRequestHeaders:#Exchange",
-        RequestServerVersion: "Exchange2013",
-      },
-      Body: {
-        __type: "MoveFolderRequest:#Exchange",
-        FolderIds: [{
-          FolderId: {
-            __type: "FolderId:#Exchange",
-            Id: folder.id,
-          },
-        }],
-        ToFolderId: {
-          __type: "TargetFolderId:#Exchange",
-          FolderId: {
-            __type: "FolderId:#Exchange",
-            Id: this.id,
-          },
-        },
-      },
-    };
-    await this.account.callOWA(request);
+    await this.account.callOWA(owaMoveEntireFolderRequest(folder.id, this.id));
   }
 
   async createSubFolder(name: string): Promise<OWAFolder> {
     let folder = await super.createSubFolder(name) as OWAFolder;
-    let request = {
-      __type: "CreateFolderJsonRequest:#Exchange",
-      Header: {
-        __type: "JsonRequestHeaders:#Exchange",
-        RequestServerVersion: "Exchange2013",
-      },
-      Body: {
-        __type: "CreateFolderRequest:#Exchange",
-        ParentFolderId: {
-          __type: "TargetFolderId:#Exchange",
-          BaseFolderId: {
-            __type: "FolderId:#Exchange",
-            Id: this.id,
-          },
-        },
-        Folders: [{
-          __type: "Folder:#Exchange",
-          FolderClass: "IPF.Note",
-          DisplayName: name,
-        }],
-      },
-    };
-    let result = await this.account.callOWA(request);
+    let result = await this.account.callOWA(owaCreateNewFolderRequest(name, this.id));
     folder.id = sanitize.nonemptystring(result.Folders[0].FolderId.Id);
     this.account.folderMap.set(folder.id, folder);
     return folder;
@@ -484,76 +236,16 @@ export class OWAFolder extends Folder {
 
   async rename(name: string) {
     await super.rename(name);
-    let request = {
-      __type: "UpdateFolderJsonRequest:#Exchange",
-      Header: {
-        __type: "JsonRequestHeaders:#Exchange",
-        RequestServerVersion: "Exchange2013",
-      },
-      Body: {
-        __type: "UpdateFolderRequest:#Exchange",
-        FolderChanges: [{
-          __type: "FolderChange:#Exchange",
-          FolderId: {
-            __type: "FolderId:#Exchange",
-            Id: this.id,
-          },
-          Updates: [{
-            __type: "SetFolderField:#Exchange",
-            Folder: {
-              __type: "Folder:#Exchange",
-              DisplayName: name,
-            },
-            Path: {
-              __type: "PropertyUri:#Exchange",
-              FieldURI: "FolderDisplayName",
-            },
-          }],
-        }],
-      },
-    };
-    await this.account.callOWA(request);
+    await this.account.callOWA(owaRenameFolderRequest(name, this.id));
   }
 
   protected async deleteItOnServer() {
-    let request = {
-      __type: "DeleteFolderJsonRequest:#Exchange",
-      Header: {
-        __type: "JsonRequestHeaders:#Exchange",
-        RequestServerVersion: "Exchange2013",
-      },
-      Body: {
-        __type: "DeleteFolderRequest:#Exchange",
-        FolderIds: [{
-          __type: "FolderId:#Exchange",
-          Id: this.id,
-        }],
-        DeleteType: "SoftDelete",
-      },
-    };
-    await this.account.callOWA(request);
+    await this.account.callOWA(owaDeleteFolderRequest(this.id));
   }
 
   async markAllRead() {
     await super.markAllRead();
-    let request = {
-      __type: "MarkAllItemsAsReadJsonRequest:#Exchange",
-      Header: {
-        __type: "JsonRequestHeaders:#Exchange",
-        RequestServerVersion: "Exchange2013",
-      },
-      Body: {
-        __type: "MarkAllItemsAsReadRequest:#Exchange",
-        ReadFlag: true,
-        SuppressReadReceipts: true,
-        FolderIds: [{
-          __type: "FolderId:#Exchange",
-          Id: this.id,
-        }],
-        ItemIdsToExclude: [],
-      },
-    };
-    await this.account.callOWA(request);
+    await this.account.callOWA(owaFolderMarkAllMsgsReadRequest(this.id));
   }
 
   disableChangeSpecial(): string | false {

--- a/app/logic/Mail/OWA/Request/OWACreateItemRequest.ts
+++ b/app/logic/Mail/OWA/Request/OWACreateItemRequest.ts
@@ -1,15 +1,13 @@
-export default class OWACreateItemRequest {
-  readonly __type = "CreateItemJsonRequest:#Exchange";
-  readonly Header = {
-    __type: "JsonRequestHeaders:#Exchange",
-    RequestServerVersion: "Exchange2013",
-  };
+import OWARequest from "./OWARequest";
+
+export default class OWACreateItemRequest extends OWARequest {
   Body: any = {
     __type: "CreateItemRequest:#Exchange",
     Items: [{}],
   };
 
-  constructor(attributes?: {[key: string]: string | boolean | object}) {
+  constructor(attributes?: { [key: string]: string | boolean | object }) {
+    super("CreateItemJsonRequest");
     Object.assign(this.Body, attributes);
   }
 

--- a/app/logic/Mail/OWA/Request/OWADeleteItemRequest.ts
+++ b/app/logic/Mail/OWA/Request/OWADeleteItemRequest.ts
@@ -1,9 +1,6 @@
-export default class OWADeleteItemRequest {
-  readonly __type = "DeleteItemJsonRequest:#Exchange";
-  readonly Header = {
-    __type: "JsonRequestHeaders:#Exchange",
-    RequestServerVersion: "Exchange2013",
-  };
+import OWARequest from "./OWARequest";
+
+export default class OWADeleteItemRequest extends OWARequest {
   Body: any = {
     __type: "DeleteItemRequest:#Exchange",
     ItemIds: [{
@@ -12,7 +9,8 @@ export default class OWADeleteItemRequest {
     DeleteType: "MoveToDeletedItems",
   };
 
-  constructor(id: string, attributes?: {[key: string]: string | boolean}) {
+  constructor(id: string, attributes?: { [key: string]: string | boolean }) {
+    super("DeleteItemJsonRequest");
     this.Body.ItemIds[0].Id = id;
     Object.assign(this.Body, attributes);
   }

--- a/app/logic/Mail/OWA/Request/OWAFolderRequests.ts
+++ b/app/logic/Mail/OWA/Request/OWAFolderRequests.ts
@@ -1,0 +1,273 @@
+import OWARequest from "./OWARequest";
+import type { OWAEMail } from "../OWAEMail";
+import { kMaxFetchCount } from "../OWAFolder";
+
+export function owaFindMsgsInFolderRequest(folderID: string): OWARequest {
+  return new OWARequest("FindItemJsonRequest", {
+    __type: "FindItemRequest:#Exchange",
+    ItemShape: {
+      __type: "ItemResponseShape:#Exchange",
+      BaseShape: "IdOnly",
+      AdditionalProperties: [{
+        __type: "PropertyUri:#Exchange",
+        FieldURI: "message:IsRead",
+      }, {
+        __type: "PropertyUri:#Exchange",
+        FieldURI: "item:IsDraft",
+      }, {
+        __type: "PropertyUri:#Exchange",
+        FieldURI: "item:Categories",
+      }, {
+        __type: "PropertyUri:#Exchange",
+        FieldURI: "item:Flag",
+        /*}, {
+          __type: "PropertyUri:#Exchange",
+          ExtendedFieldURI: {
+            PropertyTag: "0x1080",
+            PropertyType: "Integer",
+          },*/
+      }],
+    },
+    ParentFolderIds: [{
+      __type: "FolderId:#Exchange",
+      Id: folderID,
+    }],
+    Traversal: "Shallow",
+    Paging: {
+      __type: "IndexedPageView:#Exchange",
+      BasePoint: "Beginning",
+      Offset: 0,
+      MaxEntriesReturned: kMaxFetchCount,
+    },
+  });
+}
+
+export function owaGetNewMessageHeadersInFolderRequest(newMessageIDs: string[]): OWARequest {
+  return new OWARequest("GetItemJsonRequest", {
+    __type: "GetItemRequest:#Exchange",
+    ItemShape: {
+      __type: "ItemResponseShape:#Exchange",
+      BaseShape: "IdOnly",
+      AdditionalProperties: [{
+        __type: "PropertyUri:#Exchange",
+        FieldURI: "message:InternetMessageId",
+      }, {
+        __type: "PropertyUri:#Exchange",
+        FieldURI: "message:IsRead",
+      }, {
+        __type: "PropertyUri:#Exchange",
+        FieldURI: "message:References",
+      }, {
+        __type: "PropertyUri:#Exchange",
+        FieldURI: "message:ReplyTo",
+      }, {
+        __type: "PropertyUri:#Exchange",
+        FieldURI: "message:From",
+      }, {
+        __type: "PropertyUri:#Exchange",
+        FieldURI: "message:Sender",
+      }, {
+        __type: "PropertyUri:#Exchange",
+        FieldURI: "message:ToRecipients",
+      }, {
+        __type: "PropertyUri:#Exchange",
+        FieldURI: "message:CcRecipients",
+      }, {
+        __type: "PropertyUri:#Exchange",
+        FieldURI: "message:BccRecipients",
+      }, {
+        __type: "PropertyUri:#Exchange",
+        FieldURI: "item:ItemClass",
+        /* Non-MIME @see OWAEMail.bodyAndAttachmentsFromJson()
+        }, {
+          __type: "PropertyUri:#Exchange",
+          FieldURI: "item:Attachments",
+        */
+      }, {
+        __type: "PropertyUri:#Exchange",
+        FieldURI: "item:Subject",
+      }, {
+        __type: "PropertyUri:#Exchange",
+        FieldURI: "item:DateTimeReceived",
+      }, {
+        __type: "PropertyUri:#Exchange",
+        FieldURI: "item:InReplyTo",
+      }, {
+        __type: "PropertyUri:#Exchange",
+        FieldURI: "item:IsDraft",
+      }, {
+        __type: "PropertyUri:#Exchange",
+        FieldURI: "item:DateTimeSent",
+        /* Non-MIME
+        }, {
+          __type: "PropertyUri:#Exchange",
+          FieldURI: "item:Body",
+        */
+      }, {
+        __type: "PropertyUri:#Exchange",
+        FieldURI: "item:Categories",
+      }, {
+        __type: "PropertyUri:#Exchange",
+        FieldURI: "item:Flag",
+        /* Non-MIME
+        }, {
+          __type: "PropertyUri:#Exchange",
+          FieldURI: "item:TextBody",
+        */
+        /*}, {
+          __type: "PropertyUri:#Exchange",
+          ExtendedFieldURI: {
+            PropertyTag: "0x1080",
+            PropertyType: "Integer",
+          },*/
+      }],
+    },
+    ItemIds: newMessageIDs.map(id => ({
+      __type: "ItemId:#Exchange",
+      Id: id,
+    })),
+  });
+}
+
+export function owaDownloadMsgsInFolderRequest(messages: OWAEMail[]): OWARequest {
+  return new OWARequest("GetItemJsonRequest", {
+    __type: "GetItemRequest:#Exchange",
+    ItemShape: {
+      __type: "ItemResponseShape:#Exchange",
+      BaseShape: "IdOnly",
+      AdditionalProperties: [{ // Work around Office365 bug
+        __type: "PropertyUri:#Exchange",
+        FieldURI: "item:Size"
+      }],
+      IncludeMimeContent: true,
+    },
+    ItemIds: messages.map(message => ({
+      __type: "ItemId:#Exchange",
+      Id: message.itemID,
+    })),
+  });
+}
+
+export function owaMoveOrCopyMsgsIntoFolderRequest(action: "Move" | "Copy", folderID: string, messages: OWAEMail[]): OWARequest {
+  return new OWARequest("ItemJsonRequest", {
+    __type: action + "ItemRequest:#Exchange",
+    ItemIds: messages.map(message => ({
+      __type: "ItemId:#Exchange",
+      Id: message.itemID,
+    })),
+    ToFolderId: {
+      __type: "TargetFolderId:#Exchange",
+      BaseFolderId: {
+        __type: "FolderId:#Exchange",
+        Id: folderID,
+      },
+    },
+    // ReturnNewItemIds: false,
+  });
+}
+
+export function owaMoveEntireFolderRequest(sourceFolderID: string, newParentFolderId: string): OWARequest {
+  return new OWARequest("MoveFolderJsonRequest", {
+    __type: "MoveFolderRequest:#Exchange",
+    FolderIds: [{
+      FolderId: {
+        __type: "FolderId:#Exchange",
+        Id: sourceFolderID,
+      },
+    }],
+    ToFolderId: {
+      __type: "TargetFolderId:#Exchange",
+      FolderId: {
+        __type: "FolderId:#Exchange",
+        Id: newParentFolderId,
+      },
+    },
+  });
+}
+
+export function owaCreateNewFolderRequest(name: string, parentFolderID: string): OWARequest {
+  return new OWARequest("CreateFolderJsonRequest", {
+    __type: "CreateFolderRequest:#Exchange",
+    ParentFolderId: {
+      __type: "TargetFolderId:#Exchange",
+      BaseFolderId: {
+        __type: "FolderId:#Exchange",
+        Id: parentFolderID,
+      },
+    },
+    Folders: [{
+      __type: "Folder:#Exchange",
+      FolderClass: "IPF.Note",
+      DisplayName: name,
+    }],
+  });
+}
+
+export function owaRenameFolderRequest(name: string, folderID: string): OWARequest {
+  return new OWARequest("UpdateFolderJsonRequest", {
+    __type: "UpdateFolderRequest:#Exchange",
+    FolderChanges: [{
+      __type: "FolderChange:#Exchange",
+      FolderId: {
+        __type: "FolderId:#Exchange",
+        Id: folderID,
+      },
+      Updates: [{
+        __type: "SetFolderField:#Exchange",
+        Folder: {
+          __type: "Folder:#Exchange",
+          DisplayName: name,
+        },
+        Path: {
+          __type: "PropertyUri:#Exchange",
+          FieldURI: "FolderDisplayName",
+        },
+      }],
+    }],
+  });
+}
+
+export function owaFolderCountsRequests(folderID: string): OWARequest {
+  return new OWARequest("GetFolderJsonRequest", {
+    __type: "GetFolderRequest:#Exchange",
+    FolderShape: {
+      __type: "FolderResponseShape:#Exchange",
+      BaseShape: "IdOnly",
+      AdditionalProperties: [{
+        __type: "PropertyUri:#Exchange",
+        FieldURI: "folder:UnreadCount",
+      }, {
+        __type: "PropertyUri:#Exchange",
+        FieldURI: "folder:TotalCount",
+      }],
+    },
+    FolderIds: [{
+      __type: "FolderId:#Exchange",
+      Id: folderID,
+    }],
+  });
+}
+
+export function owaDeleteFolderRequest(folderID: string): OWARequest {
+  return new OWARequest("DeleteFolderJsonRequest", {
+    __type: "DeleteFolderRequest:#Exchange",
+    FolderIds: [{
+      __type: "FolderId:#Exchange",
+      Id: folderID,
+    }],
+    DeleteType: "SoftDelete",
+  });
+}
+
+export function owaFolderMarkAllMsgsReadRequest(folderID: string): OWARequest {
+  return new OWARequest("MarkAllItemsAsReadJsonRequest", {
+    __type: "MarkAllItemsAsReadRequest:#Exchange",
+    ReadFlag: true,
+    SuppressReadReceipts: true,
+    FolderIds: [{
+      __type: "FolderId:#Exchange",
+      Id: folderID,
+    }],
+    ItemIdsToExclude: [],
+  });
+}

--- a/app/logic/Mail/OWA/Request/OWAFolderRequests.ts
+++ b/app/logic/Mail/OWA/Request/OWAFolderRequests.ts
@@ -1,8 +1,7 @@
 import OWARequest from "./OWARequest";
 import type { OWAEMail } from "../OWAEMail";
-import { kMaxFetchCount } from "../OWAFolder";
 
-export function owaFindMsgsInFolderRequest(folderID: string): OWARequest {
+export function owaFindMsgsInFolderRequest(folderID: string, maxFetchCount: number): OWARequest {
   return new OWARequest("FindItemJsonRequest", {
     __type: "FindItemRequest:#Exchange",
     ItemShape: {
@@ -37,12 +36,12 @@ export function owaFindMsgsInFolderRequest(folderID: string): OWARequest {
       __type: "IndexedPageView:#Exchange",
       BasePoint: "Beginning",
       Offset: 0,
-      MaxEntriesReturned: kMaxFetchCount,
+      MaxEntriesReturned: maxFetchCount,
     },
   });
 }
 
-export function owaGetNewMessageHeadersInFolderRequest(newMessageIDs: string[]): OWARequest {
+export function owaGetNewMsgHeadersRequest(newMessageIDs: string[]): OWARequest {
   return new OWARequest("GetItemJsonRequest", {
     __type: "GetItemRequest:#Exchange",
     ItemShape: {
@@ -129,7 +128,7 @@ export function owaGetNewMessageHeadersInFolderRequest(newMessageIDs: string[]):
   });
 }
 
-export function owaDownloadMsgsInFolderRequest(messages: OWAEMail[]): OWARequest {
+export function owaDownloadMsgsRequest(messages: OWAEMail[]): OWARequest {
   return new OWARequest("GetItemJsonRequest", {
     __type: "GetItemRequest:#Exchange",
     ItemShape: {
@@ -245,7 +244,7 @@ export function owaRenameFolderRequest(name: string, folderID: string): OWAReque
   });
 }
 
-export function owaFolderCountsRequests(folderID: string): OWARequest {
+export function owaFolderCountsRequest(folderID: string): OWARequest {
   return new OWARequest("GetFolderJsonRequest", {
     __type: "GetFolderRequest:#Exchange",
     FolderShape: {

--- a/app/logic/Mail/OWA/Request/OWAFolderRequests.ts
+++ b/app/logic/Mail/OWA/Request/OWAFolderRequests.ts
@@ -185,7 +185,7 @@ export function owaMoveEntireFolderRequest(sourceFolderID: string, newParentFold
   });
 }
 
-export function owaCreateNewFolderRequest(name: string, parentFolderID: string): OWARequest {
+export function owaCreateNewSubFolderRequest(name: string, parentFolderID: string): OWARequest {
   return new OWARequest("CreateFolderJsonRequest", {
     __type: "CreateFolderRequest:#Exchange",
     ParentFolderId: {
@@ -193,6 +193,24 @@ export function owaCreateNewFolderRequest(name: string, parentFolderID: string):
       BaseFolderId: {
         __type: "FolderId:#Exchange",
         Id: parentFolderID,
+      },
+    },
+    Folders: [{
+      __type: "Folder:#Exchange",
+      FolderClass: "IPF.Note",
+      DisplayName: name,
+    }],
+  });
+}
+
+export function owaCreateNewTopLevelFolderRequest(name: string): OWARequest {
+  return new OWARequest("CreateFolderJsonRequest", {
+    __type: "CreateFolderRequest:#Exchange",
+    ParentFolderId: {
+      __type: "TargetFolderId:#Exchange",
+      BaseFolderId: {
+        __type: "DistinguishedFolderId:#Exchange",
+        Id: "msgfolderroot",
       },
     },
     Folders: [{

--- a/app/logic/Mail/OWA/Request/OWARequest.ts
+++ b/app/logic/Mail/OWA/Request/OWARequest.ts
@@ -1,0 +1,17 @@
+export default class OWARequest {
+  readonly __type: string;
+  readonly Header = {
+    __type: "JsonRequestHeaders:#Exchange",
+    RequestServerVersion: "Exchange2013",
+  };
+  Body: any;
+
+  /**
+   * @param type __type
+   * @param body Body
+   */
+  constructor(type: string, body?: any) {
+    this.__type = type + ":#Exchange";
+    this.Body = body;
+  }
+}

--- a/app/logic/Mail/OWA/Request/OWASubscribeToNotificationRequest.ts
+++ b/app/logic/Mail/OWA/Request/OWASubscribeToNotificationRequest.ts
@@ -1,0 +1,27 @@
+import OWARequest from "./OWARequest";
+
+export default class OWASubscribeToNotificationRequest extends OWARequest {
+  readonly subscriptionData = [{
+    __type: "SubscriptionData:#Exchange",
+    SubscriptionId: "HierarchyNotification",
+    Parameters: {
+      __type: "SubscriptionParameters:#Exchange",
+      NotificationType: "HierarchyNotification",
+    },
+  }, {
+    __type: "SubscriptionData:#Exchange",
+    SubscriptionId: "NewMailNotification",
+    Parameters: {
+      __type: "SubscriptionParameters:#Exchange",
+      NotificationType: "NewMailNotification",
+    },
+  }];
+
+  get type() {
+    return "SubscribeToNotification";
+  }
+
+  constructor() {
+    super("NotificationSubscribeJsonRequest");
+  }
+}

--- a/app/logic/Mail/OWA/Request/OWAUpdateItemRequest.ts
+++ b/app/logic/Mail/OWA/Request/OWAUpdateItemRequest.ts
@@ -1,9 +1,6 @@
-export default class OWAUpdateItemRequest {
-  readonly __type = "UpdateItemJsonRequest:#Exchange";
-  readonly Header = {
-    __type: "JsonRequestHeaders:#Exchange",
-    RequestServerVersion: "Exchange2013",
-  };
+import OWARequest from "./OWARequest";
+
+export default class OWAUpdateItemRequest extends OWARequest {
   Body: any = {
     __type: "UpdateItemRequest:#Exchange",
     ConflictResolution: "AlwaysOverwrite",
@@ -16,7 +13,8 @@ export default class OWAUpdateItemRequest {
     }],
   };
 
-  constructor(id: string, attributes?: {[key: string]: string | boolean}) {
+  constructor(id: string, attributes?: { [key: string]: string | boolean }) {
+    super("UpdateItemJsonRequest", "JsonRequestHeaders");
     this.itemChange.ItemId.Id = id;
     Object.assign(this.Body, attributes);
   }


### PR DESCRIPTION
Refactoring only. No functional changes.

* The OWA implementation files are very long, but mostly because of the JSON literal objects that we need to send as requests to the server.
* Move these into separate files in Request/ subdir
* We already have existing `*Request` classes, but:
  * They don't have a common superclass
  * Adding the parameter in the constructor makes these JSON objects much more difficult to read.
  * When the requests are not classes, but inline JSON literal, they are much easier to read. I would like to preserve that
* Therefore, I have decided to put them into functions (not classes). This allows to keep them as literals *with their parameter*.
* Nonethless, a common class for requests would be nice. Plus, the header is very repetitive and can be factored out. Only the function name and the body changes.
* I kept the existing generic Create/UpdateRequest classes.

Advantages:
* The OWA implementation files are considerably smaller, making it easier to navigate in them and to concentrate on the parts that are important.
* `OWAFolder` and `OWACalendar` are both **less than half the size** now, but still contain all of the logic as before. Only the JSON literals are moved out.

Disadvantages:
* If you need to see or modify the JSON request sent to the server, you need to open another file. That's inconvenient. (However, the penalty is only when you actually need to change the server request, and not for any other changes.)
* The results of the server functions are still very dependent on the request, obviously. This didn't change. It just becomes more obvious now.
