### PR TITLE
ActiveSync: Save draft if 16.1 available

### DIFF
--- a/app/logic/Mail/ActiveSync/ActiveSyncEMail.ts
+++ b/app/logic/Mail/ActiveSync/ActiveSyncEMail.ts
@@ -84,6 +84,9 @@ export class ActiveSyncEMail extends EMail {
   setFlags(wbxmljs: any) {
     this.isRead = wbxmljs.Read != "0";
     this.isStarred = wbxmljs.Flag?.Status == "2";
+    if (this.folder.account.protocolVersion == "16.1") {
+      this.isDraft = wbxmljs.IsDraft != "0";
+    }
     this.tags.clear();
     if (wbxmljs.Categories) {
       this.tags.addAll(ensureArray(wbxmljs.Categories.Category).map(name => getTagByName(name)));

--- a/app/logic/Mail/ActiveSync/ActiveSyncFolder.ts
+++ b/app/logic/Mail/ActiveSync/ActiveSyncFolder.ts
@@ -108,7 +108,7 @@ export class ActiveSyncFolder extends Folder implements ActiveSyncPingable {
             }, data),
           },
         };
-        response = await this.account.callEAS("Sync", request);
+        response = await this.account.callEAS("Sync", request, { allowV16: true });
         if (!response) {
           return null;
         }

--- a/app/logic/Mail/ActiveSync/WBXML.ts
+++ b/app/logic/Mail/ActiveSync/WBXML.ts
@@ -29,7 +29,7 @@ const kTags = [
   [],
   [,,,,, "ItemOperations", "Fetch", "Store", "Options",,, "Properties",, "Status", "Response",,,, "EmptyFolderContents", "DeleteSubFolders"],
   [,,,,, "SendMail",,, "SaveInSentItems",,,,,,,, "Mime", "ClientId", "Status"],
-  [,,,,,,,,, "ConversationId", "ConversationIndex", "LastVerbExecuted", "LastVerbExecutionTime",, "Sender",,,,"FirstDayOfWeek", "MeetingMessageType"],
+  [,,,,,,,,, "ConversationId", "ConversationIndex", "LastVerbExecuted", "LastVerbExecutionTime",, "Sender",,,,"FirstDayOfWeek", "MeetingMessageType", "IsDraft", "Bcc"],
 ];
 
 /**


### PR DESCRIPTION
The alternative would be to directly support 16.1 as a protocol version, which would mean having to check all of the APIs we currently use to see if they work differently in 16.1

[Sync Command Request](https://learn.microsoft.com/en-us/openspecs/exchange_server_protocols/ms-asemail/a8602ea5-a3f3-4426-83b5-a8d5315a953d)