### PR TITLE
UI: Change font sizes into CSS classes - Pass 2 (#556)

### DIFF
--- a/app/frontend/Calendar/DisplayEvent/Invitation.svelte
+++ b/app/frontend/Calendar/DisplayEvent/Invitation.svelte
@@ -20,18 +20,18 @@
         label={$t`Confirm *=> Confirm to attend the meeting`}
         onClick={onAccept}
         icon={AcceptIcon}
-        classes="accept" />
+        classes="accept font-normal" />
       <Button
         label={$t`Reject *=> Decline to attend the meeting`}
         onClick={onDecline}
         icon={DeclineIcon}
-        classes="decline secondary" />
+        classes="decline secondary font-normal" />
       <ButtonMenu buttonIcon={ChevronDownIcon}>
         <MenuItem
           label={$t`Maybe *=> Maybe attend the meeting`}
           onClick={onTentative}
           icon={MaybeIcon}
-          classes="maybe" />
+          classes="maybe font-normal" />
       </ButtonMenu>
     </hbox>
   {:else if message.scheduling == Scheduling.Accepted}
@@ -41,18 +41,18 @@
         icon={AcceptIcon}
         selected={true}
         disabled={true}
-        classes="accept done" />
+        classes="accept done font-normal" />
       <ButtonMenu buttonIcon={ChevronDownIcon}>
         <MenuItem
           label={$t`Change to Reject *=> not attend the meeting`}
           onClick={onDecline}
           icon={DeclineIcon}
-          classes="decline" />
+          classes="decline font-normal" />
         <MenuItem
           label={$t`Change to Maybe *=> Maybe attend the meeting`}
           onClick={onTentative}
           icon={MaybeIcon}
-          classes="maybe" />
+          classes="maybe font-normal" />
       </ButtonMenu>
     </hbox>
   {:else if message.scheduling == Scheduling.Declined}
@@ -62,18 +62,18 @@
         icon={DeclineIcon}
         selected={true}
         disabled={true}
-        classes="decline done" />
+        classes="decline done font-normal" />
       <ButtonMenu buttonIcon={ChevronDownIcon}>
         <MenuItem
           label={$t`Change to Accept *=> attend the meeting`}
           onClick={onAccept}
           icon={AcceptIcon}
-          classes="accept" />
+          classes="accept font-normal" />
         <MenuItem
           label={$t`Change to Maybe *=> Maybe attend the meeting`}
           onClick={onTentative}
           icon={MaybeIcon}
-          classes="maybe" />
+          classes="maybe font-normal" />
       </ButtonMenu>
     </hbox>
   {/if}
@@ -119,11 +119,9 @@
   }
   .buttons > :global(button) {
     margin-inline-start: 12px;
-    font-size: 15px;
   }
   .buttons :global(button.menu-button) {
     margin-inline-start: 4px;
-    font-size: 15px;
   }
   .buttons :global(button .label) {
     margin-inline-end: 6px;

--- a/app/frontend/Calendar/DisplayEvent/MoreBubble.svelte
+++ b/app/frontend/Calendar/DisplayEvent/MoreBubble.svelte
@@ -1,7 +1,9 @@
 <hbox class="more-bubble a b">
   <Button {onClick} iconSize="10px"
     label="+ {plusNum}"
-    tooltip={$t`Show ${plusNum} more`} />
+    tooltip={$t`Show ${plusNum} more`}
+    classes="font-small"
+    />
 </hbox>
 
 <script lang="ts">
@@ -15,7 +17,6 @@
 <style>
   .more-bubble.a.b :global(button) {
     border: none;
-    font-size: 14px;
     padding: 0px 8px;
   }
   .more-bubble :global(button:not(:hover)) {

--- a/app/frontend/Calendar/DisplayEvent/ParticipantsDisplay.svelte
+++ b/app/frontend/Calendar/DisplayEvent/ParticipantsDisplay.svelte
@@ -16,7 +16,7 @@
         icon={ChevronUpIcon}
         label={$t`Collapse`}
         onClick={() => showAllParticipants = false}
-        classes="small collapse"
+        classes="small collapse font-small"
         iconOnly
         />
     {:else if $participants?.length > showNumParticipants}
@@ -65,7 +65,6 @@
   }
   .participants .buttons :global(button.collapse) {
     border: none;
-    font-size: 14px;
     padding: 0px 4px;
   }
 </style>

--- a/app/frontend/Calendar/EditEvent/TitleBox.svelte
+++ b/app/frontend/Calendar/EditEvent/TitleBox.svelte
@@ -1,5 +1,5 @@
 <hbox class="title">
-  <input type="text" placeholder={$t`Title - Enter the topic of the meeting`} bind:value={event.title} />
+  <input type="text" placeholder={$t`Title - Enter the topic of the meeting`} bind:value={event.title} class="font-normal"/>
 </hbox>
 
 <script lang="ts">
@@ -13,7 +13,6 @@
   .title input {
     font-size: 100%;
     font-weight: bold;
-    font-size: 16px;
     padding: 6px 12px;
     max-width: 40em;
   }

--- a/app/frontend/Contacts/PersonAutocomplete/PersonPopup.svelte
+++ b/app/frontend/Contacts/PersonAutocomplete/PersonPopup.svelte
@@ -12,13 +12,13 @@
       {/if}
     </vbox>
     {#if isEditing}
-      <vbox class="name-primary-mail" flex>
-        <input class="name" type="text"
+      <vbox class="name-primary-mail font-normal" flex>
+        <input class="name font-normal" type="text"
           bind:value={personUID.name}
           bind:this={nameInputEl}
           on:keydown={(event) => onKeyEnter(event, onClose)}
           placeholder={$t`Enter a name for the person`} />
-        <input class="email" type="email"
+        <input class="email font-normal" type="email"
           bind:value={personUID.emailAddress}
           placeholder={$t`Email address to be used here`} />
       </vbox>
@@ -179,10 +179,8 @@
   }
   .name-primary-mail,
   .name-primary-mail input {
-    font-size: 15px;
   }
   input {
-    font-size: 15px;
     min-width: 15em;
   }
   .helptext {

--- a/app/frontend/Contacts/PersonDetails.svelte
+++ b/app/frontend/Contacts/PersonDetails.svelte
@@ -71,7 +71,7 @@
       <GroupBox classes="email">
         <svelte:fragment slot="header">
           <Icon data={MailIcon} size="16px" />
-          <h3>{$t`Mail`}</h3>
+          <h3 class="font-small">{$t`Mail`}</h3>
           <hbox flex class="actions">
             <Button on:click={addEmail} icon={AddIcon} iconOnly plain classes="add" />
           </hbox>
@@ -91,7 +91,7 @@
       <GroupBox classes="chat">
         <svelte:fragment slot="header">
           <Icon data={ChatIcon} size="16px" />
-          <h3>{$t`Chat`}</h3>
+          <h3 class="font-small">{$t`Chat`}</h3>
           <hbox flex class="actions">
             <Button on:click={addChatAccount} icon={AddIcon} iconOnly plain classes="add" />
           </hbox>
@@ -113,7 +113,7 @@
           <hbox class="phone">
             <Icon data={PhoneIcon} size="16px" />
           </hbox>
-          <h3>{$t`Phone numbers`}</h3>
+          <h3 class="font-small">{$t`Phone numbers`}</h3>
           <hbox flex class="actions">
             <Button on:click={addPhoneNumber} icon={AddIcon} iconOnly plain classes="add" />
           </hbox>
@@ -133,7 +133,7 @@
       <GroupBox classes="street-addresses">
         <svelte:fragment slot="header">
           <Icon data={MailIcon} size="16px" />
-          <h3>{$t`Street addresses`}</h3>
+          <h3 class="font-small">{$t`Street addresses`}</h3>
           <hbox flex class="actions">
             <Button on:click={addStreetAddress} icon={AddIcon} iconOnly plain classes="add" />
           </hbox>
@@ -153,7 +153,7 @@
       <GroupBox classes="categories">
         <svelte:fragment slot="header">
           <Icon data={ContactsIcon} size="16px" />
-          <h3>{$t`Groups`}</h3>
+          <h3 class="font-small">{$t`Groups`}</h3>
           <hbox flex class="actions">
             <!--
             <Button on:click={addEmail} icon={AddIcon} iconOnly plain classes="add" />
@@ -174,7 +174,7 @@
     <GroupBox classes="preferences">
       <svelte:fragment slot="header">
         <Icon data={ChatIcon} size="16px" />
-        <h3>Preferences</h3>
+        <h3 class="font-small">Preferences</h3>
       </svelte:fragment>
       <vbox class="preferred" slot="content">
         <hbox>Preferred communication tool</hbox>
@@ -200,7 +200,7 @@
 
   {#if showNotes}
     <vbox flex class="notes">
-      <textarea bind:value={person.notes} placeholder={$t`Personal notes`} autofocus={person.notes == " "} />
+      <textarea bind:value={person.notes} placeholder={$t`Personal notes`} autofocus={person.notes == " "} class="font-small" />
     </vbox>
   {/if}
 </vbox>
@@ -381,7 +381,6 @@
     background-color: var(--main-bg);
     color: var(--main-fg);
     font-family: sans-serif;
-    font-size: 14px;
     border: 1px solid var(--border);
     padding: 8px;
   }

--- a/app/frontend/Mail/Composer/MailComposer.svelte
+++ b/app/frontend/Mail/Composer/MailComposer.svelte
@@ -114,7 +114,7 @@
           </Scroll>
           <hbox class="footer">
             <hbox class="subject" flex>
-              <input type="text" bind:value={mail.subject} tabindex={1} placeholder={$t`Subject`} />
+              <input type="text" bind:value={mail.subject} tabindex={1} placeholder={$t`Subject`} class="font-normal" />
             </hbox>
             <hbox class="buttons">
               <RoundButton
@@ -406,7 +406,6 @@
     margin-inline-end: 8px;
   }
   .subject input {
-    font-size: 16px;
   }
   .footer {
     margin-block-start: 8px;

--- a/app/frontend/Mail/Search/RulesFromSearchUI.svelte
+++ b/app/frontend/Mail/Search/RulesFromSearchUI.svelte
@@ -4,7 +4,7 @@
       <label for="rule-account-name">{$t`Runs in account`}</label>
       <hbox id="rule-account-name">{rule.account.name}</hbox>
     </hbox>
-    <input type="text" bind:value={rule.name} placeholder={$t`Name of the rule`} class="font-normal"/>
+    <input type="text" bind:value={rule.name} placeholder={$t`Name of the rule`} class="font-normal" />
 
     <RuleActions {rule} />
 

--- a/app/frontend/Mail/Search/RulesFromSearchUI.svelte
+++ b/app/frontend/Mail/Search/RulesFromSearchUI.svelte
@@ -4,7 +4,7 @@
       <label for="rule-account-name">{$t`Runs in account`}</label>
       <hbox id="rule-account-name">{rule.account.name}</hbox>
     </hbox>
-    <input type="text" bind:value={rule.name} placeholder={$t`Name of the rule`} />
+    <input type="text" bind:value={rule.name} placeholder={$t`Name of the rule`} class="font-normal"/>
 
     <RuleActions {rule} />
 
@@ -57,7 +57,6 @@
   input {
     margin: 12px;
     padding: 2px 4px;
-    font-size: 16px;
   }
   .buttons {
     margin: 12px;

--- a/app/frontend/Mail/Search/SavedSearchUI.svelte
+++ b/app/frontend/Mail/Search/SavedSearchUI.svelte
@@ -1,5 +1,5 @@
 <vbox class="saved-search">
-  <input type="text" bind:value={name} placeholder={$t`Name of the folder`} />
+  <input type="text" bind:value={name} placeholder={$t`Name of the folder`} class="font-normal" />
   <hbox class="buttons">
     <Button
       icon={SaveIcon}
@@ -40,7 +40,6 @@
   input {
     margin: 12px;
     padding: 2px 4px;
-    font-size: 16px;
   }
   .buttons {
     margin: 12px;

--- a/app/frontend/Settings/Mail/Manual/ManualConfigURL.svelte
+++ b/app/frontend/Settings/Mail/Manual/ManualConfigURL.svelte
@@ -1,5 +1,5 @@
 <grid class="manual-config" full={stepFull}>
-  <hbox class="header"></hbox>
+  <hbox class="header font-small"></hbox>
   <hbox class="label">{$t`Protocol`}</hbox>
   <hbox class="label">{$t`URL`}</hbox>
   {#if stepFull}
@@ -8,7 +8,7 @@
     <hbox class="label">{$t`Password`}</hbox>
   {/if}
 
-  <hbox class="header">
+  <hbox class="header font-small">
     <hbox class="direction">
       <ServerIcon size={14} />
     </hbox>
@@ -168,7 +168,6 @@
     padding-block-start: 8px;
     padding-block-end: 8px;
     padding-inline-start: 8px;
-    font-size: 14px;
     border-bottom: 1px solid var(--border);
   }
   grid :global(> *) {

--- a/app/frontend/Setup/Shared/Footer.svelte
+++ b/app/frontend/Setup/Shared/Footer.svelte
@@ -1,6 +1,6 @@
 <hbox class="footer">
-  <a href="{siteRoot}/eula" target="_blank">{$t`Terms of use`}</a>
-  <a href="{siteRoot}/privacy" target="_blank">{$t`Privacy`}</a>
+  <a href="{siteRoot}/eula" target="_blank" class="font-smallest">{$t`Terms of use`}</a>
+  <a href="{siteRoot}/privacy" target="_blank" class="font-smallest">{$t`Privacy`}</a>
 </hbox>
 
 <script lang="ts">
@@ -16,6 +16,5 @@
     margin-inline-end: 24px;
     color: #8583A8;
     font-weight: 300;
-    font-size: 12px;
   }
 </style>


### PR DESCRIPTION
- Replaced instances of `font-size` in CSS rules with classes: `font-smallest`, `font-small`, `font-normal`
- Instances where components export a `classes` prop and select the correct element are replaced
- Instances where the CSS rule is in a tag select are replaced
- Instances where there's a `!important` is still not replaced