### PR TITLE
HTMLEditor: Insert link UI

### DIFF
--- a/app/frontend/Shared/Editor/HTMLEditor.svelte
+++ b/app/frontend/Shared/Editor/HTMLEditor.svelte
@@ -12,6 +12,7 @@
   import { Footer } from './Footer';
   import { BoldStar, ItalicSlash } from './StdConventions';
   import { ParagraphNewLine } from './ParagraphNewLine';
+  import { InsertLink } from './InsertLink';
   // import CodeBlockLowlightFeature from '@tiptap/extension-code-block-lowlight';
   // import { common as lowlightCommon, createLowlight } from 'lowlight'
   import { onMount, onDestroy } from 'svelte';
@@ -50,6 +51,9 @@
         BoldStar,
         ItalicSlash,
         ParagraphNewLine,
+        InsertLink.configure({
+          editorEl: rootEl,
+        }),
         // CodeBlockLowlightFeature.configure({
         //  lowlight: createLowlight(lowlightCommon),
         // }),

--- a/app/frontend/Shared/Editor/HTMLEditorToolbar.svelte
+++ b/app/frontend/Shared/Editor/HTMLEditorToolbar.svelte
@@ -129,14 +129,14 @@ block
     </Button>
     <Button
       label={$t`Link to webpage`}
-      onClick={onLinkOpen}
+      onClick={() => editor.commands.toggleLinkUI()}
       selected={editor.isActive('link')}
       icon={LinkIcon}
       iconOnly
       />
     <Button
       label={$t`Remove link`}
-      onClick={() => { editor.chain().focus().unsetLink().run(); isEditingLink = false; }}
+      onClick={() => { editor.chain().focus().unsetLink().run()}}
       disabled={!editor.can().chain().focus().unsetLink().run()}
       icon={LinkRemoveIcon}
       iconOnly
@@ -179,29 +179,6 @@ block
   </Toolbar>
 {/if}
 
-{#if isEditingLink}
-  <Toolbar>
-    <hbox flex class="link-dialog">
-      <!-- <label for="linktext">Link text</label>
-      <input type="text" bind:value={linkText} id="linktext" /> -->
-      <label for="linktargeturl">Link target URL</label>
-      <input type="url" bind:value={linkTargetURL} id="linktargeturl" />
-      <Button
-        onClick={onLinkOK}
-        label={$t`OK`}
-        icon={OKIcon}
-        iconOnly
-        />
-      <Button
-        label={$t`Remove link`}
-        onClick={() => { editor.chain().focus().unsetLink().run(); isEditingLink = false; }}
-        disabled={!editor.can().chain().focus().unsetLink().run()}
-        icon={LinkRemoveIcon}
-        iconOnly
-        />
-    </hbox>
-  </Toolbar>
-{/if}
 {#if isEditingImage}
   <Toolbar>
     <hbox flex class="link-dialog">
@@ -239,17 +216,6 @@ block
 
   /* in only */
   export let editor: Editor;
-
-  let isEditingLink = false;
-  let linkTargetURL: string = null;
-  function onLinkOpen() {
-    isEditingLink = true;
-    linkTargetURL = editor.getAttributes('link').href
-  }
-  function onLinkOK() {
-    editor.chain().focus().setLink({ href: linkTargetURL }).run();
-    isEditingLink = false;
-  }
 
   let isEditingImage = false;
   let imageURL: string = null;

--- a/app/frontend/Shared/Editor/InsertLink.ts
+++ b/app/frontend/Shared/Editor/InsertLink.ts
@@ -1,0 +1,78 @@
+import { Extension } from "@tiptap/core";
+import BubbleMenu from "@tiptap/extension-bubble-menu";
+import InsertLinkUI from "./InsertLinkUI.svelte";
+
+declare module '@tiptap/core' {
+  interface Commands<ReturnType> {
+    insertLink: {
+      /**
+       * Comments will be added to the autocomplete.
+       */
+      toggleLinkUI: () => ReturnType;
+    }
+  }
+}
+
+export interface InsertLinkOptions {
+  /** The element that the editor attachs to.
+   * Must be set otherwise this extension will not work.
+   */
+  editorEl: HTMLElement,
+}
+
+export interface InsertLinkStorage {
+  showUI: boolean,
+  UIComponent?: InsertLinkUI,
+}
+
+/**
+ * Creates an UI for inserting links.
+ * Must configure the editorEl that the editor attaches to.
+ */
+export const InsertLink = Extension.create<InsertLinkOptions, InsertLinkStorage>({
+  name: "insertLink",
+  addOptions() {
+    return {
+      editorEl: null,
+    }
+  },
+  addStorage() {
+    return {
+      showUI: false,
+      UIcomponent: null,
+    }
+  },
+  addExtensions() {
+    const elID = "insertLinkUI";
+    let div = document.createElement("div");
+    div.id = elID;
+    this.options.editorEl.after(div);
+    let el = document.getElementById(elID);
+    this.storage.UIComponent = new InsertLinkUI({
+      target: el,
+    });
+    return [
+      BubbleMenu.configure({
+        element: el,
+        shouldShow: () => {
+          return this.storage.showUI;
+        },
+      }),
+    ]
+  },
+  addCommands() {
+    return {
+      toggleLinkUI: () => ({ editor, commands }) => {
+        this.storage.showUI = !this.storage.showUI;
+        this.storage.UIComponent.$set({
+          editor: editor,
+          linkTargetURL: editor.getAttributes("link").href,
+        });
+        return commands.focus();
+      }
+    }
+  },
+  onSelectionUpdate() {
+    this.storage.showUI = false;
+  }
+});

--- a/app/frontend/Shared/Editor/InsertLinkUI.svelte
+++ b/app/frontend/Shared/Editor/InsertLinkUI.svelte
@@ -1,0 +1,44 @@
+<Toolbar>
+  <hbox flex class="link-dialog">
+    <!-- <label for="linktext">Link text</label>
+    <input type="text" bind:value={linkText} id="linktext" /> -->
+    <!-- <label for="linktargeturl">Link target URL</label> -->
+    <input type="url" bind:value={linkTargetURL} id="linktargeturl" />
+    <Button
+      onClick={onLinkOK}
+      label={$t`OK`}
+      icon={OKIcon}
+      iconOnly
+      />
+    <Button
+      label={$t`Remove link`}
+      onClick={() => { editor.chain().focus().unsetLink().toggleLinkUI().run()}}
+      disabled={!editor?.can().chain().focus().unsetLink().run()}
+      icon={LinkRemoveIcon}
+      iconOnly
+      />
+  </hbox>
+</Toolbar>
+
+<!--
+@component
+UI component for InsertLinks.ts
+-->
+
+<script lang="ts">
+  import Toolbar from "../Toolbar/Toolbar.svelte";
+  import Button from "../Button.svelte";
+  import OKIcon from "lucide-svelte/icons/check";
+  import LinkRemoveIcon from "lucide-svelte/icons/unlink";
+  import type { Editor } from "@tiptap/core";
+  import { t } from "../../../l10n/l10n";
+
+  export let editor: Editor;
+
+  /** in: Set URL to the selection */
+  export let linkTargetURL: string = null;
+  function onLinkOK() {
+    editor.chain().focus().setLink({ href: linkTargetURL }).toggleLinkUI().run();
+    linkTargetURL = null;
+  }
+</script>

--- a/app/frontend/Shared/Editor/InsertLinkUI.svelte
+++ b/app/frontend/Shared/Editor/InsertLinkUI.svelte
@@ -3,7 +3,7 @@
     <!-- <label for="linktext">Link text</label>
     <input type="text" bind:value={linkText} id="linktext" /> -->
     <!-- <label for="linktargeturl">Link target URL</label> -->
-    <input type="url" bind:value={linkTargetURL} id="linktargeturl" />
+    <input type="url" bind:value={linkTargetURL} id="linktargeturl" placeholder={$t`Link target URL`}/>
     <Button
       onClick={onLinkOK}
       label={$t`OK`}

--- a/app/package.json
+++ b/app/package.json
@@ -25,6 +25,7 @@
     "@svelteuidev/composables": "^0.14.0",
     "@svelteuidev/core": "^0.14.0",
     "@tiptap/core": "^2.2.2",
+    "@tiptap/extension-bubble-menu": "^2.11.7",
     "@tiptap/extension-code": "^2.2.2",
     "@tiptap/extension-code-block-lowlight": "^2.2.2",
     "@tiptap/extension-image": "^2.2.4",


### PR DESCRIPTION
With the new Bubble Menu, I've implemented a small bubble menu that shows up near the selected when you want to insert a link. The UI isn't great and the input field is not focused when the bubble menu shows up. But this is what I propose. I would like a better UI though.

<img width="341" alt="Image" src="https://github.com/user-attachments/assets/2a5dae67-83ac-4c02-a199-c10da47a2751" />

It only works for links now.

To use the extension you would have to configure it like, where you have to pass the element that the editor will attach to because setting up the UI needs to happen before the editor is loaded.

```js
        InsertLink.configure({
          editorEl: rootEl,
        }),
```