### PR TITLE
L10n: Use <T> component only for interpolation (#518)

### DIFF
--- a/app/frontend/Settings/About/About.svelte
+++ b/app/frontend/Settings/About/About.svelte
@@ -4,7 +4,7 @@
 <h1>{appName} {appVersion}</h1>
 
 <div>
-  <T msg="Copyright 2024 Ben Bucksch, #, and other contributors">
+  <T msg={$t`Copyright 2024 Ben Bucksch, #, and other contributors`}>
     <a href="{siteRoot}" target="_blank">{appName == "Parula" ? "Beonex GmbH" : "Mustang GmbH"}</a>
   </T>
 </div>
@@ -13,6 +13,7 @@
   import Icon from 'svelte-icon/Icon.svelte';
   import logo from '../../asset/icon/general/logo.svg?raw';
   import { appName, appVersion, siteRoot } from '../../../logic/build';
+  import { t } from '../../../l10n/l10n';
   import T from '../../../l10n/T.svelte';
 </script>
 

--- a/app/frontend/Settings/Mail/Read.svelte
+++ b/app/frontend/Settings/Mail/Read.svelte
@@ -21,7 +21,7 @@
 
       <label class="radio">
         <input type="radio" value={readSeconds} bind:group={readAfter.value} />
-        <T msg="After displaying for # seconds">
+        <T msg={$t`After displaying for # seconds`}>
           <input type="number" bind:value={readSeconds} min={1} max={20} maxlength={2} on:change={onReadSecondsChanged} />
         </T>
       </label>

--- a/app/l10n/T.svelte
+++ b/app/l10n/T.svelte
@@ -17,7 +17,7 @@
   let strings: string[] = [];
   onMount(split);
   function split() {
-    strings = $t([msg]).split('#');
+    strings = msg.split('#');
     if (strings.length > 5) {
       console.error('<T> component can only have a maximum of 5 slots. Bad string is:', ...strings);
     }

--- a/app/l10n/extractor/svelteExtract.ts
+++ b/app/l10n/extractor/svelteExtract.ts
@@ -3,7 +3,7 @@ import { parse } from "svelte/compiler";
 import { vitePreprocess } from "@sveltejs/vite-plugin-svelte";
 import { preprocess } from "svelte/compiler";
 import { onMessageExtracted } from "./extractor";
-import { extractComponent, extractPluralMessages, extractPlurals, extractTags } from "./utils";
+import { extractPluralMessages, extractPlurals, extractTags } from "./utils";
 
 export async function svelteExtract(code: string, filename: string) {
   if (!filename.endsWith(".svelte")) {
@@ -18,7 +18,6 @@ export async function svelteExtract(code: string, filename: string) {
         extractTags(['$t', 'msg'], node, filename, onMessageExtracted);
         extractPlurals(['$plural'], node, filename, onMessageExtracted);
         extractPluralMessages(['msgPlural'], node, filename, onMessageExtracted);
-        extractComponent(node, filename, onMessageExtracted);
       },
     });
   } catch (ex) {

--- a/app/l10n/extractor/utils.ts
+++ b/app/l10n/extractor/utils.ts
@@ -107,32 +107,3 @@ export const extractPluralMessages = (tags, node, filename, onMessageExtracted) 
     });
   }
 };
-
-export const extractComponent = (node, filename, onMessageExtracted) => {
-  if (node.type === 'InlineComponent' && node.name === 'T') {
-    const { start } = node; // FIXME: Find out why Loc is not printed here, causing this to be incorrect
-    const { attributes } = node;
-    let messageNode = attributes.find((a) => a.name === 'msg')?.value[0];
-    let message = messageNode?.data ?? generateMessageFromTemplate(messageNode.expression);
-    if (!message) {
-      console.error(`Message not found for <T> in ${filename}`);
-      return;
-    }
-
-    onMessageExtracted({
-      id: generateMessageID(message),
-      message,
-      origin: [filename, start.line, start.column],
-      placeholders: {},
-    });
-  }
-};
-
-function generateMessageFromTemplate(node): string {
-  const rawQuasis = node.quasis.map((q) => q.value.raw);
-  let message = rawQuasis[0];
-  rawQuasis.slice(1).forEach((q, i) => {
-    message += `{${i}}${q}`;
-  });
-  return message;
-}


### PR DESCRIPTION
- There were many problems with the <T> component when extracting string from it since it doesn't know what values are there at compile time.
- I replaced all instances where <T> is used for translation with $t.