### PR TITLE
Don't try to unset the recurrence of an instance

### DIFF
--- a/app/logic/Calendar/EWS/EWSEvent.ts
+++ b/app/logic/Calendar/EWS/EWSEvent.ts
@@ -154,7 +154,9 @@ export class EWSEvent extends Event {
     request.addField("CalendarItem", "Body", this.descriptionHTML ? { BodyType: "HTML", _TextContent_: this.descriptionHTML } : this.descriptionText ? { BodyType: "Text", _TextContent_: this.descriptionText } : "", "item:Body");
     request.addField("CalendarItem", "ReminderIsSet", this.alarm != null, "item:ReminderIsSet");
     request.addField("CalendarItem", "ReminderMinutesBeforeStart", this.alarmMinutesBeforeStart(), "item:ReminderMinutesBeforeStart");
-    request.addField("CalendarItem", "Recurrence", this.recurrenceRule ? this.saveRule(this.recurrenceRule) : null, "calendar:Recurrence");
+    if (!this.parentEvent) { // Exchange Online now requires this for EWS
+      request.addField("CalendarItem", "Recurrence", this.recurrenceRule ? this.saveRule(this.recurrenceRule) : null, "calendar:Recurrence");
+    }
     if (this.calUID && !this.itemID && !this.parentEvent) {
       // This probably only makes sense when creating an event.
       // (And it's not even needed then as Exchange will auto-generate one.)

--- a/app/logic/Calendar/EWS/EWSEvent.ts
+++ b/app/logic/Calendar/EWS/EWSEvent.ts
@@ -154,7 +154,7 @@ export class EWSEvent extends Event {
     request.addField("CalendarItem", "Body", this.descriptionHTML ? { BodyType: "HTML", _TextContent_: this.descriptionHTML } : this.descriptionText ? { BodyType: "Text", _TextContent_: this.descriptionText } : "", "item:Body");
     request.addField("CalendarItem", "ReminderIsSet", this.alarm != null, "item:ReminderIsSet");
     request.addField("CalendarItem", "ReminderMinutesBeforeStart", this.alarmMinutesBeforeStart(), "item:ReminderMinutesBeforeStart");
-    if (!this.parentEvent) { // Exchange Online now requires this for EWS
+    if (!this.parentEvent) { // Exchange Online requires not to write the `Recurrence` prop for recurrence instances
       request.addField("CalendarItem", "Recurrence", this.recurrenceRule ? this.saveRule(this.recurrenceRule) : null, "calendar:Recurrence");
     }
     if (this.calUID && !this.itemID && !this.parentEvent) {

--- a/app/logic/Calendar/Event.ts
+++ b/app/logic/Calendar/Event.ts
@@ -34,7 +34,17 @@ export class Event extends Observable {
   /** Only used by the editing UI. */
   @notifyChangedProperty
   repeat = false; // TODO remove
-  /** Only used by recurring masters, describes the recurrence pattern. */
+  /** Only used by recurring masters, describes the recurrence pattern.
+   *
+   * | `Event.parentEvent` | `Event.recurrenceRule` | Event type
+   * | ------------------- | ---------------------- | -----
+   * | without             | without                | Normal event
+   * | without             | with                   | Recurrence master
+   * | with                | with                   | Invalid state
+   * | with                | without                | Recurrence instance or exception
+   *
+   * TODO differentiate between generated instance and exception #551
+   */
   @notifyChangedProperty
   recurrenceRule: RecurrenceRule | undefined;
   /** Only used by instances, links back to the recurring master. */

--- a/app/logic/Calendar/Event.ts
+++ b/app/logic/Calendar/Event.ts
@@ -31,12 +31,13 @@ export class Event extends Observable {
   /** IANA timezone name, e.g. "Europe/Berlin" */
   @notifyChangedProperty
   timezone: string | null = null;
+  /** Only used by the editing UI. */
   @notifyChangedProperty
   repeat = false; // TODO remove
-  /** If `repeat` is set, should be the rule which describes the pattern. */
+  /** Only used by recurring masters, describes the recurrence pattern. */
   @notifyChangedProperty
   recurrenceRule: RecurrenceRule | undefined;
-  /** Links back to the recurring master from an instance. */
+  /** Only used by instances, links back to the recurring master. */
   @notifyChangedProperty
   parentEvent: Event | undefined;
   /**


### PR DESCRIPTION
Exchange Online EWS doesn't like it any more.

Obviously I didn't want to break any of the back end for handling recurring events, but I basically had to rewrite parts of the UI in order to get it into a position where I could test the change to make sure that, were the UI to work, the back end would actually do the right thing.

I was also disappointed to find that the UI to set the end date of a recurring event was never restored.