### PR TITLE
Allow future events of a series to be changed #478

### DIFF
--- a/app/frontend/Calendar/EditEvent/DialogHeader.svelte
+++ b/app/frontend/Calendar/EditEvent/DialogHeader.svelte
@@ -152,7 +152,7 @@
       event.startTime.getTime() <= event.endTime.getTime() && $event.hasChanged();
   $: seriesStatus = event.seriesStatus;
 
-  function confirmAndChangeRule(): boolean {
+  function confirmAndChangeRecurrenceRule(): boolean {
     let master = event.parentEvent || event;
     if (!repeatBox) {
       if (!master.recurrenceRule) {
@@ -207,11 +207,11 @@
   }
 
   async function onChangeAll() {
-    if (!confirmAndChangeRule()) {
+    if (!confirmAndChangeRecurrenceRule()) {
       return;
     }
     let master = event.parentEvent;
-    master.copyFrom(event);
+    master.copyEditableFieldsFrom(event);
     await master.saveToServer();
     await master.save();
     onClose();
@@ -219,7 +219,7 @@
 
   async function onChangeForward() {
     let master = event.calendar.newEvent();
-    master.copyFrom(event);
+    master.copyEditableFieldsFrom(event);
     master.recurrenceRule = repeatBox.newRecurrenceRule();
     master.recurrenceCase = RecurrenceCase.Master;
     master.fillRecurrences(new Date(Date.now() + 1e11));

--- a/app/frontend/Calendar/EditEvent/DialogHeader.svelte
+++ b/app/frontend/Calendar/EditEvent/DialogHeader.svelte
@@ -23,6 +23,25 @@
             border={false}
             iconSize="16px"
             />
+          {#if seriesStatus == "first"}
+            <RoundButton
+             label={$t`Delete entire series`}
+             icon={DeleteIcon}
+             onClick={onDeleteAll}
+             classes="plain delete"
+             border={false}
+             iconSize="16px"
+             />
+          {:else if seriesStatus == "middle"}
+            <RoundButton
+             label={$t`Delete remainder of series`}
+             icon={DeleteIcon}
+             onClick={onDeleteForward}
+             classes="plain delete"
+             border={false}
+             iconSize="16px"
+             />
+          {/if}
         {/if}
       </hbox>
       <hbox class="account-icon">
@@ -49,6 +68,27 @@
             />
         {/if}
         {#if canSave}
+          {#if seriesStatus == "first"}
+            <RoundButton
+             label={$t`Change entire series`}
+             icon={SaveIcon}
+             onClick={onChangeAll}
+             classes="plain save-or-close"
+             filled={true}
+             iconSize="16px"
+             />
+          {:else if seriesStatus == "middle"}
+            <RoundButton
+             label={$t`Change remainder of series`}
+             icon={SaveIcon}
+             onClick={onChangeForward}
+             classes="plain save-or-close"
+             filled={true}
+             iconSize="16px"
+             />
+          {/if}
+        {/if}
+        {#if canSave && !(event.parentEvent && repeatBox)}
           <RoundButton
             label={$t`Revert`}
             icon={RevertIcon}
@@ -79,7 +119,7 @@
 </vbox>
 
 <script lang="ts">
-  import type { Event } from "../../../logic/Calendar/Event";
+  import { type Event, RecurrenceCase } from "../../../logic/Calendar/Event";
   import { Calendar } from "../../../logic/Calendar/Calendar";
   import { Account } from "../../../logic/Abstract/Account";
   import { EventEditMustangApp, calendarMustangApp } from "../CalendarMustangApp";
@@ -111,6 +151,50 @@
   $: canSave = event && $event.title && $event.startTime && $event.endTime &&
       event.startTime.getTime() <= event.endTime.getTime() && $event.hasChanged();
   $: oldTitle = event?.title || $t`Event`;
+  $: seriesStatus = isInstance(event);
+
+  function isInstance(event) {
+    let master = event.parentEvent;
+    if (!master?.recurrenceRule) {
+      return "none";
+    }
+    let pos = master.instances.indexOf(event);
+    let isFirst = master.instances.getIndexRange(0, pos).every(instance => instance === null);
+    let rule = master.recurrenceRule;
+    let isLast = (rule.count != Infinity || rule.endDate) && master.instances.contents.slice(pos + 1).every(instance => instance === null || instance?.dbID) && !rule.getOccurrenceByIndex(master.instances.length + 1);
+    return isLast ? isFirst ? "only" : "last" : isFirst ? "first" : "middle";
+  }
+
+  function confirmAndChangeRule(): boolean {
+    let master = event.parentEvent || event;
+    if (!repeatBox) {
+      if (!master.recurrenceRule) {
+        // Event had never been a recurring event.
+        return true;
+      }
+      if (!confirm($t`Are you sure you want to remove this unfortunate series of events?`)) {
+        return false;
+      }
+      master.recurrenceRule = null;
+      master.recurrenceCase = RecurrenceCase.Normal;
+    } else {
+      let rule = repeatBox.newRecurrenceRule();
+      if (master.recurrenceRule) {
+        if (event.startTime.getTime() == master.recurrenceRule.startDate.getTime() &&
+            rule.getCalString() == master.recurrenceRule.getCalString()) {
+          // Rule hasn't actually changed.
+          return true;
+        }
+        if (!confirm($t`This change will reset all of your series to default values.`)) {
+          return false;
+        }
+      }
+      master.recurrenceRule = rule;
+      master.recurrenceCase = RecurrenceCase.Master;
+    }
+    master.clearExceptions();
+    return true;
+  }
 
   function onCancel() {
     assert(event.unedited, "need unedited state");
@@ -120,8 +204,11 @@
   }
 
   async function onSave() {
-    if (repeatBox && !repeatBox.confirmAndChangeRule()) {
-      return;
+    // Turning a single event into a series.
+    // (The reverse is done in `onChangeAll`.)
+    if (repeatBox) {
+      event.recurrenceRule = repeatBox.newRecurrenceRule();
+      event.recurrenceCase = RecurrenceCase.Master;
     }
     await event.saveToServer();
     await event.save();
@@ -134,14 +221,74 @@
     onClose();
   }
 
+  async function onChangeAll() {
+    if (!confirmAndChangeRule()) {
+      return;
+    }
+    let master = event.parentEvent;
+    let recurrenceRule = master.recurrenceRule;
+    master.copyFrom(event);
+    master.recurrenceStartTime = null;
+    master.recurrenceRule = recurrenceRule;
+    master.recurrenceCase = RecurrenceCase.Master;
+    await master.saveToServer();
+    await master.save();
+    onClose();
+  }
+
+  async function onChangeForward() {
+    let master = event.calendar.newEvent();
+    master.copyFrom(event);
+    master.recurrenceStartTime = null;
+    master.recurrenceRule = repeatBox.newRecurrenceRule();
+    master.recurrenceCase = RecurrenceCase.Master;
+    master.fillRecurrences(new Date(Date.now() + 1e11));
+    await master.saveToServer();
+    await master.save();
+    await onDeleteForward();
+  }
+
   async function onDelete() {
-    if (event.recurrenceRule) {
-      if (!confirm($t`Are you sure you want to remove this unfortunate series of events?`)) {
-        return;
+    if (seriesStatus == "only") {
+      await event.parentEvent.deleteFromServer();
+      await event.parentEvent.deleteIt();
+    } else {
+      await event.deleteFromServer();
+      await event.deleteIt();
+    }
+    onClose();
+  }
+
+  async function onDeleteAll() {
+    if (!confirm($t`Are you sure you want to remove this unfortunate series of events?`)) {
+      return;
+    }
+    let master = event.parentEvent;
+    await master.deleteFromServer();
+    await master.deleteIt();
+    onClose();
+  }
+
+  async function onDeleteForward() {
+    let master = event.parentEvent;
+    let pos = master.instances.indexOf(event);
+    let count = master.instances.contents.slice(pos).findLastIndex(event => event?.dbID) + pos + 1;
+    if (master.recurrenceRule.getOccurrenceByIndex(count + 1)) {
+      master.truncateRecurrence(count);
+      await master.saveToServer();
+    }
+    let exclusions = [];
+    for (let i = pos; i < count; i++) {
+      let instance = master.instances.get(i);
+      // Always delete this event, unless it got truncated above
+      if (instance == event || instance === undefined || instance && !instance.dbID) {
+        exclusions.push(pos);
       }
     }
-    await event.deleteFromServer();
-    await event.deleteIt();
+    if (exclusions.length) {
+      await master.makeExclusions(exclusions);
+    }
+    await master.save();
     onClose();
   }
 

--- a/app/frontend/Calendar/EditEvent/DialogHeader.svelte
+++ b/app/frontend/Calendar/EditEvent/DialogHeader.svelte
@@ -149,7 +149,7 @@
 
   $: event.startEditing(); // not `$event`
   $: canSave = event && $event.title && $event.startTime && $event.endTime &&
-      event.startTime.getTime() <= event.endTime.getTime() && $event.hasChanged();
+      event.startTime.getTime() <= event.endTime.getTime() && (repeatBox || $event.hasChanged());
   $: seriesStatus = event.seriesStatus;
 
   function confirmAndChangeRecurrenceRule(): boolean {
@@ -220,6 +220,7 @@
   async function onChangeForward() {
     let master = event.calendar.newEvent();
     master.copyEditableFieldsFrom(event);
+    master.calUID = null;
     master.recurrenceRule = repeatBox.newRecurrenceRule();
     master.recurrenceCase = RecurrenceCase.Master;
     master.fillRecurrences(new Date(Date.now() + 1e11));

--- a/app/frontend/Calendar/EditEvent/EditEvent.svelte
+++ b/app/frontend/Calendar/EditEvent/EditEvent.svelte
@@ -103,6 +103,7 @@
   let repeatBox: RepeatBox;
 
   function expandRepeat(): void {
+    // `showRepeat = true` set by `<ExpanderButton>` click handler
   }
 
   const kDefaultReminderMins = 5;

--- a/app/frontend/Calendar/EditEvent/EditEvent.svelte
+++ b/app/frontend/Calendar/EditEvent/EditEvent.svelte
@@ -19,7 +19,7 @@
         </Section>
         {#if showRepeat}
           <Section label={$t`Repeat`} icon={RepeatIcon}>
-            <RepeatBox {event} bind:this={repeatBox}/>
+            <RepeatBox {event} bind:this={repeatBox} bind:showRepeat/>
           </Section>
         {/if}
         {#if showReminder}
@@ -93,7 +93,7 @@
 
   export let event: Event;
 
-  $: showRepeat = $event.recurrenceCase != RecurrenceCase.Normal;
+  $: showRepeat = false;
   $: showReminder = !!$event.alarm;
   $: showParticipants = $event.participants.hasItems;
   $: showLocation = !!$event.location;
@@ -103,7 +103,6 @@
   let repeatBox: RepeatBox;
 
   function expandRepeat(): void {
-    event.recurrenceCase = RecurrenceCase.Master;
   }
 
   const kDefaultReminderMins = 5;

--- a/app/frontend/Calendar/EditEvent/RepeatBox.svelte
+++ b/app/frontend/Calendar/EditEvent/RepeatBox.svelte
@@ -79,6 +79,7 @@
   import { arrayRemove } from '../../../logic/util/util';
 
   export let event: Event;
+  export let showRepeat: boolean;
 
   let frequency = event.recurrenceRule?.frequency || Frequency.Daily;
   let interval = event.recurrenceRule?.interval || 1;
@@ -162,11 +163,8 @@
 
   function onFrequencyChanged() {
     if (frequency == Frequency.None) {
-      event.recurrenceCase = RecurrenceCase.Normal;
-      event.recurrenceRule = null;
-    } else if (event.recurrenceCase == RecurrenceCase.Normal) {
-      event.recurrenceCase = RecurrenceCase.Master;
-    } // else: leave unchanged
+      showRepeat = false;
+    }
   }
 
   export function newRecurrenceRule(): RecurrenceRule {
@@ -177,9 +175,7 @@
       init.endDate = endDate;
     }
     if (frequency == Frequency.Weekly) {
-      if (weekdays.length > 1) {
-        init.weekdays = weekdays;
-      }
+      init.weekdays = weekdays;
     } else if (frequency == Frequency.Monthly || frequency == Frequency.Yearly) {
       init.week = week;
       if (week) {

--- a/app/frontend/Calendar/EditEvent/RepeatBox.svelte
+++ b/app/frontend/Calendar/EditEvent/RepeatBox.svelte
@@ -169,7 +169,7 @@
     } // else: leave unchanged
   }
 
-  function newRecurrenceRule(): RecurrenceRule {
+  export function newRecurrenceRule(): RecurrenceRule {
     let init: RecurrenceInit = { startDate: event.startTime, frequency, interval };
     if (end == "count") {
       init.count = count;
@@ -187,35 +187,6 @@
       }
     }
     return new RecurrenceRule(init);
-  }
-
-  // TODO Call from save()
-  export function confirmAndChangeRule(): boolean {
-    if (event.recurrenceCase == RecurrenceCase.Normal) {
-      if (!event.recurrenceRule) {
-        // Never a recurring event.
-        return true;
-      }
-      if (!confirm($t`Are you sure you want to remove this unfortunate series of events?`)) {
-        return false;
-      }
-      event.recurrenceRule = null;
-    } else {
-      let rule = newRecurrenceRule();
-      if (event.recurrenceRule) {
-        if (event.startTime.getTime() == event.recurrenceRule.startDate.getTime() &&
-            rule.getCalString() == event.recurrenceRule.getCalString()) {
-          // Rule hasn't actually changed.
-          return true;
-        }
-        if (!confirm($t`This change will reset all of your series to default values.`)) {
-          return false;
-        }
-      }
-      event.recurrenceRule = rule;
-    }
-    event.clearExceptions();
-    return true;
   }
 </script>
 

--- a/app/logic/Calendar/ActiveSync/ActiveSyncEvent.ts
+++ b/app/logic/Calendar/ActiveSync/ActiveSyncEvent.ts
@@ -85,7 +85,7 @@ export class ActiveSyncEvent extends Event {
     return new RecurrenceRule({ startDate, endDate, count, frequency, interval, weekdays, week, first });
   }
 
-  toFields(exception?: any) {
+  toFields(exceptions: { Exception: any } | { Exception: any }[] = []) {
     return {
       ExceptionStartTime: toCompact(this.recurrenceStartTime) || [],
       Timezone: this.recurrenceStartTime ? [] : getTimeZoneActiveSync(this.timezone),
@@ -111,7 +111,7 @@ export class ActiveSyncEvent extends Event {
       } : [],
       Subject: this.title,
       Body: this.descriptionHTML ? { Type: "2", Data: this.descriptionHTML } : { Type: "1", Data: [this.descriptionText || ""] },
-      Exceptions: exception ? { Exception: exception } : [],
+      Exceptions: exceptions,
     };
   }
 
@@ -122,7 +122,7 @@ export class ActiveSyncEvent extends Event {
   async saveToServer(): Promise<void> {
     // Not supporting tasks for now.
     if (this.parentEvent) {
-      this.parentEvent.saveFields(this.parentEvent.toFields(this.toFields()));
+      this.parentEvent.saveFields(this.parentEvent.toFields({ Exception: this.toFields() }));
     } else {
       await this.saveFields(this.toFields());
       if (!this.calUID) {
@@ -169,8 +169,10 @@ export class ActiveSyncEvent extends Event {
   async deleteFromServer(): Promise<void> {
     if (this.parentEvent) {
       await this.parentEvent.saveFields(this.parentEvent.toFields({
-        Deleted: "1",
-        ExceptionStartTime: toCompact(this.recurrenceStartTime),
+        Exception: {
+          Deleted: "1",
+          ExceptionStartTime: toCompact(this.recurrenceStartTime),
+        }
       }));
     } else {
       let data = {
@@ -188,6 +190,15 @@ export class ActiveSyncEvent extends Event {
       }
     }
     await super.deleteFromServer();
+  }
+
+  async makeExclusion(indices: number[]) {
+    await this.saveFields(this.toFields(indices.map(index => ({
+      Exception: {
+        Deleted: "1",
+        ExceptionStartTime: toCompact(this.recurrenceRule.getOccurrenceByIndex(index + 1) as Date),
+      },
+    }))));
   }
 
   async respondToInvitation(response: InvitationResponseInMessage): Promise<void> {

--- a/app/logic/Calendar/ActiveSync/ActiveSyncEvent.ts
+++ b/app/logic/Calendar/ActiveSync/ActiveSyncEvent.ts
@@ -80,7 +80,7 @@ export class ActiveSyncEvent extends Event {
     let frequency = kRecurrenceTypes[wbxmljs.Type];
     let interval = sanitize.integer(wbxmljs.Interval, 1);
     let weekdays = extractWeekdays(wbxmljs.DayOfWeek);
-    let week = sanitize.integer(wbxmljs.DayOfWeek, 0);
+    let week = sanitize.integer(wbxmljs.WeekOfMonth, 0);
     let first = sanitize.integer(wbxmljs.FirstDayOfWeek, Weekday.Monday);
     return new RecurrenceRule({ startDate, endDate, count, frequency, interval, weekdays, week, first });
   }
@@ -192,7 +192,7 @@ export class ActiveSyncEvent extends Event {
     await super.deleteFromServer();
   }
 
-  async makeExclusion(indices: number[]) {
+  async makeExclusions(indices: number[]) {
     await this.saveFields(this.toFields(indices.map(index => ({
       Exception: {
         Deleted: "1",

--- a/app/logic/Calendar/EWS/EWSEvent.ts
+++ b/app/logic/Calendar/EWS/EWSEvent.ts
@@ -308,6 +308,23 @@ export class EWSEvent extends Event {
     }
   }
 
+  async makeExclusions(indices: number[]) {
+    let request = {
+      m$DeleteItem: {
+        m$ItemIds: indices.map(index => ({
+          t$OccurrenceItemId: {
+            RecurringMasterId: this.parentEvent.itemID,
+            InstanceIndex: index + 1,
+          },
+        })),
+        DeleteType: "MoveToDeletedItems",
+        SendMeetingCancellations: "SendToAllAndSaveCopy",
+      },
+    };
+    await this.calendar.account.callEWS(request);
+    await super.makeExclusions(indices);
+  }
+
   async respondToInvitation(response: InvitationResponseInMessage): Promise<void> {
     assert(this.isIncomingMeeting, "Only invitations can be responded to");
     let request = new EWSCreateItemRequest({MessageDisposition: "SendAndSaveCopy"});

--- a/app/logic/Calendar/Event.ts
+++ b/app/logic/Calendar/Event.ts
@@ -501,7 +501,7 @@ export class Event extends Observable {
     }
     if (exclusions.length) {
       await master.makeExclusions(exclusions);
-    } else {
+    } else if (!this.isNew) {
       await this.calendar.storage.deleteEvent(this);
     }
     await master.save();

--- a/app/logic/Calendar/OWA/OWAEvent.ts
+++ b/app/logic/Calendar/OWA/OWAEvent.ts
@@ -13,7 +13,7 @@ import OWAUpdateOffice365OccurrenceRequest from "./Request/OWAUpdateOffice365Occ
 import OWACreateItemRequest from "../../Mail/OWA/Request/OWACreateItemRequest";
 import OWADeleteItemRequest from "../../Mail/OWA/Request/OWADeleteItemRequest";
 import OWAUpdateItemRequest from "../../Mail/OWA/Request/OWAUpdateItemRequest";
-import { owaCreateExclusionRequest, owaGetEventUIDsRequest, owaOnlineMeetingDescriptionRequest, owaOnlineMeetingURLRequest } from "./Request/OWAEventRequests";
+import { owaCreateExclusionRequest, owaCreateMultipleExclusionsRequest, owaGetEventUIDsRequest, owaOnlineMeetingDescriptionRequest, owaOnlineMeetingURLRequest } from "./Request/OWAEventRequests";
 import type { ArrayColl } from "svelte-collections";
 import { sanitize } from "../../../../lib/util/sanitizeDatatypes";
 import { assert, NotReached } from "../../util/util";
@@ -324,6 +324,11 @@ export class OWAEvent extends Event {
     } else if (this.parentEvent) {
       await this.calendar.account.callOWA(owaCreateExclusionRequest(this, this.parentEvent));
     }
+  }
+
+  async makeExclusions(indices: number[]) {
+    await this.calendar.account.callOWA(owaCreateMultipleExclusionsRequest(indices, this));
+    await super.makeExclusions(indices);
   }
 
   async respondToInvitation(response: InvitationResponseInMessage): Promise<void> {

--- a/app/logic/Calendar/OWA/Request/OWAEventRequests.ts
+++ b/app/logic/Calendar/OWA/Request/OWAEventRequests.ts
@@ -166,13 +166,17 @@ export function owaGetEventUIDsRequest(eventIDs: string[]): OWARequest {
 }
 
 export function owaCreateExclusionRequest(excludeEvent: OWAEvent, parentEvent: OWAEvent): OWARequest {
+  return owaCreateMultipleExclusionsRequest([parentEvent.instances.indexOf(excludeEvent)], parentEvent);
+}
+
+export function owaCreateMultipleExclusionsRequest(indices: number[], parentEvent: OWAEvent): OWARequest {
   return new OWARequest("DeleteItem", {
     __type: "DeleteItemRequest:#Exchange",
-    ItemIds: [{
+    ItemIds: indices.map(index => ({
       __type: "OccurrenceItemId:#Exchange",
       RecurringMasterId: parentEvent.itemID,
-      InstanceIndex: parentEvent.instances.indexOf(excludeEvent) + 1,
-    }],
+      InstanceIndex: index + 1,
+    })),
     DeleteType: "MoveToDeletedItems",
     SendMeetingCancellations: "SendToAllAndSaveCopy",
   });

--- a/app/logic/Calendar/RecurrenceRule.ts
+++ b/app/logic/Calendar/RecurrenceRule.ts
@@ -190,7 +190,13 @@ export class RecurrenceRule implements Readonly<RecurrenceInit> {
     let allWeekdays = [0, 1, 2, 3, 4, 5, 6];
     let thisWeekdays = this.weekdays || allWeekdays;
     let ruleWeekdays = rule.weekdays || allWeekdays;
-    return rule.startDate.getTime() == this.startDate.getTime() && rule.frequency == this.frequency && rule.interval == this.interval && rule.week == this.week && rule.first == this.first && allWeekdays.every(weekday => ruleWeekdays.includes(weekday) == thisWeekdays.includes(weekday));
+    return rule.startDate.getTime() == this.startDate.getTime() &&
+      rule.frequency == this.frequency &&
+      rule.interval == this.interval &&
+      rule.week == this.week &&
+      rule.first == this.first &&
+      allWeekdays.every(weekday =>
+        ruleWeekdays.includes(weekday) == thisWeekdays.includes(weekday));
   }
 
   getOccurrencesByDate(endDate: Date, startDate: Date = this.startDate): Date[] {

--- a/app/logic/Calendar/RecurrenceRule.ts
+++ b/app/logic/Calendar/RecurrenceRule.ts
@@ -182,6 +182,17 @@ export class RecurrenceRule implements Readonly<RecurrenceInit> {
     return 'RRULE:' + Object.entries(rule).map(entry => entry.join("=")).join(";");
   }
 
+  /**
+   * Checks whether this rule will invalidate existing occurrences.
+   * We don't check the series length though, as the UI never sets one.
+   */
+  isCompatible(rule: RecurrenceRule) {
+    let allWeekdays = [0, 1, 2, 3, 4, 5, 6];
+    let thisWeekdays = this.weekdays || allWeekdays;
+    let ruleWeekdays = rule.weekdays || allWeekdays;
+    return rule.startDate.getTime() == this.startDate.getTime() && rule.frequency == this.frequency && rule.interval == this.interval && rule.week == this.week && rule.first == this.first && allWeekdays.every(weekday => ruleWeekdays.includes(weekday) == thisWeekdays.includes(weekday));
+  }
+
   getOccurrencesByDate(endDate: Date, startDate: Date = this.startDate): Date[] {
     if (this.endDate && this.endDate < endDate) {
       endDate = this.endDate;


### PR DESCRIPTION
- After deleting all other instances of a series, deleting the last instance deletes the series
- If editing the first instance of a series, provides button to delete entire series
- If editing an instance in the middle of a series, provides button to delete remainder of series
- If editing the first instance of a series, allows recurring master to be replaced with current event
- If editing an instance in the middle of a series, allows a new series to be started from this point (truncates old series)

Notes:
- When replacing part or all of a series, you must specify the recurrence again, as the start date may have changed, invalidating the previous recurrence
- For some reason, after converting a series back to a single event, the UI gets confused and needs a restart to be able to convert the event back to a series