### PR TITLE
Mail: Load inline messages fix (#498)

### DIFF
--- a/app/logic/Mail/EMail.ts
+++ b/app/logic/Mail/EMail.ts
@@ -416,6 +416,8 @@ export class EMail extends Message {
     if (this._loadExternalImages == val) {
       return;
     }
+    // Load body again instead of setting _sanitizedHTML to null
+    // For adding CID specifically
     this.loadBody();
     this._loadExternalImages = val; // notifyChangedProperty triggers update
   }

--- a/app/logic/Mail/EMail.ts
+++ b/app/logic/Mail/EMail.ts
@@ -411,6 +411,14 @@ export class EMail extends Message {
     super.html = val;
     this.needToLoadBody = true;
   }
+  
+  set loadExternalImages(val: boolean) {
+    if (this._loadExternalImages == val) {
+      return;
+    }
+    this.loadBody();
+    this._loadExternalImages = val; // notifyChangedProperty triggers update
+  }
 
   async download() {
     throw new AbstractFunction();

--- a/backend/backend.ts
+++ b/backend/backend.ts
@@ -82,9 +82,9 @@ function createType3MessageFromType2Message(WWWAuthenticate, username, password)
   return createType3Message(decodeType2Message(WWWAuthenticate), username, password);
 }
 
-async function readFile(path: string): Promise<Uint8Array> {
+async function readFile(path: string): Promise<ArrayBufferLike> {
   let fileHandle = await fsPromises.open(path, "r");
-  let { buffer } = await fileHandle.read();
+  let { buffer } = await fileHandle.readFile();
   await fileHandle.close();
   return buffer;
 }


### PR DESCRIPTION
- Changed `FileHandle.read()` to `FileHandle.readFile()` because the buffer limit makes the image partially rendered
> buffer [<Buffer>](https://nodejs.org/api/buffer.html#class-buffer) | [<TypedArray>](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/TypedArray) | [<DataView>](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/DataView) A buffer that will be filled with the file data read. Default: Buffer.alloc(16384)

https://nodejs.org/api/fs.html#filehandlereadoptions
https://nodejs.org/api/fs.html#filehandlereadfileoptions

- Add a new `loadExternalImages(val: boolean)` to the one in `Messages.ts` sets `sanitizedHTML` to null and doesn't addCID back

https://github.com/mustang-im/mustang/blob/1d5fe19b4603f947285db3354250bbf01ce41a2a/app/logic/Abstract/Message.ts#L121-L127