### PR TITLE
Branding: Linux: Use correct icon (#471)

### DIFF
--- a/e2/src/main/index.ts
+++ b/e2/src/main/index.ts
@@ -4,7 +4,7 @@ import { ipcMain } from 'electron/main';
 import { join } from 'path'
 import electronUpdater from 'electron-updater';
 import { electronApp, optimizer, is } from '@electron-toolkit/utils'
-import icon from '../../resources/icon.png?asset'
+import icon from '../../build/icon.png?asset'
 const { autoUpdater } = electronUpdater;
 
 function createWindow(): void {


### PR DESCRIPTION
- The imported icon was never changed with the correct icon file
- The resources folder indeed is for the `main` and `preload` folder but to continue using that folder we would have to copy the icon to that folder so I just pointed to the file in build folder.