### PR TITLE
Invitations: Allow responding to invitations using iMIP messages

### DIFF
--- a/app/frontend/Calendar/Invitation.svelte
+++ b/app/frontend/Calendar/Invitation.svelte
@@ -5,7 +5,7 @@
       <DisplayEvent event={message.event} />
     {/if}
   {:else if message.scheduling}
-    {#await message.loadEvent()}
+    {#await loadEvent()}
       Loading event...
     {:then}
       Event loaded
@@ -16,6 +16,13 @@
   {/if}
   {#if message.scheduling == Scheduling.Request}
     <hbox>
+      {#if selectedCalendar}
+        <select value={selectedCalendar} disabled={calendars.length < 2}>
+          {#each calendars as calendar}
+            <option value={calendar}>{calendar.name}</option>
+          {/each}
+        </select>
+      {/if}
       <Button label={$t`Accept`} onClick={onAccept} />
       <Button label={$t`Tentative`} onClick={onTentative} />
       <Button label={$t`Decline`} onClick={onDecline} />
@@ -28,12 +35,27 @@
   import { Scheduling, ResponseType, type Responses } from "../../logic/Calendar/Invitation";
   import DisplayEvent from "./DisplayEvent.svelte";
   import Button from "../Shared/Button.svelte";
-  import { t } from "../../l10n/l10n";
+  import { gt, t } from "../../l10n/l10n";
 
   export let message: EMail;
+  let calendars: Calendar[] = [];
+  let selectedCalendar: Calendar | undefined;
+
+  $: if (message.event) {
+    loadCalendars();
+  }
+
+  async function loadEvent() {
+    await message.loadEvent();
+    loadCalendars();
+  }
+  function loadCalendars() {
+    calendars = message.getUpdateCalendars();
+    selectedCalendar = calendars[0];
+  }
 
   async function respond(response: Responses) {
-    await message.respondToInvitation(response);
+    await selectedCalendar.respondToInvitation(message, response);
   }
   async function onAccept() {
     await respond(ResponseType.Accept);

--- a/app/logic/Calendar/ActiveSync/ActiveSyncEvent.ts
+++ b/app/logic/Calendar/ActiveSync/ActiveSyncEvent.ts
@@ -182,7 +182,7 @@ export class ActiveSyncEvent extends Event {
       },
     };
     await this.calendar.account.callEAS("MeetingResponse", request);
-    await super.sendInvitationResponse(response); // needs 16.x to do this automatically
+    await this.calendar.account.sendInvitationResponse(this, response); // needs 16.x to do this automatically
   }
 }
 

--- a/app/logic/Calendar/Calendar.ts
+++ b/app/logic/Calendar/Calendar.ts
@@ -1,12 +1,16 @@
 import { Account } from "../Abstract/Account";
 import { Event } from "./Event";
+import { Scheduling, ResponseType, type Responses } from "./Invitation";
+import type { EMail } from "../Mail/EMail";
 import { appGlobal } from "../app";
+import { assert } from "../util/util";
 import { Collection, ArrayColl } from "svelte-collections";
 import { ICSProcessor } from "./ICSProcessor";
 
 export class Calendar extends Account {
   readonly protocol: string = "calendar-local";
   readonly events = new ArrayColl<Event>();
+  readonly account: Account = null;
   storage: CalendarStorage | null = null;
   syncState: string | null = null;
 
@@ -23,6 +27,30 @@ export class Calendar extends Account {
       event.fillRecurrences(endDate);
     }
     return this.events;
+  }
+
+  async respondToInvitation(email: EMail, response: Responses) {
+    assert(email.scheduling == Scheduling.Request, "Only invitations can be responded to");
+    let event = this.events.find(event => event.calUID == email.event.calUID);
+    if (!event) {
+      event = this.newEvent();
+      event.copyFrom(email.event);
+      event.startTime = email.event.startTime;
+      event.endTime = email.event.endTime;
+      event.recurrenceRule = email.event.recurrenceRule;
+      event.response = ResponseType.NoResponseReceived;
+      this.events.add(event);
+      if (event.recurrenceRule) {
+        event.fillRecurrences(new Date(Date.now() + 1e11));
+      }
+    }
+    let participant = event.participants.find(participant => participant.emailAddress == email.folder.account.emailAddress);
+    if (participant) {
+      event.response = participant.response = response;
+      await event.save();
+      await email.folder.account.sendInvitationResponse(email.event, response);
+    }
+    /* else add participant? */
   }
 
   async save(): Promise<void> {

--- a/app/logic/Calendar/Event.ts
+++ b/app/logic/Calendar/Event.ts
@@ -1,7 +1,7 @@
 import type { Calendar } from "./Calendar";
 import type { Participant } from "./Participant";
 import type { RecurrenceRule } from "./RecurrenceRule";
-import { ResponseType, type Responses, ParticipationStatus, type iCalMethod } from "./Invitation";
+import { ResponseType, type Responses } from "./Invitation";
 import { appGlobal } from "../app";
 import { Observable, notifyChangedAccessor, notifyChangedProperty } from "../util/Observable";
 import { Lock } from "../util/Lock";
@@ -201,61 +201,6 @@ export class Event extends Observable {
     await accounts[0].sendInvitationResponse(this, response);
   }
 
-  /* Returns an icalEvent object suitable for NodeMailer */
-  getNMical(method?: iCalMethod): { method: iCalMethod, content: string } | null {
-    if (!method) {
-      return null;
-    }
-    /* We have to special-case RRULE as it contains ";"s
-     * which must not be escaped as normal text values would */
-    const lines: (string | string[])[] = [];
-    lines.push(["BEGIN", "VCALENDAR"]);
-    lines.push(["METHOD", method]);
-    lines.push(["VERSION", "2.0"]);
-    lines.push(["PRODID", "-//Beonex//Parula//EN"]);
-    lines.push(["BEGIN", "VEVENT"]);
-    lines.push(["DTSTAMP", date2ical(new Date(), false)]);
-    lines.push(["UID", this.calUID]);
-    if (this.title) {
-      lines.push(["SUMMARY", this.title]);
-    }
-    if (this.descriptionText) {
-      lines.push(["DESCRIPTION", this.descriptionText]);
-    }
-    const dateParts = ["VALUE", this.allDay ? "DATE" : "DATE-TIME", "TZID", Intl.DateTimeFormat().resolvedOptions().timeZone];
-    lines.push(["DTSTART", ...dateParts, date2ical(this.startTime, this.allDay)]);
-    lines.push(["DTEND", ...dateParts, date2ical(this.endTime, this.allDay)]);
-    if (this.location) {
-      lines.push(["LOCATION", this.location]);
-    }
-    let organizer = this.participants.find(participant => participant.response == ResponseType.Organizer);
-    if (organizer) {
-      lines.push(["ORGANIZER", "MAILTO:" + organizer.emailAddress]);
-    }
-    if (this.recurrenceRule) {
-      lines.push(this.recurrenceRule.getCalString() + "\r\n");
-    }
-    for (let participant of this.participants) {
-      switch (participant.response) {
-      case ResponseType.Organizer:
-        lines.push(["ATTENDEE", "ROLE", "CHAIR", "PARTSTAT", "ACCEPTED", "CN", participant.name, "MAILTO:" + participant.emailAddress]);
-        break;
-      case ResponseType.Tentative:
-      case ResponseType.Accept:
-      case ResponseType.Decline:
-        lines.push(["ATTENDEE", "PARTSTAT", ParticipationStatus[participant.response], "CN", participant.name, "MAILTO:" + participant.emailAddress]);
-        break;
-      default:
-        lines.push(["ATTENDEE", "RSVP", "TRUE", "CN", participant.name, "MAILTO:" + participant.emailAddress]);
-        break;
-      }
-    }
-    lines.push(["END", "VEVENT"]);
-    lines.push(["END", "VCALENDAR"]);
-    const content = lines.map(line2ical).join("");
-    return { method, content };
-  }
-
   /**
    * Ensures that all recurring instances exist up to the provided date.
    * Must only be called on recurring master events.
@@ -311,42 +256,6 @@ export class Event extends Observable {
       this.calendar.storage.deleteEvent(previous).catch(this.calendar.errorCallback);
     }
   }
-}
-
-function line2ical(line: string | string[]): string {
-  if (typeof line == "string") {
-    return line;
-  }
-  let text = line.shift();
-  let value = line.pop();
-  while (line.length) {
-    text += ";" + line.shift() + "=" + escaped(line.shift(), true);
-  }
-  text += ":" + escaped(value, false);
-  // Lines longer than 75 octets should be folded.
-  // XXX should use TextEncoder to count octets.
-  return text.match(/.{1,75}/gu).join("\r\n ") + "\r\n";
-}
-
-function date2ical(date: Date, allDay: boolean): string {
-  if (!allDay) {
-    return date.toISOString().replace(/-|:|\..../g, "");
-  }
-  return String(date.getFullYear()) + String(date.getMonth() + 1).padStart(2, "0") + String(date.getDate()).padStart(2, "0");
-}
-
-function escaped(s: string, quote: boolean): string {
-  if (quote) {
-    // param-value isn't supposed to include these at all;
-    // maybe we should just delete them?
-    s = s.replace(/["\\]/g, "\\$&").replace(/\r\n?|\n/g, "\\n");
-    if (/[\\:;,]/.test(s)) {
-      s = `"${s}"`;
-    }
-  } else {
-    s = s.replace(/[\\;,]/g, "\\$&").replace(/\r\n?|\n/g, "\\n");
-  }
-  return s;
 }
 
 const k1Day = 86400;

--- a/app/logic/Calendar/ICalGenerator.ts
+++ b/app/logic/Calendar/ICalGenerator.ts
@@ -1,5 +1,6 @@
 import type { Event } from "./Event";
 import { ResponseType, ParticipationStatus, type iCalMethod } from "./Invitation";
+import { appName } from "../build";
 
 export function getNMical(event: Event, method?: iCalMethod): { method: iCalMethod, content: string } | null {
   if (!event || !method) {
@@ -11,7 +12,7 @@ export function getNMical(event: Event, method?: iCalMethod): { method: iCalMeth
   lines.push(["BEGIN", "VCALENDAR"]);
   lines.push(["METHOD", method]);
   lines.push(["VERSION", "2.0"]);
-  lines.push(["PRODID", "-//Beonex//Parula//EN"]);
+  lines.push(["PRODID", `-//Beonex//${appName}//EN`]);
   lines.push(["BEGIN", "VEVENT"]);
   lines.push(["DTSTAMP", date2ical(new Date(), false)]);
   lines.push(["UID", event.calUID]);

--- a/app/logic/Calendar/ICalGenerator.ts
+++ b/app/logic/Calendar/ICalGenerator.ts
@@ -1,0 +1,92 @@
+import type { Event } from "./Event";
+import { ResponseType, ParticipationStatus, type iCalMethod } from "./Invitation";
+
+export function getNMical(event: Event, method?: iCalMethod): { method: iCalMethod, content: string } | null {
+  if (!event || !method) {
+    return null;
+  }
+  /* We have to special-case RRULE as it contains ";"s
+   * which must not be escaped as normal text values would */
+  const lines: (string | string[])[] = [];
+  lines.push(["BEGIN", "VCALENDAR"]);
+  lines.push(["METHOD", method]);
+  lines.push(["VERSION", "2.0"]);
+  lines.push(["PRODID", "-//Beonex//Parula//EN"]);
+  lines.push(["BEGIN", "VEVENT"]);
+  lines.push(["DTSTAMP", date2ical(new Date(), false)]);
+  lines.push(["UID", event.calUID]);
+  if (event.title) {
+    lines.push(["SUMMARY", event.title]);
+  }
+  if (event.descriptionText) {
+    lines.push(["DESCRIPTION", event.descriptionText]);
+  }
+  const dateParts = ["VALUE", event.allDay ? "DATE" : "DATE-TIME", "TZID", Intl.DateTimeFormat().resolvedOptions().timeZone];
+  lines.push(["DTSTART", ...dateParts, date2ical(event.startTime, event.allDay)]);
+  lines.push(["DTEND", ...dateParts, date2ical(event.endTime, event.allDay)]);
+  if (event.location) {
+    lines.push(["LOCATION", event.location]);
+  }
+  let organizer = event.participants.find(participant => participant.response == ResponseType.Organizer);
+  if (organizer) {
+    lines.push(["ORGANIZER", "MAILTO:" + organizer.emailAddress]);
+  }
+  if (event.recurrenceRule) {
+    lines.push(event.recurrenceRule.getCalString() + "\r\n");
+  }
+  for (let participant of event.participants) {
+    switch (participant.response) {
+    case ResponseType.Organizer:
+      lines.push(["ATTENDEE", "ROLE", "CHAIR", "PARTSTAT", "ACCEPTED", "CN", participant.name, "MAILTO:" + participant.emailAddress]);
+      break;
+    case ResponseType.Tentative:
+    case ResponseType.Accept:
+    case ResponseType.Decline:
+      lines.push(["ATTENDEE", "PARTSTAT", ParticipationStatus[participant.response], "CN", participant.name, "MAILTO:" + participant.emailAddress]);
+      break;
+    default:
+      lines.push(["ATTENDEE", "RSVP", "TRUE", "CN", participant.name, "MAILTO:" + participant.emailAddress]);
+      break;
+    }
+  }
+  lines.push(["END", "VEVENT"]);
+  lines.push(["END", "VCALENDAR"]);
+  const content = lines.map(line2ical).join("");
+  return { method, content };
+}
+
+function line2ical(line: string | string[]): string {
+  if (typeof line == "string") {
+    return line;
+  }
+  let text = line.shift();
+  let value = line.pop();
+  while (line.length) {
+    text += ";" + line.shift() + "=" + escaped(line.shift(), true);
+  }
+  text += ":" + escaped(value, false);
+  // Lines longer than 75 octets should be folded.
+  // XXX should use TextEncoder to count octets.
+  return text.match(/.{1,75}/gu).join("\r\n ") + "\r\n";
+}
+
+function date2ical(date: Date, allDay: boolean): string {
+  if (!allDay) {
+    return date.toISOString().replace(/-|:|\..../g, "");
+  }
+  return String(date.getFullYear()) + String(date.getMonth() + 1).padStart(2, "0") + String(date.getDate()).padStart(2, "0");
+}
+
+function escaped(s: string, quote: boolean): string {
+  if (quote) {
+    // param-value isn't supposed to include these at all;
+    // maybe we should just delete them?
+    s = s.replace(/["\\]/g, "\\$&").replace(/\r\n?|\n/g, "\\n");
+    if (/[\\:;,]/.test(s)) {
+      s = `"${s}"`;
+    }
+  } else {
+    s = s.replace(/[\\;,]/g, "\\$&").replace(/\r\n?|\n/g, "\\n");
+  }
+  return s;
+}

--- a/app/logic/Calendar/Invitation.ts
+++ b/app/logic/Calendar/Invitation.ts
@@ -1,3 +1,4 @@
+export type iCalMethod = "CANCEL" | "REQUEST" | "REPLY";
 
 /**
  * For an inbox item that represents a scheduling message, the type of message:

--- a/app/logic/Mail/ActiveSync/ActiveSyncAccount.ts
+++ b/app/logic/Mail/ActiveSync/ActiveSyncAccount.ts
@@ -35,6 +35,7 @@ export class ActiveSyncAccount extends MailAccount {
   readonly protocol: string = "activesync";
   readonly port: number = 443;
   readonly tls = TLSSocketType.TLS;
+  readonly canSendInvitations: boolean = false;
   readonly pingsMRU = new ArrayColl<ActiveSyncPingable>();
   heartbeat = 60;
   maxPings = kMaxCount;

--- a/app/logic/Mail/EMail.ts
+++ b/app/logic/Mail/EMail.ts
@@ -86,7 +86,7 @@ export class EMail extends Message {
   /** For composer only. Optional. */
   identity: MailIdentity;
   /* Only used when constructing iMIP outgoing messages */
-  method: iCalMethod | undefined;
+  iCalMethod: iCalMethod | undefined;
 
   constructor(folder: Folder) {
     super();

--- a/app/logic/Mail/EMail.ts
+++ b/app/logic/Mail/EMail.ts
@@ -6,8 +6,9 @@ import type { Tag } from "./Tag";
 import { DeleteStrategy, type MailAccountStorage } from "./MailAccount";
 import { PersonUID, findOrCreatePersonUID } from "../Abstract/PersonUID";
 import type { MailIdentity } from "./MailIdentity";
+import type { Calendar } from "../Calendar/Calendar";
 import { Event } from "../Calendar/Event";
-import { Scheduling, ResponseType, type Responses, type iCalMethod } from "../Calendar/Invitation";
+import { Scheduling, type iCalMethod } from "../Calendar/Invitation";
 import { EMailProcessorList, ProcessingStartOn } from "./EMailProccessor";
 import { fileExtensionForMIMEType, blobToDataURL, assert, AbstractFunction } from "../util/util";
 import { gt } from "../../l10n/l10n";
@@ -198,39 +199,11 @@ export class EMail extends Message {
   async removeTagOnServer(tag: Tag) {
   }
 
-  async respondToInvitation(response: Responses): Promise<void> {
-    assert(this.scheduling == Scheduling.Request, "Only invitations can be responded to");
-    let event: Event;
-    for (let calendar of appGlobal.calendars) {
-      event = calendar.events.find(event => event.calUID == this.event.calUID);
-      if (event) {
-        break;
-      }
-    }
-    if (!event) {
-      let calendar = appGlobal.calendars.first;
-      event = calendar.newEvent();
-      event.copyFrom(this.event);
-      event.startTime = this.event.startTime;
-      event.endTime = this.event.endTime;
-      event.recurrenceRule = this.event.recurrenceRule;
-      event.response = ResponseType.NoResponseReceived;
-      calendar.events.add(event);
-      if (event.recurrenceRule) {
-        event.fillRecurrences(new Date(Date.now() + 1e11));
-      }
-    }
-    let participant = event.participants.find(participant => participant.emailAddress == this.folder.account.emailAddress);
-    if (participant) {
-      event.response = participant.response = response;
-      await event.save();
-      await this.sendInvitationResponse(response);
-    }
-    /* else add participant? */
-  }
-
-  protected async sendInvitationResponse(response: Responses): Promise<void> {
-    await this.folder.account.sendInvitationResponse(this.event, response);
+  getUpdateCalendars(): Calendar[] {
+    assert(this.scheduling && this.event, "Must have event to find calendar");
+    let validCalendars = appGlobal.calendars.contents.filter(calendar => !calendar.account);
+    let foundCalendars = validCalendars.filter(calendar => calendar.events.some(event => event.calUID == this.event.calUID));
+    return this.scheduling == Scheduling.Request && !foundCalendars.length ? validCalendars : foundCalendars;
   }
 
   async loadEvent() {

--- a/app/logic/Mail/EWS/EWSAccount.ts
+++ b/app/logic/Mail/EWS/EWSAccount.ts
@@ -19,13 +19,14 @@ import { XML2JSON, type Json, JSON2XML } from "./XML2JSON";
 import { Throttle } from "../../util/Throttle";
 import { Semaphore } from "../../util/Semaphore";
 import { sanitize } from "../../../../lib/util/sanitizeDatatypes";
-import { assert, blobToBase64, ensureArray, NotReached } from "../../util/util";
+import { assert, blobToBase64, ensureArray, NotReached, NotSupported } from "../../util/util";
 import { gt } from "../../../l10n/l10n";
 
 export class EWSAccount extends MailAccount {
   readonly protocol: string = "ews";
   readonly port: number = 443;
   readonly tls = TLSSocketType.TLS;
+  readonly canSendInvitations: boolean = false;
   readonly folderMap = new Map<string, EWSFolder>;
   throttle = new Throttle(50, 1);
   semaphore = new Semaphore(20);
@@ -89,6 +90,9 @@ export class EWSAccount extends MailAccount {
   }
 
   async send(email: EMail): Promise<void> {
+    if (email.method) {
+      throw new NotSupported("Please use Exchange APIs to send iMIP messages");
+    }
     assert(email.folder?.id, "Need folder to save the sent email in");
     let request = new EWSCreateItemRequest({ m$SavedItemFolderId: { t$FolderId: { Id: email.folder.id } }, MessageDisposition: "SendAndSaveCopy" });
     request.addField("Message", "ItemClass", "IPM.Note", "item:ItemClass");

--- a/app/logic/Mail/EWS/EWSAccount.ts
+++ b/app/logic/Mail/EWS/EWSAccount.ts
@@ -28,6 +28,7 @@ export class EWSAccount extends MailAccount {
   readonly tls = TLSSocketType.TLS;
   readonly canSendInvitations: boolean = false;
   readonly folderMap = new Map<string, EWSFolder>;
+  calendar: EWSCalendar | void;
   throttle = new Throttle(50, 1);
   semaphore = new Semaphore(20);
 
@@ -70,17 +71,17 @@ export class EWSAccount extends MailAccount {
     addressbook.account = this;
     await addressbook.listContacts();
 
-    let calendar = appGlobal.calendars.find((calendar: EWSCalendar) => calendar.protocol == "calendar-ews" && calendar.url == this.url && calendar.username == this.username) as EWSCalendar | void;
-    if (!calendar) {
-      calendar = newCalendarForProtocol("calendar-ews") as EWSCalendar;
-      calendar.name = this.name;
-      calendar.url = this.url;
-      calendar.username = this.emailAddress;
-      calendar.workspace = this.workspace;
-      appGlobal.calendars.add(calendar);
+    this.calendar = appGlobal.calendars.find((calendar: EWSCalendar) => calendar.protocol == "calendar-ews" && calendar.url == this.url && calendar.username == this.username) as EWSCalendar | void;
+    if (!this.calendar) {
+      this.calendar = newCalendarForProtocol("calendar-ews") as EWSCalendar;
+      this.calendar.name = this.name;
+      this.calendar.url = this.url;
+      this.calendar.username = this.emailAddress;
+      this.calendar.workspace = this.workspace;
+      appGlobal.calendars.add(this.calendar);
     }
-    calendar.account = this;
-    await calendar.listEvents();
+    this.calendar.account = this;
+    await this.calendar.listEvents();
 
     await this.streamNotifications();
   }

--- a/app/logic/Mail/EWS/EWSAccount.ts
+++ b/app/logic/Mail/EWS/EWSAccount.ts
@@ -90,7 +90,7 @@ export class EWSAccount extends MailAccount {
   }
 
   async send(email: EMail): Promise<void> {
-    if (email.method) {
+    if (email.iCalMethod) {
       throw new NotSupported("Please use Exchange APIs to send iMIP messages");
     }
     assert(email.folder?.id, "Need folder to save the sent email in");

--- a/app/logic/Mail/MailAccount.ts
+++ b/app/logic/Mail/MailAccount.ts
@@ -90,7 +90,7 @@ export class MailAccount extends Account {
     assert(organizer, "Invitation should have an organizer");
     let email = this.newEMailFrom();
     email.to.add(organizer);
-    email.method = "REPLY";
+    email.iCalMethod = "REPLY";
     email.event = new Event();
     email.event.copyFrom(invitation);
     email.event.startTime = invitation.startTime;

--- a/app/logic/Mail/OWA/OWAAccount.ts
+++ b/app/logic/Mail/OWA/OWAAccount.ts
@@ -20,13 +20,14 @@ import { Semaphore } from "../../util/Semaphore";
 import { Throttle } from "../../util/Throttle";
 import { notifyChangedProperty } from "../../util/Observable";
 import { sanitize } from "../../../../lib/util/sanitizeDatatypes";
-import { assert, blobToBase64 } from "../../util/util";
+import { assert, blobToBase64, NotSupported } from "../../util/util";
 import { gt } from "../../../l10n/l10n";
 
 export class OWAAccount extends MailAccount {
   readonly protocol: string = "owa";
   readonly port: number = 443;
   readonly tls = TLSSocketType.TLS;
+  readonly canSendInvitations: boolean = false;
   readonly folderMap = new Map<string, OWAFolder>;
   /**
    * We get notifications for folders we're not interested in.
@@ -126,6 +127,9 @@ export class OWAAccount extends MailAccount {
   }
 
   async send(email: EMail): Promise<void> {
+    if (email.method) {
+      throw new NotSupported("Please use Exchange APIs to send iMIP messages");
+    }
     assert(email.folder?.id, "Need folder to save the sent email in");
     let request = new OWACreateItemRequest({ SavedItemFolderId: { __type: "TargetFolderId:#Exchange", BaseFolderId: { __type: "FolderId:#Exchange", Id: email.folder.id } }, MessageDisposition: "SendAndSaveCopy" });
     request.addField("Message", "ItemClass", "IPM.Note", "item:ItemClass");

--- a/app/logic/Mail/OWA/OWAAccount.ts
+++ b/app/logic/Mail/OWA/OWAAccount.ts
@@ -29,6 +29,7 @@ export class OWAAccount extends MailAccount {
   readonly tls = TLSSocketType.TLS;
   readonly canSendInvitations: boolean = false;
   readonly folderMap = new Map<string, OWAFolder>;
+  calendar: OWACalendar | void;
   /**
    * We get notifications for folders we're not interested in.
    * We filter them out by checking that the parent exists.
@@ -99,17 +100,17 @@ export class OWAAccount extends MailAccount {
     addressbook.account = this;
     await addressbook.listContacts();
 
-    let calendar = appGlobal.calendars.find((calendar: OWACalendar) => calendar.protocol == "calendar-owa" && calendar.url == this.url && calendar.username == this.username) as OWACalendar | void;
-    if (!calendar) {
-      calendar = newCalendarForProtocol("calendar-owa") as OWACalendar;
-      calendar.name = this.name;
-      calendar.url = this.url;
-      calendar.username = this.emailAddress;
-      calendar.workspace = this.workspace;
-      appGlobal.calendars.add(calendar);
+    this.calendar = appGlobal.calendars.find((calendar: OWACalendar) => calendar.protocol == "calendar-owa" && calendar.url == this.url && calendar.username == this.username) as OWACalendar | void;
+    if (!this.calendar) {
+      this.calendar = newCalendarForProtocol("calendar-owa") as OWACalendar;
+      this.calendar.name = this.name;
+      this.calendar.url = this.url;
+      this.calendar.username = this.emailAddress;
+      this.calendar.workspace = this.workspace;
+      appGlobal.calendars.add(this.calendar);
     }
-    calendar.account = this;
-    await calendar.listEvents();
+    this.calendar.account = this;
+    await this.calendar.listEvents();
 
     let request = new OWASubscribeToNotificationRequest();
     await this.callOWA(request);

--- a/app/logic/Mail/OWA/OWAAccount.ts
+++ b/app/logic/Mail/OWA/OWAAccount.ts
@@ -127,7 +127,7 @@ export class OWAAccount extends MailAccount {
   }
 
   async send(email: EMail): Promise<void> {
-    if (email.method) {
+    if (email.iCalMethod) {
       throw new NotSupported("Please use Exchange APIs to send iMIP messages");
     }
     assert(email.folder?.id, "Need folder to save the sent email in");

--- a/app/logic/Mail/SMTP/CreateMIME.ts
+++ b/app/logic/Mail/SMTP/CreateMIME.ts
@@ -28,6 +28,7 @@ export class CreateMIME {
       bcc: CreateMIME.getRecipients(email.bcc),
       text: email.text,
       html: doHTML ? email.html : null,
+      icalEvent: email.event?.getNMical(email.method),
       attachDataUrls: true,
       attachments: await CreateMIME.getAttachments(email),
       headers: email.headers.contentKeyValues(),

--- a/app/logic/Mail/SMTP/CreateMIME.ts
+++ b/app/logic/Mail/SMTP/CreateMIME.ts
@@ -1,6 +1,7 @@
 import type { EMail } from "../EMail";
 import type { PersonUID } from "../../Abstract/PersonUID";
 import { Attachment , ContentDisposition } from "../../Abstract/Attachment";
+import { getNMical } from "../../Calendar/ICalGenerator";
 import { appGlobal } from "../../app";
 import { getLocalStorage } from "../../../frontend/Util/LocalStorage";
 import { blobToBase64 } from "../../util/util";
@@ -28,7 +29,7 @@ export class CreateMIME {
       bcc: CreateMIME.getRecipients(email.bcc),
       text: email.text,
       html: doHTML ? email.html : null,
-      icalEvent: email.event?.getNMical(email.method),
+      icalEvent: getNMical(email.event, email.iCalMethod),
       attachDataUrls: true,
       attachments: await CreateMIME.getAttachments(email),
       headers: email.headers.contentKeyValues(),


### PR DESCRIPTION
In particular, all accounts can now send invitation responses.

Still to do:
- [ ] Send invitations
  - [ ] IMAP
  - [ ] ActiveSync
  - [X] EWS
  - [X] OWA
- [X] Recognise invitation email
- [X] Display invitation data
- [X] Accept or decline invitation
- [X] Recognise invitation event
- [X] Change invitation acceptance
- [X] Recognise acceptance email
- [ ] Update meeting participation
  - [ ] IMAP
  - [X] ActiveSync
  - [X] EWS
  - [X] OWA