### PR TITLE
Mac: Native style title bar (#410)

### DIFF
--- a/app/frontend/MainWindow/WindowHeader.svelte
+++ b/app/frontend/MainWindow/WindowHeader.svelte
@@ -39,10 +39,10 @@
 
   // #if [WEBMAIL]
   // @ts-ignore
-  let isMacOS = false; // don't style for Web Mail
+  const isMacOS = false; // don't style for Web Mail
   // #else
   // @ts-ignore
-  let isMacOS = getOSName() == "macintosh" ? true : false;
+  const isMacOS = getOSName() == "macintosh" ? true : false;
   // #endif
 
   function onMinimize() {

--- a/app/frontend/MainWindow/WindowHeader.svelte
+++ b/app/frontend/MainWindow/WindowHeader.svelte
@@ -1,4 +1,4 @@
-<hbox class="window-header">
+<hbox class="window-header" class:mac={isMacOS}>
   <vbox class="app-logo">
     {#if appName == "Mustang"}
     <Icon data={logo} size="20px" />
@@ -32,9 +32,18 @@
   import logo from '../asset/icon/general/logo.svg?raw';
   import MinimizeIcon from 'lucide-svelte/icons/minus';
   import XIcon from 'lucide-svelte/icons/x';
+  import { getOSName } from "../Util/util";
   import { t } from "../../l10n/l10n";
 
   export let selectedApp: MustangApp;
+
+  // #if [WEBMAIL]
+  // @ts-ignore
+  let isMacOS = false; // don't style for Web Mail
+  // #else
+  // @ts-ignore
+  let isMacOS = getOSName() == "macintosh" ? true : false;
+  // #endif
 
   function onMinimize() {
     appGlobal.remoteApp.minimizeMainWindow();
@@ -91,5 +100,13 @@
   .window-header :global(.search:not(.has-search) input) {
     background-color: transparent;
     color: var(--inverted-fg);
+  }
+
+  .mac .app-logo {
+    margin-inline-start: 80px;
+    width: 15px;
+  }
+  .mac .right {
+    display: none;
   }
 </style>

--- a/app/frontend/MainWindow/WindowHeader.svelte
+++ b/app/frontend/MainWindow/WindowHeader.svelte
@@ -102,6 +102,7 @@
     color: var(--inverted-fg);
   }
 
+  /* Styles for Mac */
   .mac .app-logo {
     margin-inline-start: 80px;
     width: 15px;

--- a/app/frontend/MainWindow/WindowHeader.svelte
+++ b/app/frontend/MainWindow/WindowHeader.svelte
@@ -1,4 +1,4 @@
-<hbox class="window-header" class:mac={isMacOS}>
+<hbox class="window-header" class:mac>
   <vbox class="app-logo">
     {#if appName == "Mustang"}
     <Icon data={logo} size="20px" />
@@ -33,17 +33,13 @@
   import MinimizeIcon from 'lucide-svelte/icons/minus';
   import XIcon from 'lucide-svelte/icons/x';
   import { getOSName } from "../Util/util";
+  import { webMail } from "../../logic/build";
   import { t } from "../../l10n/l10n";
 
   export let selectedApp: MustangApp;
 
-  // #if [WEBMAIL]
-  // @ts-ignore
-  const isMacOS = false; // don't style for Web Mail
-  // #else
-  // @ts-ignore
-  const isMacOS = getOSName() == "macintosh" ? true : false;
-  // #endif
+  // Enable Mac Styles
+  const mac = (!webMail && getOSName() == "macintosh") ? true : false;
 
   function onMinimize() {
     appGlobal.remoteApp.minimizeMainWindow();

--- a/app/frontend/Util/util.ts
+++ b/app/frontend/Util/util.ts
@@ -39,3 +39,21 @@ export async function stringToDataURL(mimetype: string, content: string): Promis
     reader.readAsDataURL(new Blob([bytes], { type: mimetype + ";charset=utf-8" }));
   });
 }
+
+/**
+ * Gets the OS using the userAgent string.
+ * @returns os name
+ */
+export function getOSName() {
+  let userAgent = navigator.userAgent.toLocaleLowerCase();
+  if (userAgent.includes("windows")) {
+    return "windows";
+  }
+  if (userAgent.includes("macintosh")) {
+    return "macintosh";
+  }
+  if (userAgent.includes("linux")) {
+    return "linux";
+  }
+  return "unknown";
+}

--- a/e2/src/main/index.ts
+++ b/e2/src/main/index.ts
@@ -17,7 +17,7 @@ function createWindow(): void {
       height: 950,
       show: false,
       autoHideMenuBar: true,
-      titleBarStyle: process.platform == 'darwin'? 'hiddenInset' : 'customButtonsOnHover',
+      titleBarStyle: process.platform == 'darwin' ? 'hiddenInset' : 'customButtonsOnHover',
       titleBarOverlay: true,
       frame: false,
       ...(process.platform === 'linux' ? { icon } : {}),

--- a/e2/src/main/index.ts
+++ b/e2/src/main/index.ts
@@ -17,7 +17,7 @@ function createWindow(): void {
       height: 950,
       show: false,
       autoHideMenuBar: true,
-      titleBarStyle: 'customButtonsOnHover',
+      titleBarStyle: process.platform == 'darwin'? 'hiddenInset' : 'customButtonsOnHover',
       titleBarOverlay: true,
       frame: false,
       ...(process.platform === 'linux' ? { icon } : {}),


### PR DESCRIPTION
<img width="1440" alt="圖片" src="https://github.com/user-attachments/assets/a5e3546b-4fd1-45c9-85e7-38a26de16764" />

- Add styles for MacOS only
  - Move app logo to the right of the traffic light
  - Move title closer to the logo
  - Remove Mustang Minimize and Close buttons
- Only enable if not Webmail and the OS name is "macintosh"

Haven't tested if it affects other OS builds yet.