### PR TITLE
Calendar: Free/Busy: EWS, OWA, ActiveSync

### DIFF
--- a/app/logic/Calendar/Calendar.ts
+++ b/app/logic/Calendar/Calendar.ts
@@ -1,5 +1,6 @@
 import { Account } from "../Abstract/Account";
 import { Event } from "./Event";
+import type { Participant } from "./Participant";
 import { appGlobal } from "../app";
 import { Collection, ArrayColl } from "svelte-collections";
 import { ICalEMailProcessor } from "./ICal/ICalEMailProcessor";
@@ -12,6 +13,10 @@ export class Calendar extends Account {
 
   newEvent(parentEvent?: Event): Event {
     return new Event(this, parentEvent);
+  }
+
+  async arePersonsFree(participants: Participant[], from: Date, to: Date): Promise<{ participant: Participant, availability: { from: Date, to: Date, free: boolean }[] }[]> {
+    return participants.map(participant => ({ participant, availability: [] }));
   }
 
   /**

--- a/app/logic/Calendar/OWA/Request/OWAGetUserAvailabilityRequest.ts
+++ b/app/logic/Calendar/OWA/Request/OWAGetUserAvailabilityRequest.ts
@@ -1,0 +1,45 @@
+import type { Participant } from "../../Participant";
+
+export default class OWAGetUserAvailabilityRequest {
+  /** Free/Busy requests are wrapped in an additional object for some reason. */
+  readonly request: any = {
+    __type: "GetUserAvailabilityInternalJsonRequest:#Exchange",
+    Header: {
+      __type: "JsonRequestHeaders:#Exchange",
+      RequestServerVersion: "Exchange2013",
+      TimeZoneContext: {
+        __type: "TimeZoneContext:#Exchange",
+        TimeZoneDefinition: {
+          __type: "TimeZoneDefinitionType:#Exchange",
+          Id: "UTC",
+        },
+      },
+    },
+    Body: {
+      __type: "GetUserAvailabilityRequest:#Exchange",
+      FreeBusyViewOptions: {
+        __type: "FreeBusyViewOptions:#Exchange",
+        TimeWindow: {
+          __type: "Duration:#Exchange",
+        },
+        RequestedView: "FreeBusy",
+      },
+    },
+  };
+
+  constructor(participants: Participant[], from: Date, to: Date) {
+    this.request.Body.MailboxDataArray = participants.map(participant => ({
+      __type: "MailboxData:#Exchange",
+      Email: {
+        __type: "EmailAddress:#Exchange",
+        Address: participant.emailAddress,
+      },
+    }));
+    this.request.Body.FreeBusyViewOptions.TimeWindow.StartTime = from.toISOString();
+    this.request.Body.FreeBusyViewOptions.TimeWindow.EndTime = to.toISOString();
+  }
+
+  get action() {
+    return "GetUserAvailabilityInternal";
+  }
+}

--- a/app/logic/Mail/ActiveSync/ActiveSyncError.ts
+++ b/app/logic/Mail/ActiveSync/ActiveSyncError.ts
@@ -160,6 +160,10 @@ const messages: Record<string, Record<number, string>> = {
     2: "Protocol error",
     3: "Server error",
   },
+  ResolveRecipients: {
+    5: "Invalid parameters",
+    6: "Retryable server error",
+  },
   Settings: {
     2: "Protocol error",
     3: "Access is deined",

--- a/app/logic/Mail/ActiveSync/WBXML.ts
+++ b/app/logic/Mail/ActiveSync/WBXML.ts
@@ -17,7 +17,7 @@ const kTags = [
   [,,,,,,, "DisplayName", "ServerId", "ParentId", "Type",, "Status",, "Changes", "Add", "Delete", "Update", "SyncKey", "FolderCreate", "FolderDelete", "FolderUpdate", "FolderSync", "Count"],
   [,,,,, "CalendarId", "CollectionId", "MeetingResponse", "RequestId", "Request", "Result", "Status", "UserResponse",, "InstanceId"],
   [,,,,,,,, "Categories", "Category", "Complete", "DateCompleted", "DueDate", "UtcDueDate", "Importance", "Recurrence", "Type", "Start", "Until", "Occurrences", "Interval", "DayOfMonth", "DayOfWeek", "WeekOfMonth", "MonthOfYear", "Regenerate", "DeadOccur", "ReminderSet", "ReminderTime", "Sensitivity", "StartDate", "UtcStartDate", "Subject",, "OrdinalDate", "SubOrdinalDate", "CalendarType", "IsLeapMonth", "FirstDayOfWeek"],
-  [,,,,, "ResolveRecipients", "Response", "Status", "Type", "Recipient", "DisplayName", "EmailAddress",,,, "Options", "To",,,,,, "Availability", "StartTime", "EndTime", "MergedFreeBusy"],
+  [,,,,, "ResolveRecipients", "Response", "Status", "Type", "Recipient", "DisplayName", "EmailAddress",,,, "Options", "To",, "RecipientCount",,,, "Availability", "StartTime", "EndTime", "MergedFreeBusy"],
   [],
   [,,,,,,, "IMAddress", "IMAddress2", "IMAddress3",,,, "NickName"],
   [,,,,, "Ping",, "Status", "HeartbeatInterval", "Folders", "Folder", "Id", "Class", "MaxFolders"],

--- a/app/logic/Mail/EWS/EWSAccount.ts
+++ b/app/logic/Mail/EWS/EWSAccount.ts
@@ -1,6 +1,6 @@
 import { AuthMethod, MailAccount, TLSSocketType } from "../MailAccount";
 import type { EMail } from "../EMail";
-import { EWSFolder } from "./EWSFolder";
+import { EWSFolder, getEWSItem } from "./EWSFolder";
 import EWSCreateItemRequest from "./Request/EWSCreateItemRequest";
 import type EWSDeleteItemRequest from "./Request/EWSDeleteItemRequest";
 import type EWSUpdateItemRequest from "./Request/EWSUpdateItemRequest";
@@ -170,6 +170,11 @@ export class EWSAccount extends MailAccount {
     let responseXML = aResponse.responseXML;
     if (!responseXML) {
       throw new EWSError(aResponse, aRequest);
+    }
+    // Free/Busy is a special snowflake and has its own element.
+    let freebusy = responseXML.querySelector("FreeBusyResponseArray");
+    if (freebusy) {
+      return ensureArray(getEWSItem(XML2JSON(freebusy)));
     }
     let messages = responseXML.querySelector("ResponseMessages");
     if (!messages) {


### PR DESCRIPTION
Works from the console at least.

Note that EWS and OWA return one availability entry for each event within the time frame, while ActiveSync returns half hour availability entries for the entire time frame which are marked free only if no busy event overlaps the given half hour.