### PR TITLE
Build: Open-Source licenses file is not in production build #476

### DIFF
--- a/app/frontend/Settings/About/Licenses.svelte
+++ b/app/frontend/Settings/About/Licenses.svelte
@@ -13,7 +13,7 @@
 </div>
 
 <iframe 
-  src="" 
+  src={attributionURL}
   title="Licenses" sandbox=""
   bind:this={iframeE}
 />
@@ -24,11 +24,12 @@
   import T from '../../../l10n/T.svelte';
   import { fetchGzip } from "../../Util/util";
   import { onMount } from "svelte";
+  import attributionURL from "../../../public/attribution.txt.gz?url";
 
   let iframeE: HTMLIFrameElement;
 
   onMount(async () => {
-    iframeE.src = await fetchGzip(new URL("../attribution.txt.gz", import.meta.url).href);
+    iframeE.src = await fetchGzip(iframeE.src);
   });
 </script>
 

--- a/app/frontend/Settings/About/Licenses.svelte
+++ b/app/frontend/Settings/About/Licenses.svelte
@@ -12,12 +12,24 @@
   </T>
 </div>
 
-<iframe src="attribution.txt.gz" title="Licenses" sandbox="" />
+<iframe 
+  src="" 
+  title="Licenses" sandbox=""
+  bind:this={iframeE}
+/>
 
-<script>
+<script lang="ts">
   import { appName } from "../../../logic/build";
   import { t } from "../../../l10n/l10n";
   import T from '../../../l10n/T.svelte';
+  import { fetchGzip } from "../../Util/util";
+  import { onMount } from "svelte";
+
+  let iframeE: HTMLIFrameElement;
+
+  onMount(async () => {
+    iframeE.src = await fetchGzip(new URL("../attribution.txt.gz", import.meta.url).href);
+  });
 </script>
 
 <style>

--- a/app/frontend/Settings/About/Licenses.svelte
+++ b/app/frontend/Settings/About/Licenses.svelte
@@ -12,7 +12,7 @@
   </T>
 </div>
 
-<iframe src="public/attribution.txt.gz" title="Licenses" sandbox="" />
+<iframe src="attribution.txt.gz" title="Licenses" sandbox="" />
 
 <script>
   import { appName } from "../../../logic/build";

--- a/app/frontend/Util/util.ts
+++ b/app/frontend/Util/util.ts
@@ -57,3 +57,17 @@ export function getOSName() {
   }
   return "unknown";
 }
+
+/**
+ * Fetches and decompresses gzip files that are compressed
+ * @param url 
+ * @returns 
+ */
+export async function fetchGzip(url: string) {
+  let stream = (await fetch(url)).body;
+  let decompressedStream = stream.pipeThrough(
+    new DecompressionStream('gzip')
+  );
+  let blob = await new Response(decompressedStream).blob();
+  return URL.createObjectURL(blob);
+}

--- a/e2/electron.vite.config.ts
+++ b/e2/electron.vite.config.ts
@@ -42,5 +42,6 @@ export default defineConfig({
         disable: !production,
       }),
     ],
+    publicDir: '../../../app/public',
   }
 })

--- a/e2/electron.vite.config.ts
+++ b/e2/electron.vite.config.ts
@@ -43,6 +43,5 @@ export default defineConfig({
       }),
     ],
     publicDir: '../../../app/public',
-    base: './',
   }
 })

--- a/e2/electron.vite.config.ts
+++ b/e2/electron.vite.config.ts
@@ -43,5 +43,6 @@ export default defineConfig({
       }),
     ],
     publicDir: '../../../app/public',
+    base: './',
   }
 })


### PR DESCRIPTION
There were 3 problems that caused this bug:

1. The public assets were never copied to the dist folder because the default is '<root>/public' and in the case of `e2` it is `e2/public` which has no assets in there. I've set it to `../../../app/public`
2. The file was using the `file:///` url instead of HTTP which doesn't tell the browser it is a gzipped file and it needs to unzip it. I've implemented a `fetchGzip()` function for that and it fetches and unzips it. In development these static assets are served through HTTP so that's why there's no issue.
3. The URL is wrong in production when you set `public/attribution.txt.gz` it turn into `<root>/public/attribution.txt.gz` which is not the correct location in production since the static assets are copied to root and there's no public directory.

Attempts tried:

1. fetching the resource with HTTP and adding `Content-Encoding: gzip, [...other compressions]` and `Accept-Encoding: gzip, [...other compressions]`.
2. search a plugin to unzip or process zipped assets
3. search for a setting in Vite for zipped files
4. search for a setting for iframes
5. tried `config.base`  with `./`, `''`, `http://localhost:5454`, it seems like it doesn't change the URL for No.3
6. Also did `new URL(resource, import.meta.url).href` but that doesn't look nice