### PR TITLE
SQL: Add json column to most tables, for supplemental properties

### DIFF
--- a/app/TODO.md
+++ b/app/TODO.md
@@ -5,8 +5,6 @@
     * Results miss From - Include from/to (both content of messages, and name of recipients/sender)
       * Email
       * Chat
-  * SQL
-    * Non-search properties as JSON
   * Main/Dependent accounts
     * Calendar
     * SMTP
@@ -16,7 +14,6 @@
   * Calendar
     * Edit Event:
       * Buttons: Recurring
-      * Buttons: Cancel?
       * Sidebar
     * List view: FastList missing scrollbar
     * Invitations

--- a/app/logic/Calendar/SQL/SQLCalendar.ts
+++ b/app/logic/Calendar/SQL/SQLCalendar.ts
@@ -68,7 +68,7 @@ export class SQLCalendar {
     for (let row of rows) {
       try {
         let calendar = newCalendarForProtocol(row.protocol);
-        await SQLCalendar.read(row.idStr, row.protocol, row.configJSON, calendar);
+        await SQLCalendar.read(row.idStr, row.protocol, row.json, calendar);
         calendars.add(calendar);
       } catch (ex) {
         backgroundError(ex);

--- a/app/logic/Calendar/SQL/createDatabase.ts
+++ b/app/logic/Calendar/SQL/createDatabase.ts
@@ -95,6 +95,8 @@ export const calendarDatabaseSchema = sql`
     -- Format of the "source"
     -- As MIME type, e.g. "text/calendar" for iCalendar as defined by RFC 9253
     "sourceMimetype" TEXT default null,
+    -- Additional data
+    "json" TEXT default null,
     FOREIGN KEY (calendarID)
       REFERENCES calendar (id)
       ON DELETE CASCADE,
@@ -125,6 +127,8 @@ export const calendarDatabaseSchema = sql`
     -- 4 = rejected
     -- 5 = not responded
     "confirmed" INTEGER default 0,
+    -- Additional data
+    "json" TEXT default null,
     FOREIGN KEY (eventID)
       REFERENCES event (id)
       ON DELETE CASCADE

--- a/app/logic/Chat/SQL/SQLChatAccount.ts
+++ b/app/logic/Chat/SQL/SQLChatAccount.ts
@@ -68,7 +68,7 @@ export class SQLChatAccount {
     for (let row of rows) {
       try {
         let account = newChatAccountForProtocol(row.protocol);
-        await SQLChatAccount.read(row.idStr, row.protocol, row.configJSON, account);
+        await SQLChatAccount.read(row.idStr, row.protocol, row.json, account);
         accounts.add(account);
       } catch (ex) {
         backgroundError(ex);

--- a/app/logic/Chat/SQL/SQLChatMessage.ts
+++ b/app/logic/Chat/SQL/SQLChatMessage.ts
@@ -36,7 +36,7 @@ export class SQLChatMessage {
     if (!msg.dbID) {
       let insert = await (await getDatabase()).run(sql`
         INSERT INTO message (
-          outgoing, fromPersonID, inReplyToMsgID,
+          outgoing, fromPersonID, inReplyToIDStr,
           dateSent, dateReceived,
           plaintext, html, reactionsJSON,
           chatID, idStr
@@ -51,7 +51,7 @@ export class SQLChatMessage {
       await (await getDatabase()).run(sql`
         UPDATE message SET
           fromPersonID = ${msg.contact.dbID},
-          inReplyToMsgID = ${msg.inReplyTo},
+          inReplyToIDStr = ${msg.inReplyTo},
           dateSent = ${msg.sent.getTime() / 1000},
           dateReceived = ${msg.received.getTime() / 1000},
           outgoing = ${msg.outgoing ? 1 : 0},
@@ -69,7 +69,7 @@ export class SQLChatMessage {
     if (!row) {
       row = await (await getDatabase()).get(sql`
         SELECT
-          outgoing, fromPersonID, inReplyToMsgID,
+          outgoing, fromPersonID, inReplyToIDStr,
           dateSent, dateReceived,
           plaintext, html, reactionsJSON,
           chatID, idStr
@@ -143,7 +143,7 @@ export class SQLChatMessage {
     let rows = await (await getDatabase()).all(sql`
       SELECT
         id,
-        outgoing, fromPersonID, inReplyToMsgID,
+        outgoing, fromPersonID, inReplyToIDStr,
         dateSent, dateReceived,
         plaintext, html, reactionsJSON,
         chatID, idStr

--- a/app/logic/Chat/SQL/createDatabase.ts
+++ b/app/logic/Chat/SQL/createDatabase.ts
@@ -3,7 +3,9 @@ import sql from "../../../../lib/rs-sqlite/index";
 export const chatDatabaseSchema = sql`
   CREATE TABLE "message" (
     "id" INTEGER PRIMARY KEY,
+    -- Chat room (or 1:1 chat) where this message was posted
     "chatID" INTEGER not null,
+    -- Protocol-specific message ID
     "idStr" TEXT default null,
     -- When this email was sent, according to RFC822 Header Date:. Unixtime, in seconds (not milliseconds as JS Date).
     "dateSent" INTEGER not null,
@@ -18,10 +20,14 @@ export const chatDatabaseSchema = sql`
     "plaintext" TEXT default null,
     -- HTML content of the email body. May be converted or post-processed.
     "html" TEXT default null,
+    -- This message is a reply to the parent message.
+    -- References "message.idStr"
+    "inReplyToIDStr" INTEGER default null,
     -- Emoji reactions
     -- Format: { personID: number, emoji: string }[]
     "reactionsJSON" TEXT default null,
-    "inReplyToMsgID" INTEGER default null,
+    -- Additional data
+    "json" TEXT default null,
     FOREIGN KEY (chatID)
       REFERENCES chat (ID)
       ON DELETE CASCADE
@@ -39,6 +45,8 @@ export const chatDatabaseSchema = sql`
     -- file size in bytes. null, if not yet downloaded
     "size" INTEGER default null,
     "related" BOOLEAN default 0,
+    -- Additional data
+    "json" TEXT default null,
     UNIQUE("messageID", "filename"),
     FOREIGN KEY (messageID)
       REFERENCES message (ID)
@@ -57,6 +65,8 @@ export const chatDatabaseSchema = sql`
     "contactID" INTEGER not null,
     -- Last update from server we for this folder.
     "syncState" TEXT default null,
+    -- Additional data
+    "json" TEXT default null,
     UNIQUE("accountID", "idStr"),
     FOREIGN KEY (accountID)
       REFERENCES chatAccount (id)

--- a/app/logic/Contacts/SQL/SQLAddressbook.ts
+++ b/app/logic/Contacts/SQL/SQLAddressbook.ts
@@ -68,7 +68,7 @@ export class SQLAddressbook {
     for (let row of rows) {
       try {
         let account = newAddressbookForProtocol(row.protocol);
-        await SQLAddressbook.read(row.idStr, row.protocol, row.configJSON, account);
+        await SQLAddressbook.read(row.idStr, row.protocol, row.json, account);
         accounts.add(account);
       } catch (ex) {
         backgroundError(ex);

--- a/app/logic/Contacts/SQL/createDatabase.ts
+++ b/app/logic/Contacts/SQL/createDatabase.ts
@@ -20,6 +20,8 @@ export const contactsDatabaseSchema = sql`
     "picture" TEXT default null,
     "notes" TEXT default null,
     "popularity" INTEGER default null,
+    -- Additional data
+    "json" TEXT default null,
     FOREIGN KEY (addressbookID)
       REFERENCES addressbook (id)
       ON DELETE SET NULL
@@ -40,6 +42,8 @@ export const contactsDatabaseSchema = sql`
     -- Lower is more preferred.
     -- Number across all contact methods. Preference value should be unique per person.
     "preference" INTEGER default 0,
+    -- Additional data
+    "json" TEXT default null,
     -- UNIQUE("personID", "value", "protocol", "purpose"),
     FOREIGN KEY (personID)
       REFERENCES person (id)
@@ -56,6 +60,8 @@ export const contactsDatabaseSchema = sql`
     "pID" ANY default null,
     "name" TEXT not null,
     "description" TEXT default null,
+    -- Additional data
+    "json" TEXT default null,
     FOREIGN KEY (addressbookID)
       REFERENCES addressbook (id)
       ON DELETE SET NULL
@@ -65,6 +71,8 @@ export const contactsDatabaseSchema = sql`
   CREATE TABLE "groupMember" (
     "groupID" INTEGER not null,
     "personID" INTEGER not null,
+    -- Additional data
+    "json" TEXT default null,
     FOREIGN KEY (groupID)
       REFERENCES "group" (id)
       ON DELETE CASCADE,

--- a/app/logic/Mail/SQL/Account/SQLAccount.ts
+++ b/app/logic/Mail/SQL/Account/SQLAccount.ts
@@ -66,7 +66,7 @@ export class SQLAccount {
   /**
    * Called by SQLMailAccount.readAll() etc.
    */
-  static async readAll(type: AccountType): Promise<{ idStr: string, protocol: string, configJSON: string }[]> {
+  static async readAll(type: AccountType): Promise<{ idStr: string, protocol: string, json: string }[]> {
     let rows = await (await getDatabase()).all(sql`
       SELECT
         idStr, protocol, json

--- a/app/logic/Mail/SQL/Account/SQLAccount.ts
+++ b/app/logic/Mail/SQL/Account/SQLAccount.ts
@@ -27,7 +27,7 @@ export class SQLAccount {
     if (!existing) {
       await (await getDatabase()).run(sql`
         INSERT INTO account (
-          idStr, type, protocol, mainAccountIDStr, configJSON
+          idStr, type, protocol, mainAccountIDStr, json
         ) VALUES (
           ${acc.id}, ${type}, ${acc.protocol}, ${acc.mainAccount?.id},
           ${jsonStr}
@@ -37,7 +37,7 @@ export class SQLAccount {
       await (await getDatabase()).run(sql`
         UPDATE account SET
           mainAccountIDStr = ${acc.mainAccount?.id},
-          configJSON = ${jsonStr}
+          json = ${jsonStr}
         WHERE idStr = ${acc.id}
         `);
     }
@@ -69,7 +69,7 @@ export class SQLAccount {
   static async readAll(type: AccountType): Promise<{ idStr: string, protocol: string, configJSON: string }[]> {
     let rows = await (await getDatabase()).all(sql`
       SELECT
-        idStr, protocol, configJSON
+        idStr, protocol, json
       FROM account
       WHERE type = ${type}
       `) as any;

--- a/app/logic/Mail/SQL/Account/createDatabase.ts
+++ b/app/logic/Mail/SQL/Account/createDatabase.ts
@@ -18,8 +18,11 @@ export const accountsDatabaseSchema = sql`
     "protocol" TEXT not null,
     -- Account.mainAccount
     "mainAccountIDStr" integer default null,
-
-    "configJSON" TEXT default null,
+    -- Most account parameters are stored in here.
+    -- This includes the URL or hostname, port,
+    -- auth method, username, password etc.,
+    -- as well as protocol-specific config options.
+    "json" TEXT default null,
     FOREIGN KEY (mainAccountIDStr)
       REFERENCES account (idStr)
       ON DELETE CASCADE

--- a/app/logic/Mail/SQL/SQLMailAccount.ts
+++ b/app/logic/Mail/SQL/SQLMailAccount.ts
@@ -75,7 +75,7 @@ export class SQLMailAccount {
     for (let row of rows) {
       try {
         let account = newAccountForProtocol(row.protocol);
-        await SQLMailAccount.read(row.idStr, row.protocol, row.configJSON, account);
+        await SQLMailAccount.read(row.idStr, row.protocol, row.json, account);
         if (row.protocol == "smtp") {
           smtpAccounts.add(account);
         } else {

--- a/app/logic/Mail/SQL/createDatabase.ts
+++ b/app/logic/Mail/SQL/createDatabase.ts
@@ -66,11 +66,6 @@ export const mailDatabaseSchema = sql`
     "contactName" TEXT default null,
     -- RFC822 header Subject:
     "subject" TEXT not null,
-    -- If not zero, then one of the following values:
-    -- 4 - Invitation - Either an update to or a new invitation
-    -- 5 - CancelledEvent - Organiser cancelled the event
-    -- 6 - ParticipantReply - Attendee repied to your invitation
-    "scheduling" INTEGER default 0,
     -- plaintext content of the email body. May be converted or post-processed.
     "plaintext" TEXT default null,
     -- HTML content of the email body. May be converted or post-processed.
@@ -80,7 +75,10 @@ export const mailDatabaseSchema = sql`
     "isReplied" BOOLEAN default false,
     "isDraft" BOOLEAN default false,
     "isSpam" BOOLEAN default false,
+    -- We have the full MIME source and saved it locally on disk, and parsed it into the DB.
     "downloadComplete" BOOLEAN default false,
+    -- Additional data
+    "json" TEXT default null,
     -- FOREIGN KEY (parentMsgID)
     --   REFERENCES email (messageID)
     --   ON DELETE SET NULL,
@@ -92,6 +90,7 @@ export const mailDatabaseSchema = sql`
   CREATE TABLE "emailAttachment" (
     "id" INTEGER PRIMARY KEY,
     "emailID" INTEGER not null,
+    "contentID" TEXT default null,
     -- filename with extension, as given my the email sender
     "filename" TEXT not null,
     -- filename and path where the attachment is stored on the user's local disk, after download
@@ -100,9 +99,11 @@ export const mailDatabaseSchema = sql`
     "mimeType" TEXT not null,
     -- file size in bytes. null, if not yet downloaded
     "size" INTEGER default null,
+    -- Content-Disposition header: "attachment", "inline", ...
     "disposition" TEXT default "attachment",
-    "contentID" TEXT default null,
     "related" BOOLEAN default 0,
+    -- Additional data
+    "json" TEXT default null,
     UNIQUE("emailID", "filename"),
     FOREIGN KEY (emailID)
       REFERENCES email (ID)
@@ -113,6 +114,8 @@ export const mailDatabaseSchema = sql`
     "id" INTEGER PRIMARY KEY,
     "emailID" INTEGER not null,
     "tagName" TEXT not null,
+    -- Additional data
+    "json" TEXT default null,
     FOREIGN KEY (emailID)
       REFERENCES email (ID)
       ON DELETE CASCADE
@@ -145,8 +148,8 @@ export const mailDatabaseSchema = sql`
     -- ActiveSync and EWS: The last sync state.
     -- Data type can be either string or integer or null (sqlite supports dynamic typing, per cell).
     "syncState" ANY default null,
-    -- <https://www.rfc-editor.org/rfc/rfc3501#section-2.3.1.1>
-    "uidvalidity" INTEGER default null,
+    -- Additional data
+    "json" TEXT default null,
     UNIQUE("accountID", "path"),
     FOREIGN KEY (accountID)
       REFERENCES emailAccount (id)

--- a/app/logic/Meet/SQL/SQLMeetAccount.ts
+++ b/app/logic/Meet/SQL/SQLMeetAccount.ts
@@ -67,7 +67,7 @@ export class SQLMeetAccount {
     for (let row of rows) {
       try {
         let account = newMeetAccountForProtocol(row.protocol);
-        await SQLMeetAccount.read(row.idStr, row.protocol, row.configJSON, account);
+        await SQLMeetAccount.read(row.idStr, row.protocol, row.json, account);
         accounts.add(account);
       } catch (ex) {
         backgroundError(ex);

--- a/app/logic/Meet/SQL/createDatabase.ts
+++ b/app/logic/Meet/SQL/createDatabase.ts
@@ -6,4 +6,36 @@ export const meetDatabaseSchema = sql`
     "idStr" TEXT not null UNIQUE,
     "protocol" TEXT not null
   );
+
+  -- Meetings, phone calls, and other voice/video calls that the user participated in.
+  -- Only those that already and actually happened. Scheduled calls are calendar events.
+  CREATE TABLE "call" (
+    "id" INTEGER PRIMARY KEY,
+    "accountID" INTEGER default null,
+    "startTime" TEXT default null,
+    "endTime" TEXT default null,
+    -- 0 = incoming call, 1 = outgoing call
+    "outgoing" BOOLEAN default false,
+    -- The calendar event
+    -- References "calendar.event.id". Optional.
+    "eventID" INTEGER default null,
+    -- The person that our user spoke with (the "contact").
+    -- For meetings with multiple people, it's the organizer or
+    -- (if our user is the organizer) the first participant.
+    -- References "contacts.person.id". Optional.
+    "contactID" INTEGER default null,
+    -- Real name of the contact
+    "contactName" TEXT default null,
+    -- For phone calls, a "tel:" URL with the phone number of the contact.
+    -- For meetings, the "calendar.event.onlineMeetingURL"
+    "contactURL" TEXT default null,
+    -- One of the email addresses of the contact.
+    -- Mostly to help to find the contact in the address book later on.
+    "contactEMailAddress" TEXT default null,
+    -- Additional data
+    "json" TEXT default null,
+    FOREIGN KEY (accountID)
+      REFERENCES meetAccount (id)
+      ON DELETE CASCADE
+  );
 `;


### PR DESCRIPTION
* Add `json` column to most tables, for supplemental properties. This allows to add message-specific additional data, e.g. from addons or for calendar, without changing the DB schema.
* Move email.scheduling into the JSON, given that it's used only for emails that contain invitations
* Move folder.uidvalidity into JSON, given that it's needed only for IMAP folders.
* Keep syncState as separate column, not in JSON, given that it's needed for most protocols, and will be written often.
* Add `meet.call` table, for a call log