### PR TITLE
Account: Add mainAccount and dependent accounts - fixes #155

### DIFF
--- a/app/logic/Calendar/ActiveSync/ActiveSyncCalendar.ts
+++ b/app/logic/Calendar/ActiveSync/ActiveSyncCalendar.ts
@@ -14,9 +14,12 @@ const kHalfHour = 30 * 60 * 1000; // milliseconds
 export class ActiveSyncCalendar extends Calendar implements ActiveSyncPingable {
   readonly protocol: string = "calendar-activesync";
   readonly events: ArrayColl<ActiveSyncEvent>;
-  account: ActiveSyncAccount;
   readonly folderClass = "Calendar";
   protected requestLock = new Lock();
+
+  get account(): ActiveSyncAccount {
+    return this.mainAccount as ActiveSyncAccount;
+  }
 
   get serverID() {
     return new URL(this.url).searchParams.get("serverID");

--- a/app/logic/Calendar/EWS/EWSCalendar.ts
+++ b/app/logic/Calendar/EWS/EWSCalendar.ts
@@ -10,7 +10,10 @@ import type { ArrayColl } from "svelte-collections";
 export class EWSCalendar extends Calendar {
   readonly protocol: string = "calendar-ews";
   readonly events: ArrayColl<EWSEvent>;
-  account: EWSAccount;
+
+  get account(): EWSAccount {
+    return this.mainAccount as EWSAccount;
+  }
 
   newEvent(parentEvent?: EWSEvent): EWSEvent {
     return new EWSEvent(this, parentEvent);

--- a/app/logic/Calendar/OWA/OWACalendar.ts
+++ b/app/logic/Calendar/OWA/OWACalendar.ts
@@ -11,7 +11,10 @@ import { ArrayColl } from "svelte-collections";
 export class OWACalendar extends Calendar {
   readonly protocol: string = "calendar-owa";
   readonly events: ArrayColl<OWAEvent>;
-  account: OWAAccount;
+
+  get account(): OWAAccount {
+    return this.mainAccount as OWAAccount;
+  }
 
   newEvent(parentEvent?: OWAEvent): OWAEvent {
     return new OWAEvent(this, parentEvent);

--- a/app/logic/Calendar/SQL/SQLCalendar.ts
+++ b/app/logic/Calendar/SQL/SQLCalendar.ts
@@ -1,5 +1,5 @@
 import type { Calendar } from "../Calendar";
-import { AccountType, SQLAccount } from "../../Mail/SQL/Account/SQLAccount";
+import { AccountType, SQLAccount, type AccountDBRow } from "../../Mail/SQL/Account/SQLAccount";
 import { getDatabase } from "./SQLDatabase";
 import { newCalendarForProtocol } from "../AccountsList/Calendars";
 import { SQLCalendarStorage } from "./SQLCalendarStorage";
@@ -43,14 +43,14 @@ export class SQLCalendar {
       `);
   }
 
-  static async read(idStr: string, protocol: string, configJSON: string, cal: Calendar) {
-    await SQLAccount.read(idStr, protocol, configJSON, cal);
+  static async read(accountRow: AccountDBRow, cal: Calendar) {
+    await SQLAccount.read(accountRow, cal);
 
     let row = await (await getDatabase()).get(sql`
       SELECT
         id, protocol
       FROM calendar
-      WHERE idStr = ${idStr}
+      WHERE idStr = ${accountRow.idStr}
       `) as any;
     if (row.id) {
       cal.dbID = row.id;
@@ -68,7 +68,7 @@ export class SQLCalendar {
     for (let row of rows) {
       try {
         let calendar = newCalendarForProtocol(row.protocol);
-        await SQLCalendar.read(row.idStr, row.protocol, row.json, calendar);
+        await SQLCalendar.read(row, calendar);
         calendars.add(calendar);
       } catch (ex) {
         backgroundError(ex);

--- a/app/logic/Chat/SQL/SQLChatAccount.ts
+++ b/app/logic/Chat/SQL/SQLChatAccount.ts
@@ -1,5 +1,5 @@
 import type { ChatAccount } from "../ChatAccount";
-import { AccountType, SQLAccount } from "../../Mail/SQL/Account/SQLAccount";
+import { AccountType, SQLAccount, type AccountDBRow } from "../../Mail/SQL/Account/SQLAccount";
 import { getDatabase } from "./SQLDatabase";
 import { newChatAccountForProtocol } from "../AccountsList/ChatAccounts";
 import { SQLChatStorage } from "./SQLChatStorage";
@@ -43,14 +43,14 @@ export class SQLChatAccount {
       `);
   }
 
-  static async read(idStr: string, protocol: string, configJSON: string, acc: ChatAccount) {
-    await SQLAccount.read(idStr, protocol, configJSON, acc);
+  static async read(accountRow: AccountDBRow, acc: ChatAccount) {
+    await SQLAccount.read(accountRow, acc);
 
     let row = await (await getDatabase()).get(sql`
       SELECT
         id, protocol
       FROM chatAccount
-      WHERE idStr = ${idStr}
+      WHERE idStr = ${accountRow.idStr}
       `) as any;
     acc.storage = new SQLChatStorage();
     if (row.id) {
@@ -68,7 +68,7 @@ export class SQLChatAccount {
     for (let row of rows) {
       try {
         let account = newChatAccountForProtocol(row.protocol);
-        await SQLChatAccount.read(row.idStr, row.protocol, row.json, account);
+        await SQLChatAccount.read(row, account);
         accounts.add(account);
       } catch (ex) {
         backgroundError(ex);

--- a/app/logic/Contacts/ActiveSync/ActiveSyncAddressbook.ts
+++ b/app/logic/Contacts/ActiveSync/ActiveSyncAddressbook.ts
@@ -11,9 +11,12 @@ import type { ArrayColl } from "svelte-collections";
 export class ActiveSyncAddressbook extends Addressbook implements ActiveSyncPingable {
   readonly protocol: string = "addressbook-activesync";
   readonly persons: ArrayColl<ActiveSyncPerson>;
-  account: ActiveSyncAccount;
   readonly folderClass = "Contacts";
   protected requestLock = new Lock();
+
+  get account(): ActiveSyncAccount {
+    return this.mainAccount as ActiveSyncAccount;
+  }
 
   get serverID() {
     return new URL(this.url).searchParams.get("serverID");

--- a/app/logic/Contacts/EWS/EWSAddressbook.ts
+++ b/app/logic/Contacts/EWS/EWSAddressbook.ts
@@ -11,7 +11,10 @@ export class EWSAddressbook extends Addressbook {
   readonly protocol: string = "addressbook-ews";
   readonly persons: ArrayColl<EWSPerson>;
   readonly groups: ArrayColl<EWSGroup>;
-  account: EWSAccount;
+
+  get account(): EWSAccount {
+    return this.mainAccount as EWSAccount;
+  }
 
   newPerson(): EWSPerson {
     return new EWSPerson(this);

--- a/app/logic/Contacts/OWA/OWAAddressbook.ts
+++ b/app/logic/Contacts/OWA/OWAAddressbook.ts
@@ -9,7 +9,10 @@ export class OWAAddressbook extends Addressbook {
   readonly protocol: string = "addressbook-owa";
   readonly persons: ArrayColl<OWAPerson>;
   readonly groups: ArrayColl<OWAGroup>;
-  account: OWAAccount;
+
+  get account(): OWAAccount {
+    return this.mainAccount as OWAAccount;
+  }
 
   newPerson(): OWAPerson {
     return new OWAPerson(this);

--- a/app/logic/Contacts/SQL/SQLAddressbook.ts
+++ b/app/logic/Contacts/SQL/SQLAddressbook.ts
@@ -1,5 +1,5 @@
 import type { Addressbook } from "../Addressbook";
-import { AccountType, SQLAccount } from "../../Mail/SQL/Account/SQLAccount";
+import { AccountType, SQLAccount, type AccountDBRow } from "../../Mail/SQL/Account/SQLAccount";
 import { getDatabase } from "./SQLDatabase";
 import { newAddressbookForProtocol } from "../AccountsList/Addressbooks";
 import { SQLAddressbookStorage } from "./SQLAddressbookStorage";
@@ -43,14 +43,14 @@ export class SQLAddressbook {
       `);
   }
 
-  static async read(idStr: string, protocol: string, configJSON: string, acc: Addressbook) {
-    await SQLAccount.read(idStr, protocol, configJSON, acc);
+  static async read(accountRow: AccountDBRow, acc: Addressbook) {
+    await SQLAccount.read(accountRow, acc);
 
     let row = await (await getDatabase()).get(sql`
       SELECT
         id, protocol
       FROM addressbook
-      WHERE idStr = ${idStr}
+      WHERE idStr = ${accountRow.idStr}
       `) as any;
     if (row.id) {
       acc.dbID = row.id;
@@ -68,7 +68,7 @@ export class SQLAddressbook {
     for (let row of rows) {
       try {
         let account = newAddressbookForProtocol(row.protocol);
-        await SQLAddressbook.read(row.idStr, row.protocol, row.json, account);
+        await SQLAddressbook.read(row, account);
         accounts.add(account);
       } catch (ex) {
         backgroundError(ex);

--- a/app/logic/Mail/AccountsList/MailAccounts.ts
+++ b/app/logic/Mail/AccountsList/MailAccounts.ts
@@ -16,6 +16,7 @@ import { OWAAccount } from '../OWA/OWAAccount';
 import { ActiveSyncAccount } from '../ActiveSync/ActiveSyncAccount';
 import { GraphAccount } from '../Graph/GraphAccount';
 // #endif
+import { getAllAccounts } from '../../Abstract/Account';
 import { setStorage } from '../Store/setStorage';
 import { NotReached } from '../../util/util';
 import type { Collection } from 'svelte-collections';
@@ -67,7 +68,6 @@ export async function readMailAccounts(): Promise<Collection<MailAccount>> {
   return await SQLMailStorage.readMailAccounts();
 }
 // #endif
-
 
 const kProtocolLabel = {
   // Displayed to user, but do not translate (technical term)

--- a/app/logic/Mail/EWS/EWSAccount.ts
+++ b/app/logic/Mail/EWS/EWSAccount.ts
@@ -64,30 +64,32 @@ export class EWSAccount extends MailAccount {
 
     // Link (until #155) or create the default address book.
     // TODO: Support user-added address books.
-    let addressbook = appGlobal.addressbooks.find((addressbook: EWSAddressbook) => addressbook.protocol == "addressbook-ews" && addressbook.url == this.url && addressbook.username == this.username) as EWSAddressbook | void;
+    let addressbook = appGlobal.addressbooks.find(addressbook => addressbook.mainAccount == this) as EWSAddressbook | null;
+    console.log("found the EWS AB again", addressbook?.name);
     if (!addressbook) {
       addressbook = newAddressbookForProtocol("addressbook-ews") as EWSAddressbook;
       addressbook.name = this.name;
       addressbook.url = this.url;
       addressbook.username = this.username;
       addressbook.workspace = this.workspace;
+      addressbook.mainAccount = this;
       appGlobal.addressbooks.add(addressbook);
     }
-    addressbook.account = this;
     await addressbook.listContacts();
 
     // Link (until #155) or create the default calendar.
     // TODO: Support user-added calendars.
-    let calendar = appGlobal.calendars.find((calendar: EWSCalendar) => calendar.protocol == "calendar-ews" && calendar.url == this.url && calendar.username == this.username) as EWSCalendar | void;
+    let calendar = appGlobal.calendars.find(calendar => calendar.mainAccount == this) as EWSCalendar | null;
+    console.log("found the EWS cal again", calendar?.name);
     if (!calendar) {
       calendar = newCalendarForProtocol("calendar-ews") as EWSCalendar;
       calendar.name = this.name;
       calendar.url = this.url;
       calendar.username = this.username;
       calendar.workspace = this.workspace;
+      calendar.mainAccount = this;
       appGlobal.calendars.add(calendar);
     }
-    calendar.account = this;
     await calendar.listEvents();
 
     await this.streamNotifications();

--- a/app/logic/Mail/OWA/OWAAccount.ts
+++ b/app/logic/Mail/OWA/OWAAccount.ts
@@ -107,29 +107,32 @@ export class OWAAccount extends MailAccount {
 
     // Link (until #155) or create the default address book.
     // TODO: Support user-added address books.
-    let addressbook = appGlobal.addressbooks.find((addressbook: OWAAddressbook) => addressbook.protocol == "addressbook-owa" && addressbook.url == this.url && addressbook.username == this.username) as OWAAddressbook | void;
+    let addressbook = appGlobal.addressbooks.find(addressbook => addressbook.mainAccount == this) as OWAAddressbook | null;
+    console.log("found the OWA AB again", addressbook?.name);
     if (!addressbook) {
       addressbook = newAddressbookForProtocol("addressbook-owa") as OWAAddressbook;
       addressbook.url = this.url;
       addressbook.username = this.username;
       addressbook.workspace = this.workspace;
+      addressbook.mainAccount = this;
       appGlobal.addressbooks.add(addressbook);
     }
-    addressbook.account = this;
     await addressbook.listContacts();
 
     // Link (until #155) or create the default calendar.
     // TODO: Support user-added calendars.
-    let calendar = appGlobal.calendars.find((calendar: OWACalendar) => calendar.protocol == "calendar-owa" && calendar.url == this.url && calendar.username == this.username) as OWACalendar | void;
+    // TODO: Compare ID
+    let calendar = appGlobal.calendars.find(calendar => calendar.mainAccount == this) as OWACalendar | null;
+    console.log("found the OWA cal again", calendar?.name);
     if (!calendar) {
       calendar = newCalendarForProtocol("calendar-owa") as OWACalendar;
       calendar.name = this.name;
       calendar.url = this.url;
       calendar.username = this.username;
       calendar.workspace = this.workspace;
+      calendar.mainAccount = this;
       appGlobal.calendars.add(calendar);
     }
-    calendar.account = this;
     await calendar.listEvents();
 
     await this.callOWA(new OWASubscribeToNotificationRequest());

--- a/app/logic/Mail/SQL/Account/createDatabase.ts
+++ b/app/logic/Mail/SQL/Account/createDatabase.ts
@@ -17,14 +17,16 @@ export const accountsDatabaseSchema = sql`
     -- Must fit to type"
     "protocol" TEXT not null,
     -- Account.mainAccount
-    "mainAccountIDStr" integer default null,
+    -- References account.idStr
+    "mainAccountIDStr" TEXT default null,
     -- Most account parameters are stored in here.
     -- This includes the URL or hostname, port,
     -- auth method, username, password etc.,
     -- as well as protocol-specific config options.
-    "json" TEXT default null,
-    FOREIGN KEY (mainAccountIDStr)
-      REFERENCES account (idStr)
-      ON DELETE CASCADE
+    "json" TEXT default null
+    -- TODO dependent account might be saved before the main account
+    -- FOREIGN KEY (mainAccountIDStr)
+    --   REFERENCES account (idStr)
+    --   ON DELETE CASCADE
   );
 `;

--- a/app/logic/Mail/SQL/SQLMailAccount.ts
+++ b/app/logic/Mail/SQL/SQLMailAccount.ts
@@ -1,6 +1,6 @@
 import type { MailAccount } from "../MailAccount";
 import { getDatabase } from "./SQLDatabase";
-import { AccountType, SQLAccount } from "./Account/SQLAccount";
+import { AccountType, SQLAccount, type AccountDBRow } from "./Account/SQLAccount";
 import { newAccountForProtocol } from "../AccountsList/MailAccounts";
 import { SQLMailStorage } from "./SQLMailStorage";
 import { backgroundError } from "../../../frontend/Util/error";
@@ -49,14 +49,14 @@ export class SQLMailAccount {
       `);
   }
 
-  static async read(idStr: string, protocol: string, configJSON: string, acc: MailAccount) {
-    await SQLAccount.read(idStr, protocol, configJSON, acc);
+  static async read(accountRow: AccountDBRow, acc: MailAccount) {
+    await SQLAccount.read(accountRow, acc);
 
     let row = await (await getDatabase()).get(sql`
       SELECT
         id, protocol
       FROM emailAccount
-      WHERE idStr = ${idStr}
+      WHERE idStr = ${accountRow.idStr}
       `) as any;
     if (row.id) {
       acc.dbID = row.id;
@@ -75,7 +75,7 @@ export class SQLMailAccount {
     for (let row of rows) {
       try {
         let account = newAccountForProtocol(row.protocol);
-        await SQLMailAccount.read(row.idStr, row.protocol, row.json, account);
+        await SQLMailAccount.read(row, account);
         if (row.protocol == "smtp") {
           smtpAccounts.add(account);
         } else {

--- a/app/logic/Meet/SQL/SQLMeetAccount.ts
+++ b/app/logic/Meet/SQL/SQLMeetAccount.ts
@@ -1,5 +1,5 @@
 import type { MeetAccount } from "../MeetAccount";
-import { AccountType, SQLAccount } from "../../Mail/SQL/Account/SQLAccount";
+import { AccountType, SQLAccount, type AccountDBRow } from "../../Mail/SQL/Account/SQLAccount";
 import { getDatabase } from "./SQLDatabase";
 import { SQLMeetStorage } from "./SQLMeetStorage";
 import { newMeetAccountForProtocol } from "../AccountsList/MeetAccounts";
@@ -43,13 +43,14 @@ export class SQLMeetAccount {
       `);
   }
 
-  static async read(idStr: string, protocol: string, configJSON: string, acc: MeetAccount) {
-    await SQLAccount.read(idStr, protocol, configJSON, acc);
+  static async read(accountRow: AccountDBRow, acc: MeetAccount) {
+    await SQLAccount.read(accountRow, acc);
+
     let row = await (await getDatabase()).get(sql`
       SELECT
         id, protocol
       FROM meetAccount
-      WHERE idStr = ${idStr}
+      WHERE idStr = ${accountRow.idStr}
       `) as any;
     if (row.id) {
       acc.dbID = row.id;
@@ -67,7 +68,7 @@ export class SQLMeetAccount {
     for (let row of rows) {
       try {
         let account = newMeetAccountForProtocol(row.protocol);
-        await SQLMeetAccount.read(row.idStr, row.protocol, row.json, account);
+        await SQLMeetAccount.read(row, account);
         accounts.add(account);
       } catch (ex) {
         backgroundError(ex);

--- a/app/logic/startup.ts
+++ b/app/logic/startup.ts
@@ -8,7 +8,7 @@ import { readSavedSearches } from './Mail/Virtual/SavedSearchFolder';
 import { loadWorkspaces } from './Abstract/Workspace';
 import { loadTagsList } from './Mail/Tag';
 import type { MailAccount } from './Mail/MailAccount';
-import type { Account } from './Abstract/Account';
+import { type Account, setMainAccounts } from './Abstract/Account';
 import JPCWebSocket from '../../lib/jpc-ws';
 import { production } from './build';
 import { logError } from '../frontend/Util/error';
@@ -21,11 +21,12 @@ export async function getStartObjects(): Promise<void> {
   console.log("Connected to backend");
   appGlobal.remoteApp = await jpc.getRemoteStartObject();
   await loadWorkspaces();
-  appGlobal.addressbooks.addAll(await readAddressbooks());
-  appGlobal.calendars.addAll(await readCalendars());
   appGlobal.emailAccounts.addAll(await readMailAccounts());
   appGlobal.chatAccounts.addAll(await readChatAccounts());
   appGlobal.meetAccounts.addAll(await readMeetAccounts());
+  appGlobal.calendars.addAll(await readCalendars());
+  appGlobal.addressbooks.addAll(await readAddressbooks());
+  setMainAccounts();
 
   // TODO Save the address book type and ensure that they are of the right type
   appGlobal.personalAddressbook = appGlobal.addressbooks.first;


### PR DESCRIPTION
* Add `Account.mainAccount` and `Account.dependentAccounts()`
* Persist it to DB and restore it after load
* Use it for addresssbook and calendar to email account in Exchange protocols
* TODO: SMTP to IMAP