### PR TITLE
Polyfill global for frontend

### DIFF
--- a/app/l10n/l10n.ts
+++ b/app/l10n/l10n.ts
@@ -40,8 +40,6 @@ import sk from './locales/sk/messages.json';
 import th from './locales/th/messages.json';
 import tr from './locales/tr/messages.json';
 
-window.global = window; // Fix Stanza and getUILocale()
-
 /** Map of lang code to messages.
  * Lang codes: <https://www.wikiwand.com/en/List_of_ISO_639_language_codes> */
 const languageMessages = {

--- a/app/vite.config.ts
+++ b/app/vite.config.ts
@@ -22,7 +22,7 @@ export default defineConfig({
         PROPRIETARY: includeProprietary ? true : undefined,
       },
     }),
-    nodePolyfills({ include: ['buffer'], globals: { global: false, process: webMail } }),
+    nodePolyfills({ include: ['buffer'], globals: { global: true, process: webMail } }),
     svelte(),
     olm,
     sentryVitePlugin({


### PR DESCRIPTION
`window.global = window;` doesn't work when the file gets included by a test.