### PR TITLE
Provide useful message if ActiveSync server sends Retry-After header

### DIFF
--- a/app/logic/Mail/ActiveSync/ActiveSyncAccount.ts
+++ b/app/logic/Mail/ActiveSync/ActiveSyncAccount.ts
@@ -233,7 +233,7 @@ export class ActiveSyncAccount extends MailAccount {
         "MS-ASProtocolVersion": this.protocolVersion,
         Cookie: `DefaultAnchorMailbox=${encodeURI(this.emailAddress)}`, // required for 14.0
       },
-      timeout: heartbeat * 1000 + 10000, // extra timeout for Ping commands
+      timeout: heartbeat * 1000 + 25000, // extra timeout for Ping commands
     };
     if (this.oAuth2) {
       options.headers.Authorization = this.oAuth2.authorizationHeader;
@@ -300,6 +300,9 @@ export class ActiveSyncAccount extends MailAccount {
       }
     }
     this.throttle.waitForSecond(1);
+    if (response.RetryAfter) {
+      throw new Error(`The server is overloaded. Please try again after ${response.RetryAfter} seconds.`);
+    }
     throw new Error(`HTTP ${response.status} ${response.statusText}`);
   }
 

--- a/backend/backend.ts
+++ b/backend/backend.ts
@@ -239,6 +239,7 @@ async function postHTTP(url: string, data: any, responseType: string, config: an
     status: response.status,
     statusText: response.statusText,
     data: await response[responseType](),
+    RetryAfter: response.headers.get("Retry-After"),
     WWWAuthenticate: response.headers.get("WWW-Authenticate"),
   };
 }


### PR DESCRIPTION
I had to increase the timeout otherwise `ky` will just abort the request. (I tried 20s but that was too low.)