### PR TITLE
EWS, OWA, ActiveSync: Save timezone

### DIFF
--- a/app/logic/Calendar/ActiveSync/ActiveSyncEvent.ts
+++ b/app/logic/Calendar/ActiveSync/ActiveSyncEvent.ts
@@ -87,7 +87,7 @@ export class ActiveSyncEvent extends Event {
   toFields(exception?: any) {
     return {
       ExceptionStartTime: toCompact(this.recurrenceStartTime) || [],
-      Timezone: this.recurrenceStartTime ? [] : getTimeZoneActiveSync(),
+      Timezone: this.recurrenceStartTime ? [] : getTimeZoneActiveSync(this.timezone),
       AllDayEvent: this.allDay ? "1" : "0",
       Attendees: (!this.recurrenceStartTime || this.participants.hasItems) ? {
         Attendee: this.participants.contents.map(entry => ({ Email: entry.emailAddress, Name: entry.name, AttendeeType: kRequiredAttendee })),
@@ -207,18 +207,15 @@ export function fromCompact(date: string): Date {
   return new Date(date.replace(/-|:|\..../g, "").replace(/(..)(..T..)(..)/, "-$1-$2:$3:"));
 }
 
-let gTimeZone: string = "";
-function getTimeZoneActiveSync(): string {
-  if (!gTimeZone) {
-    let timezone = IANAToWindowsTimezone[Intl.DateTimeFormat().resolvedOptions().timeZone] || "UTC";
-    let unicode = new Uint16Array(86);
-    let pos = 2;
-    for (let c of timezone) {
-      unicode[pos++] = c.charCodeAt();
-    }
-    gTimeZone = btoa(String.fromCharCode(...new Uint8Array(unicode.buffer)));
+function getTimeZoneActiveSync(timezone): string {
+  timezone ||= Intl.DateTimeFormat().resolvedOptions().timeZone;
+  timezone = IANAToWindowsTimezone[timezone] || "UTC";
+  let unicode = new Uint16Array(86);
+  let pos = 2;
+  for (let c of timezone) {
+    unicode[pos++] = c.charCodeAt();
   }
-  return gTimeZone;
+  return btoa(String.fromCharCode(...new Uint8Array(unicode.buffer)));
 }
 
 function fromActiveSyncZone(zone): string | null {

--- a/app/logic/Calendar/EWS/EWSEvent.ts
+++ b/app/logic/Calendar/EWS/EWSEvent.ts
@@ -35,8 +35,6 @@ const RecurrenceType = {
   DailyRecurrence: Frequency.Daily,
 };
 
-const gTimeZone = IANAToWindowsTimezone[Intl.DateTimeFormat().resolvedOptions().timeZone] || "UTC";
-
 export class EWSEvent extends Event {
   calendar: EWSCalendar;
   parentEvent: EWSEvent;
@@ -75,7 +73,7 @@ export class EWSEvent extends Event {
     if (xmljs.DueDate) {
       this.endTime = sanitize.date(xmljs.DueDate);
     }
-    this.timezone = fromWindowsZone(xmljs.StartTimezoneId);
+    this.timezone = fromWindowsZone(xmljs.StartTimeZoneId);
     this.allDay = sanitize.boolean(xmljs.IsAllDayEvent, false);
     if (xmljs.Recurrence) {
       this.recurrenceCase = RecurrenceCase.Master;
@@ -182,8 +180,9 @@ export class EWSEvent extends Event {
     // No support for optional attendees in mustang;
     // all attendees get converted to be required for now.
     request.addField("CalendarItem", "OptionalAttendees", null, "calendar:OptionalAttendees");
-    request.addField("CalendarItem", "StartTimeZone", { Id: gTimeZone }, "calendar:StartTimeZone");
-    request.addField("CalendarItem", "EndTimeZone", { Id: gTimeZone }, "calendar:EndTimeZone");
+    let timezone = IANAToWindowsTimezone[this.timezone || Intl.DateTimeFormat().resolvedOptions().timeZone] || "UTC";
+    request.addField("CalendarItem", "StartTimeZone", { Id: timezone }, "calendar:StartTimeZone");
+    request.addField("CalendarItem", "EndTimeZone", { Id: timezone }, "calendar:EndTimeZone");
     let response = await this.calendar.account.callEWS(request);
     this.itemID = sanitize.nonemptystring(response.Items.CalendarItem.ItemId.Id);
     if (this.calUID) {

--- a/app/logic/Calendar/Event.ts
+++ b/app/logic/Calendar/Event.ts
@@ -201,7 +201,7 @@ export class Event extends Observable {
       this.calUID != this.unedited.calUID ||
       this.startTime?.getTime() != this.unedited.startTime?.getTime() ||
       this.endTime?.getTime() != this.unedited.endTime?.getTime() ||
-      this.timezone != this.unedited.timezone  && !!this.unedited.timezone ||
+      this.timezone != this.unedited.timezone ||
       this.allDay != this.unedited.allDay ||
       this.title != this.unedited.title ||
       this.descriptionText != this.unedited.descriptionText ||
@@ -221,6 +221,7 @@ export class Event extends Observable {
   }
 
   startEditing() {
+    this.timezone ||= Intl.DateTimeFormat().resolvedOptions().timeZone;
     this.unedited = this.calendar.newEvent();
     this.unedited.copyFrom(this);
   }

--- a/app/logic/Calendar/OWA/OWAEvent.ts
+++ b/app/logic/Calendar/OWA/OWAEvent.ts
@@ -23,8 +23,6 @@ const ResponseTypes: Record<Responses, string> = {
   [ResponseType.Decline]: "DeclineItem",
 };
 
-const gTimeZone = IANAToWindowsTimezone[Intl.DateTimeFormat().resolvedOptions().timeZone] || "UTC";
-
 enum WeekOfMonth {
   'First' = 1,
   'Second' = 2,
@@ -189,8 +187,14 @@ export class OWAEvent extends Event {
     // No support for optional attendees in mustang;
     // all attendees get converted to be required for now.
     request.addField("CalendarItem", "OptionalAttendees", null, "calendar:OptionalAttendees");
-    request.addField("CalendarItem", "StartTimeZone", { __type: "TimeZoneDefinitionType:#Exchange", Id: gTimeZone }, "calendar:StartTimeZone");
-    request.addField("CalendarItem", "EndTimeZone", { __type: "TimeZoneDefinitionType:#Exchange", Id: gTimeZone }, "calendar:EndTimeZone");
+    let timezone = IANAToWindowsTimezone[this.timezone || Intl.DateTimeFormat().resolvedOptions().timeZone] || "UTC";
+    if (this.calendar.account.isOffice365()) {
+      request.addField("CalendarItem", "StartTimeZoneId", timezone, "calendar:StartTimeZoneId");
+      request.addField("CalendarItem", "EndTimeZoneId", timezone, "calendar:EndTimeZoneId");
+    } else {
+      request.addField("CalendarItem", "StartTimeZone", { __type: "TimeZoneDefinitionType:#Exchange", Id: timezone }, "calendar:StartTimeZone");
+      request.addField("CalendarItem", "EndTimeZone", { __type: "TimeZoneDefinitionType:#Exchange", Id: timezone }, "calendar:EndTimeZone");
+    }
     if (this.calendar.account.isOffice365() && this.isOnline && !this.onlineMeetingURL) {
       request.addField("CalendarItem", "IsOnlineMeeting", true, "IsOnlineMeeting");
       request.addField("CalendarItem", "OnlineMeetingProvider", "TeamsForBusiness", "OnlineMeetingProvider");


### PR DESCRIPTION
Also fix Office 365 to save timezones correctly (regression from #455).

Plus fix EWS to read the timezone correctly (bug in #517).