### PR TITLE
Fix some more recurrenceCase cases in the backend

### DIFF
--- a/app/logic/Calendar/ActiveSync/ActiveSyncEvent.ts
+++ b/app/logic/Calendar/ActiveSync/ActiveSyncEvent.ts
@@ -61,6 +61,10 @@ export class ActiveSyncEvent extends Event {
           this.replaceInstance(occurrences.length - 1, null);
         }
       }
+    } else if (this.recurrenceRule) {
+      this.recurrenceCase = RecurrenceCase.Normal;
+      this.recurrenceRule = null;
+      this.clearExceptions();
     }
     this.alarm = wbxmljs.Reminder ? new Date(this.startTime.getTime() - 60 * sanitize.integer(wbxmljs.Reminder)) : null;
     this.location = sanitize.nonemptystring(wbxmljs.Location, "");

--- a/app/logic/Calendar/EWS/EWSEvent.ts
+++ b/app/logic/Calendar/EWS/EWSEvent.ts
@@ -86,6 +86,10 @@ export class EWSEvent extends Event {
           this.replaceInstance(occurrences.length - 1, null);
         }
       }
+    } else if (this.recurrenceRule) {
+      this.recurrenceCase = RecurrenceCase.Normal;
+      this.recurrenceRule = null;
+      this.clearExceptions();
     }
     if (xmljs.ReminderIsSet == "true") {
       this.alarm = new Date(this.startTime.getTime() - 60 * sanitize.integer(xmljs.ReminderMinutesBeforeStart));

--- a/app/logic/Calendar/Event.ts
+++ b/app/logic/Calendar/Event.ts
@@ -240,6 +240,9 @@ export class Event extends Observable {
         occurrence.copyFromRecurrenceMaster(this);
       }
     }
+    if (this.recurrenceCase == RecurrenceCase.Instance) {
+      this.recurrenceCase = RecurrenceCase.Exception;
+    }
   }
 
   async saveToServer(): Promise<void> {

--- a/app/logic/Calendar/JSON/JSONEvent.ts
+++ b/app/logic/Calendar/JSON/JSONEvent.ts
@@ -1,4 +1,4 @@
-import { Event } from "../Event";
+import { Event, RecurrenceCase } from "../Event";
 import { Participant } from "../Participant";
 import { RecurrenceRule } from "../RecurrenceRule";
 import { appGlobal } from "../../app";
@@ -78,6 +78,7 @@ export class JSONEvent {
       let masterID = sanitize.string(json.recurrenceMasterEventID);
       let parentEvent = events?.find(event => event.pID == masterID);
       if (parentEvent?.recurrenceRule) {
+        event.recurrenceCase = RecurrenceCase.Exception;
         event.parentEvent = parentEvent;
         event.recurrenceStartTime = sanitize.date(json.recurrenceStartTime);
         let occurrences = event.parentEvent.recurrenceRule?.getOccurrencesByDate(event.recurrenceStartTime) as Date[];
@@ -85,7 +86,7 @@ export class JSONEvent {
       }
     }
     if (json.recurrenceRule) {
-      event.repeat = true;
+      event.recurrenceCase = RecurrenceCase.Master;
       event.recurrenceRule = RecurrenceRule.fromCalString(event.startTime, json.recurrenceRule);
       JSONEvent.readExclusions(event, json);
     }

--- a/app/logic/Calendar/OWA/OWAEvent.ts
+++ b/app/logic/Calendar/OWA/OWAEvent.ts
@@ -82,6 +82,10 @@ export class OWAEvent extends Event {
           this.replaceInstance(occurrences.length - 1, null);
         }
       }
+    } else if (this.recurrenceRule) {
+      this.recurrenceCase = RecurrenceCase.Normal;
+      this.recurrenceRule = null;
+      this.clearExceptions();
     }
     if (json.ReminderIsSet) {
       this.alarm = new Date(this.startTime.getTime() - 60 * sanitize.integer(json.ReminderMinutesBeforeStart));


### PR DESCRIPTION
- Fixed cases where an event wasn't getting correctly marked as an exception
- Tried to fix `JSONEvent` (untested)

While I was there I noticed that there's no support for recurring masters that were turned back into single events from a different client. This is possible in Lightning and in older versions of Outlook Web Access but they removed the UI from Exchange Online.