### PR TITLE
Mail composer: Use props properly in slots (#489)

### DIFF
--- a/app/frontend/Mail/Composer/MailAutocomplete.svelte
+++ b/app/frontend/Mail/Composer/MailAutocomplete.svelte
@@ -6,7 +6,7 @@
     {person.emailAddress}
   </hbox>
   <slot name="end" slot="end" />
-  <slot name="person-popup-buttons" slot="person-popup-buttons" let:personUID {personUID} />
+  <slot name="person-popup-buttons" slot="person-popup-buttons" let:person {person} />
 </PersonsAutocomplete>
 
 <script lang="ts">

--- a/app/frontend/Mail/Composer/MailComposer.svelte
+++ b/app/frontend/Mail/Composer/MailComposer.svelte
@@ -36,9 +36,9 @@
       <hbox flex>
         <hbox flex>
           <MailAutocomplete addresses={mail.to} placeholder={$t`Add recipient`} tabindex={1} autofocus={mail.to.isEmpty}>
-            <svelte:fragment slot="person-popup-buttons" let:person={personUID}>
-              <Button plain label={$t`CC`} onClick={() => onMoveToCC(personUID)} />
-              <Button plain label={$t`BCC`} onClick={() => onMoveToBCC(personUID)} />
+            <svelte:fragment slot="person-popup-buttons" let:person>
+              <Button plain label={$t`CC`} onClick={() => onMoveToCC(person)} />
+              <Button plain label={$t`BCC`} onClick={() => onMoveToBCC(person)} />
             </svelte:fragment>
           </MailAutocomplete>
         </hbox>
@@ -60,18 +60,18 @@
     {#if showCC}
       <hbox class="label">{$t`Cc`}</hbox>
       <MailAutocomplete addresses={mail.cc} placeholder={$t`Add CC recipient`} tabindex={1}>
-        <svelte:fragment slot="person-popup-buttons" let:person={personUID}>
-          <Button plain label={$t`To`} onClick={() => onMoveToTo(personUID)} />
-          <Button plain label={$t`BCC`} onClick={() => onMoveToBCC(personUID)} />
+        <svelte:fragment slot="person-popup-buttons" let:person={person}>
+          <Button plain label={$t`To`} onClick={() => onMoveToTo(person)} />
+          <Button plain label={$t`BCC`} onClick={() => onMoveToBCC(person)} />
         </svelte:fragment>
       </MailAutocomplete>
     {/if}
     {#if showBCC}
       <hbox class="label">{$t`Bcc`}</hbox>
       <MailAutocomplete addresses={mail.bcc} placeholder={$t`Add BCC recipient`} tabindex={1}>
-        <svelte:fragment slot="person-popup-buttons" let:person={personUID}>
-          <Button plain label={$t`To`} onClick={() => onMoveToTo(personUID)} />
-          <Button plain label={$t`CC`} onClick={() => onMoveToCC(personUID)} />
+        <svelte:fragment slot="person-popup-buttons" let:person>
+          <Button plain label={$t`To`} onClick={() => onMoveToTo(person)} />
+          <Button plain label={$t`CC`} onClick={() => onMoveToCC(person)} />
         </svelte:fragment>
       </MailAutocomplete>
     {/if}

--- a/app/frontend/Mail/Composer/MailComposer.svelte
+++ b/app/frontend/Mail/Composer/MailComposer.svelte
@@ -36,10 +36,10 @@
       <hbox flex>
         <hbox flex>
           <MailAutocomplete addresses={mail.to} placeholder={$t`Add recipient`} tabindex={1} autofocus={mail.to.isEmpty}>
-            <!--<svelte:fragment slot="person-popup-buttons" let:personUID>
+            <svelte:fragment slot="person-popup-buttons" let:personUID>
               <Button plain label={$t`CC`} onClick={() => onMoveToCC(personUID)} />
               <Button plain label={$t`BCC`} onClick={() => onMoveToBCC(personUID)} />
-            </svelte:fragment>-->
+            </svelte:fragment>
           </MailAutocomplete>
         </hbox>
         <hbox class="cc buttons">
@@ -60,19 +60,19 @@
     {#if showCC}
       <hbox class="label">{$t`Cc`}</hbox>
       <MailAutocomplete addresses={mail.cc} placeholder={$t`Add CC recipient`} tabindex={1}>
-        <!--<svelte:fragment slot="person-popup-buttons" let:personUID>
+        <svelte:fragment slot="person-popup-buttons" let:personUID>
           <Button plain label={$t`To`} onClick={() => onMoveToTo(personUID)} />
           <Button plain label={$t`BCC`} onClick={() => onMoveToBCC(personUID)} />
-        </svelte:fragment>-->
+        </svelte:fragment>
       </MailAutocomplete>
     {/if}
     {#if showBCC}
       <hbox class="label">{$t`Bcc`}</hbox>
       <MailAutocomplete addresses={mail.bcc} placeholder={$t`Add BCC recipient`} tabindex={1}>
-        <!--<svelte:fragment slot="person-popup-buttons" let:personUID>
+        <svelte:fragment slot="person-popup-buttons" let:personUID>
           <Button plain label={$t`To`} onClick={() => onMoveToTo(personUID)} />
           <Button plain label={$t`CC`} onClick={() => onMoveToCC(personUID)} />
-        </svelte:fragment>-->
+        </svelte:fragment>
       </MailAutocomplete>
     {/if}
     </grid>
@@ -248,15 +248,11 @@
   }
 
   function onMoveToCC(person: PersonUID) {
-    // TODO `{#if person}<PersonEntry {person}/>` in PersonsAutocomplete.svelte ?
-    // TODO Does not actually add it to CC, or at least that doesn't show.
-    showCCForce = true;
     mail.bcc.remove(person);
     mail.to.remove(person);
     mail.cc.add(person);
   }
   function onMoveToBCC(person: PersonUID) {
-    showBCCForce = true;
     mail.cc.remove(person);
     mail.to.remove(person);
     mail.bcc.add(person);

--- a/app/frontend/Mail/Composer/MailComposer.svelte
+++ b/app/frontend/Mail/Composer/MailComposer.svelte
@@ -36,7 +36,7 @@
       <hbox flex>
         <hbox flex>
           <MailAutocomplete addresses={mail.to} placeholder={$t`Add recipient`} tabindex={1} autofocus={mail.to.isEmpty}>
-            <svelte:fragment slot="person-popup-buttons" let:personUID>
+            <svelte:fragment slot="person-popup-buttons" let:person={personUID}>
               <Button plain label={$t`CC`} onClick={() => onMoveToCC(personUID)} />
               <Button plain label={$t`BCC`} onClick={() => onMoveToBCC(personUID)} />
             </svelte:fragment>
@@ -60,7 +60,7 @@
     {#if showCC}
       <hbox class="label">{$t`Cc`}</hbox>
       <MailAutocomplete addresses={mail.cc} placeholder={$t`Add CC recipient`} tabindex={1}>
-        <svelte:fragment slot="person-popup-buttons" let:personUID>
+        <svelte:fragment slot="person-popup-buttons" let:person={personUID}>
           <Button plain label={$t`To`} onClick={() => onMoveToTo(personUID)} />
           <Button plain label={$t`BCC`} onClick={() => onMoveToBCC(personUID)} />
         </svelte:fragment>
@@ -69,7 +69,7 @@
     {#if showBCC}
       <hbox class="label">{$t`Bcc`}</hbox>
       <MailAutocomplete addresses={mail.bcc} placeholder={$t`Add BCC recipient`} tabindex={1}>
-        <svelte:fragment slot="person-popup-buttons" let:personUID>
+        <svelte:fragment slot="person-popup-buttons" let:person={personUID}>
           <Button plain label={$t`To`} onClick={() => onMoveToTo(personUID)} />
           <Button plain label={$t`CC`} onClick={() => onMoveToCC(personUID)} />
         </svelte:fragment>

--- a/app/frontend/Shared/PersonAutocomplete/PersonEntry.svelte
+++ b/app/frontend/Shared/PersonAutocomplete/PersonEntry.svelte
@@ -28,7 +28,7 @@
   import PersonPopup from "./PersonPopup.svelte";
   import PersonPicture from "../Person/PersonPicture.svelte";
   import Popup from "../Popup.svelte";
-  import { createEventDispatcher } from 'svelte';
+  import { createEventDispatcher, onMount } from 'svelte';
   const dispatchEvent = createEventDispatcher<{ focusNext: void }>();
 
   export let person: PersonUID;
@@ -38,8 +38,11 @@
   let popupOpen = false;
   let popupAnchor: HTMLElement;
 
-  if ((person as any).openPopup) {
-    popupOpen = true;
+  onMount(checkPopup);
+  function checkPopup() {
+    if ((person as any).openPopup) {
+      popupOpen = true;
+    }
   }
 
   function onPopupToggle(event: MouseEvent) {


### PR DESCRIPTION
- There were 2 issues I found that caused the UI to freeze, the `person` prop was access before mount is always `undefined` and in the inner components the slots took a `person` prop instead of a `personUID` but `personUID` was the prop passed only in MailComposer, in Display even it uses a `person` also