### PR TITLE
Mac: WindowHeader: Styling to fix button overlap in RTL languages (#469)

### DIFF
--- a/app/frontend/MainWindow/WindowHeader.svelte
+++ b/app/frontend/MainWindow/WindowHeader.svelte
@@ -128,4 +128,10 @@
   .mac .right {
     display: none;
   }
+  :global([dir="rtl"]) .mac .app-logo {
+    margin-inline-start: 0px;
+  }
+  :global([dir="rtl"]) .mac .search-box {
+    padding-inline-end: 80px;
+  }
 </style>


### PR DESCRIPTION
- Styling to fix button over lap in RTL languages on Mac

<img width="1552" alt="圖片" src="https://github.com/user-attachments/assets/65b91889-4eb7-4e56-8877-98fdde353200" />
