### PR TITLE
Mac: WindowHeader: Styling for system RTL (#469)

### DIFF
--- a/app/frontend/MainWindow/WindowHeader.svelte
+++ b/app/frontend/MainWindow/WindowHeader.svelte
@@ -1,4 +1,4 @@
-<hbox class="window-header {osRTL ? "os-rtl" : ""}" class:mac
+<hbox class="window-header" class:os-rtl={osRTL} class:mac
   style="--workspace-color: {$selectedWorkspace?.color ?? "var(--windowheader-bg)"}">
   <vbox class="app-logo">
     {#if appName == "Mustang"}


### PR DESCRIPTION
- Fixes window header styling for when the system and app text directions are different

### Cases

1. System LTR, App LTR
<img width="1003" alt="圖片" src="https://github.com/user-attachments/assets/a9cc826c-f9e0-4f90-82ed-f72bab57d521" />

2. System LTR, App RTL
<img width="1003" alt="圖片" src="https://github.com/user-attachments/assets/13ca44c2-f2bd-4010-bfd1-e20763e0a38e" />

3. System RTL, App RTL
<img width="1003" alt="圖片" src="https://github.com/user-attachments/assets/6f399bf5-d463-4756-a1dd-aeb7da6f7ab9" />

4. System RTL, App LTR
<img width="1003" alt="圖片" src="https://github.com/user-attachments/assets/b8dc6839-2bb8-4310-9be4-ca6fb68e5def" />

