### PR TITLE
Mail Composer: Newline vs. paragraph (#35)

### DIFF
--- a/app/frontend/Shared/Editor/HTMLEditor.svelte
+++ b/app/frontend/Shared/Editor/HTMLEditor.svelte
@@ -12,6 +12,7 @@
   import { SplitBlockquote } from './SplitBlockquote';
   import { Footer } from './Footer';
   import { BoldStar, ItalicSlash } from './StdConventions';
+  import { ParagraphNewLine } from './ParagraphNewLine';
   // import CodeBlockLowlightFeature from '@tiptap/extension-code-block-lowlight';
   // import { common as lowlightCommon, createLowlight } from 'lowlight'
   import { onMount, onDestroy } from 'svelte';
@@ -49,6 +50,7 @@
         }),
         BoldStar,
         ItalicSlash,
+        ParagraphNewLine,
         // CodeBlockLowlightFeature.configure({
         //  lowlight: createLowlight(lowlightCommon),
         // }),

--- a/app/frontend/Shared/Editor/HTMLEditor.svelte
+++ b/app/frontend/Shared/Editor/HTMLEditor.svelte
@@ -6,7 +6,6 @@
   import { Editor } from '@tiptap/core';
   import StarterKit from '@tiptap/starter-kit';
   import LinkFeature from '@tiptap/extension-link';
-  import ImageFeature from '@tiptap/extension-image';
   import CodeWordFeature from '@tiptap/extension-code';
   import ImageResize from 'tiptap-extension-resize-image';
   import { SplitBlockquote } from './SplitBlockquote';

--- a/app/frontend/Shared/Editor/HTMLEditor.svelte
+++ b/app/frontend/Shared/Editor/HTMLEditor.svelte
@@ -126,4 +126,15 @@
   .html-editor :global(img) {
     max-width: 100%;
   }
+
+  /* Only change styling for first level <p> */
+  .html-editor :global(.tiptap) > :global(p) {
+    margin: 1.5em 0;
+  }
+  .html-editor :global(.tiptap) > :global(:first(p)) {
+    margin-top: 0;
+  }
+  .html-editor :global(.tiptap) > :global(:last-of-type) {
+    margin-bottom: 0;
+  }
 </style>

--- a/app/frontend/Shared/Editor/HTMLEditor.svelte
+++ b/app/frontend/Shared/Editor/HTMLEditor.svelte
@@ -115,9 +115,6 @@
   /* Content styles
      TODO @import url(../Message/content.css); into iframe */
 
-  .html-editor :global(p) {
-    margin: 0px;
-  }
   .html-editor :global(blockquote) {
     border-left: 3px solid blue;
     padding-inline-start: 20px;
@@ -127,14 +124,9 @@
     max-width: 100%;
   }
 
-  /* Only change styling for first level <p> */
-  .html-editor :global(.tiptap) > :global(p) {
-    margin: 1.5em 0;
-  }
-  .html-editor :global(.tiptap) > :global(:first(p)) {
-    margin-top: 0;
-  }
-  .html-editor :global(.tiptap) > :global(:last-of-type) {
-    margin-bottom: 0;
+  /** Undo the default margin of first/last <p> */
+  .html-editor :global(.tiptap) {
+    margin-top: -1em;
+    margin-bottom: -1em;
   }
 </style>

--- a/app/frontend/Shared/Editor/ParagraphNewLine.ts
+++ b/app/frontend/Shared/Editor/ParagraphNewLine.ts
@@ -1,0 +1,48 @@
+import Paragraph from '@tiptap/extension-paragraph';
+
+declare module '@tiptap/core' {
+  interface Commands<ReturnType> {
+    paragraphNewLine: {
+      /**
+       * Adds standard enter key behavior on paragraphs `<p>`
+       * 1. If there's a `<br>` before or after the cursor
+       * create a new paragraph
+       * 2. Else insert a `<br>`
+       */
+      onParagraphEnter: () => ReturnType;
+    }
+  }
+}
+
+export const ParagraphNewLine = Paragraph.extend({
+  addKeyboardShortcuts() {
+    return {
+      Enter: () => this.editor.commands.onParagraphEnter(),
+    }
+  },
+  addCommands() {
+    return {
+      onParagraphEnter: () => ({ tr, commands, chain }) => {
+        let { $from, $to } = tr.selection;
+        if ($from.parent.type.name != 'paragraph' && $from.depth > 1) {
+          return false;
+        }
+        if ($from.nodeBefore?.type.name == "hardBreak") {
+          return chain()
+            .deleteRange({ 
+              from: $from.pos - $from.nodeBefore.nodeSize,
+              to: $from.pos
+            }).splitBlock().scrollIntoView().run();
+        }
+        if ($to.nodeAfter?.type.name == "hardBreak") {
+          return chain()
+            .deleteRange({ 
+              from: $to.pos,
+              to: $to.pos + $to.nodeAfter.nodeSize
+            }).splitBlock().scrollIntoView().run();
+        }
+        return commands.setHardBreak();
+      },
+    }
+  },
+});

--- a/app/frontend/Shared/Editor/ParagraphNewLine.ts
+++ b/app/frontend/Shared/Editor/ParagraphNewLine.ts
@@ -34,14 +34,14 @@ export const ParagraphNewLine = Paragraph.extend({
          */
         if ($from.nodeBefore?.type.name == "hardBreak") {
           return chain()
-            .deleteRange({ 
+            .deleteRange({
               from: $from.pos - $from.nodeBefore.nodeSize,
               to: $from.pos
             }).splitBlock().scrollIntoView().run();
         }
         if ($to.nodeAfter?.type.name == "hardBreak") {
           return chain()
-            .deleteRange({ 
+            .deleteRange({
               from: $to.pos,
               to: $to.pos + $to.nodeAfter.nodeSize
             }).splitBlock().scrollIntoView().run();

--- a/app/frontend/Shared/Editor/ParagraphNewLine.ts
+++ b/app/frontend/Shared/Editor/ParagraphNewLine.ts
@@ -27,6 +27,11 @@ export const ParagraphNewLine = Paragraph.extend({
         if ($from.parent.type.name != 'paragraph' || $from.depth > 1) {
           return false;
         }
+        /*
+         * Deletes the <br> then splits the paragraph into two paragraphs
+         * This is becauase just splitting creates <p><br></br><p></p>
+         * instead of <p></p><p></p>
+         */
         if ($from.nodeBefore?.type.name == "hardBreak") {
           return chain()
             .deleteRange({ 

--- a/app/frontend/Shared/Editor/ParagraphNewLine.ts
+++ b/app/frontend/Shared/Editor/ParagraphNewLine.ts
@@ -24,7 +24,7 @@ export const ParagraphNewLine = Paragraph.extend({
     return {
       onParagraphEnter: () => ({ tr, commands, chain }) => {
         let { $from, $to } = tr.selection;
-        if ($from.parent.type.name != 'paragraph' && $from.depth > 1) {
+        if ($from.parent.type.name != 'paragraph' || $from.depth > 1) {
           return false;
         }
         if ($from.nodeBefore?.type.name == "hardBreak") {


### PR DESCRIPTION
- Adds a `<br>` when there's no `<br>`
- Splits paragraph into 2 paragraphs when there's already a `<br>`
- Only happens in first level `<p>` so `<li><p></li>` is not affected and still has the default behavior