### PR TITLE
EWS, OWA: Fix save draft

### DIFF
--- a/app/logic/Mail/EWS/EWSFolder.ts
+++ b/app/logic/Mail/EWS/EWSFolder.ts
@@ -3,6 +3,7 @@ import type { EMail } from "../EMail";
 import { EWSEMail } from "./EWSEMail";
 import type { EWSAccount } from "./EWSAccount";
 import EWSCreateItemRequest from "./Request/EWSCreateItemRequest";
+import { CreateMIME } from "../SMTP/CreateMIME";
 import { sanitize } from "../../../../lib/util/sanitizeDatatypes";
 import { base64ToArrayBuffer, blobToBase64, ensureArray, assert } from "../../util/util";
 import { ArrayColl, Collection } from "svelte-collections";
@@ -392,7 +393,7 @@ export class EWSFolder extends Folder {
   }
 
   async addMessage(message: EMail) {
-    assert(message.mime, "Call loadMIME() first");
+    message.mime ??= await CreateMIME.getMIME(message);
     let request = new EWSCreateItemRequest({ m$SavedItemFolderId: { t$FolderId: { Id: this.id } }, MessageDisposition: "SaveOnly" });
     request.addField("Message", "MimeContent", await blobToBase64(new Blob([message.mime])));
     if (message.tags.hasItems) {

--- a/app/logic/Mail/Folder.ts
+++ b/app/logic/Mail/Folder.ts
@@ -173,8 +173,7 @@ export class Folder extends Observable implements TreeItem<Folder> {
    *   then this function will create the MIME from the properties.
    */
   async addMessage(message: EMail) {
-    assert(message.mime, "Call loadMIME() first");
-    throw new NotImplemented();
+    throw new AbstractFunction();
   }
 
   async moveFolderHere(folder: Folder) {

--- a/app/logic/Mail/OWA/OWAFolder.ts
+++ b/app/logic/Mail/OWA/OWAFolder.ts
@@ -10,6 +10,7 @@ import {
   owaGetNewMsgHeadersRequest, owaMoveEntireFolderRequest,
   owaMoveOrCopyMsgsIntoFolderRequest, owaRenameFolderRequest
 } from "./Request/OWAFolderRequests";
+import { CreateMIME } from "../SMTP/CreateMIME";
 import { base64ToArrayBuffer, blobToBase64, assert } from "../../util/util";
 import { sanitize } from "../../../../lib/util/sanitizeDatatypes";
 import { ArrayColl, Collection } from "svelte-collections";
@@ -205,7 +206,7 @@ export class OWAFolder extends Folder {
   }
 
   async addMessage(message: EMail) {
-    assert(message.mime, "Call loadMIME() first");
+    message.mime ??= await CreateMIME.getMIME(message);
     let request = new OWACreateItemRequest({ SavedItemFolderId: { __type: "TargetFolderId:#Exchange", BaseFolderId: { __type: "FolderId:#Exchange", Id: this.id } }, MessageDisposition: "SaveOnly" });
     request.addField("Message", "MimeContent", { CharacterSet: "UTF-8", Value: await blobToBase64(new Blob([message.mime])) });
     if (message.tags.hasItems) {


### PR DESCRIPTION
Port of ebdb226.

(Why do we have `AbstractFunction` when we can just use TypeScript's abstract classes?)