### PR TITLE
Mail Composer: Set image size to window and add the ability to resize #414

### DIFF
--- a/app/frontend/Shared/Editor/HTMLEditor.svelte
+++ b/app/frontend/Shared/Editor/HTMLEditor.svelte
@@ -8,6 +8,7 @@
   import LinkFeature from '@tiptap/extension-link';
   import ImageFeature from '@tiptap/extension-image';
   import CodeWordFeature from '@tiptap/extension-code';
+  import ImageResize from 'tiptap-extension-resize-image';
   import { SplitBlockquote } from './SplitBlockquote';
   import { Footer } from './Footer';
   import { BoldStar, ItalicSlash } from './StdConventions';
@@ -39,9 +40,12 @@
         CodeWordFeature,
         SplitBlockquote,
         Footer,
-        ImageFeature.configure({
+        ImageResize.configure({
           allowBase64: true,
           inline: true,
+          HTMLAttributes: {
+            style: "max-width: 90%; height: auto; margin: 10px;"
+          },
         }),
         BoldStar,
         ItalicSlash,

--- a/app/package.json
+++ b/app/package.json
@@ -58,6 +58,7 @@
     "svelte-collections": "^1.2.4",
     "svelte-icon": "^2.0.0",
     "timezone-picker-svelte": "^1.0.2",
+    "tiptap-extension-resize-image": "^1.2.1",
     "ws": "^8.16.0"
   },
   "devDependencies": {


### PR DESCRIPTION
- Set image size to window and add the ability to resize
- You can also align the Image
- The sent result is the same