### PR TITLE
Use correct tag when creating attachments to messages #466

### DIFF
--- a/app/logic/Mail/EWS/EWSAccount.ts
+++ b/app/logic/Mail/EWS/EWSAccount.ts
@@ -99,7 +99,7 @@ export class EWSAccount extends MailAccount {
     }, "item:Body");
     if (email.attachments.hasItems) {
       request.addField("Message", "Attachments", {
-        t$ItemAttachment: await Promise.all(email.attachments.contents.map(async attachment => ({
+        t$FileAttachment: await Promise.all(email.attachments.contents.map(async attachment => ({
           t$Name: attachment.filename,
           t$ContentType: attachment.mimeType,
           t$ContentID: attachment.contentID,


### PR DESCRIPTION
(I was confused with the UI and didn't realise that drag-n-drop from the OS file manager is apparently the only working way to insert images. It's my least preferred way of inserting images... Anyway, the password went missing from the EWS account in my configuration for some reason, but I didn't realise that was wrong because the server UI always shows `••••••••` as a placeholder...)