### PR TITLE
Fix various constraint failures during account setup

### DIFF
--- a/app/frontend/Settings/Mail/Manual/ManualConfig.svelte
+++ b/app/frontend/Settings/Mail/Manual/ManualConfig.svelte
@@ -46,6 +46,11 @@
 
   async function onSave() {
     await config.save();
+    // config.saveAll() would save all dependent accounts,
+    // but we're only interested in the outgoing account.
+    if (config.outgoing) {
+      await config.outgoing.save();
+    }
   }
 
   let el: ManualConfigURL | ManualConfigHost  = null;

--- a/app/logic/Abstract/Account.ts
+++ b/app/logic/Abstract/Account.ts
@@ -110,6 +110,12 @@ export class Account extends Observable {
   /** Saves the config in this account to disk.
    * Does not save the contents, e.g. messages. */
   async save(): Promise<void> {
+    throw new AbstractFunction();
+  }
+
+  /** Saves the config in this account and its dependent accounts to disk. */
+  async saveAll(): Promise<void> {
+    await this.save(); // must be first, because of foreign key constraint
     for (let dependent of this.dependentAccounts()) {
       await dependent.save();
     }

--- a/app/logic/Calendar/Calendar.ts
+++ b/app/logic/Calendar/Calendar.ts
@@ -31,8 +31,8 @@ export class Calendar extends Account {
   }
 
   async save(): Promise<void> {
-    await super.save();
     await this.storage?.saveCalendar(this);
+    await super.save();
   }
 
   async deleteIt(): Promise<void> {

--- a/app/logic/Calendar/Calendar.ts
+++ b/app/logic/Calendar/Calendar.ts
@@ -32,7 +32,6 @@ export class Calendar extends Account {
 
   async save(): Promise<void> {
     await this.storage?.saveCalendar(this);
-    await super.save();
   }
 
   async deleteIt(): Promise<void> {

--- a/app/logic/Chat/ChatAccount.ts
+++ b/app/logic/Chat/ChatAccount.ts
@@ -29,7 +29,6 @@ export class ChatAccount extends TCPAccount {
 
   async save(): Promise<void> {
     await this.storage?.saveAccount(this);
-    await super.save();
   }
 
   async deleteIt(): Promise<void> {

--- a/app/logic/Chat/ChatAccount.ts
+++ b/app/logic/Chat/ChatAccount.ts
@@ -28,8 +28,8 @@ export class ChatAccount extends TCPAccount {
   }
 
   async save(): Promise<void> {
-    await super.save();
     await this.storage?.saveAccount(this);
+    await super.save();
   }
 
   async deleteIt(): Promise<void> {

--- a/app/logic/Contacts/Addressbook.ts
+++ b/app/logic/Contacts/Addressbook.ts
@@ -22,7 +22,6 @@ export class Addressbook extends Account {
 
   async save(): Promise<void> {
     await this.storage?.saveAddressbook(this);
-    await super.save();
   }
 
   async deleteIt(): Promise<void> {

--- a/app/logic/Contacts/Addressbook.ts
+++ b/app/logic/Contacts/Addressbook.ts
@@ -21,8 +21,8 @@ export class Addressbook extends Account {
   }
 
   async save(): Promise<void> {
-    await super.save();
     await this.storage?.saveAddressbook(this);
+    await super.save();
   }
 
   async deleteIt(): Promise<void> {

--- a/app/logic/Mail/AutoConfig/saveConfig.ts
+++ b/app/logic/Mail/AutoConfig/saveConfig.ts
@@ -31,8 +31,7 @@ export async function saveConfig(config: MailAccount, emailAddress: string, pass
   appGlobal.emailAccounts.add(config);
   console.log("Saving new mail account", config);
   // saveAccountToLocalStorage(config);
-  setStorage(config);
-  await config.save();
+  await config.saveAll();
 }
 
 /**

--- a/app/logic/Mail/EWS/EWSAccount.ts
+++ b/app/logic/Mail/EWS/EWSAccount.ts
@@ -51,7 +51,7 @@ export class EWSAccount extends MailAccount {
     await this.commonLogin(true);
   }
 
-  async commonLogin(interactive): Promise<void> {
+  private async commonLogin(interactive): Promise<void> {
     if (this.authMethod == AuthMethod.OAuth2) {
       if (!this.oAuth2) {
         let urls = OAuth2URLs.find(a => a.hostnames.includes(this.hostname));

--- a/app/logic/Mail/EWS/EWSAccount.ts
+++ b/app/logic/Mail/EWS/EWSAccount.ts
@@ -47,7 +47,11 @@ export class EWSAccount extends MailAccount {
     return this.authMethod != AuthMethod.OAuth2 || this.oAuth2?.isLoggedIn;
   }
 
-  async verifyLogin(interactive = true): Promise<void> {
+  async verifyLogin(): Promise<void> {
+    await this.commonLogin(true);
+  }
+
+  async commonLogin(interactive): Promise<void> {
     if (this.authMethod == AuthMethod.OAuth2) {
       if (!this.oAuth2) {
         let urls = OAuth2URLs.find(a => a.hostnames.includes(this.hostname));
@@ -64,7 +68,7 @@ export class EWSAccount extends MailAccount {
   async login(interactive: boolean): Promise<void> {
     await ensureLicensed();
     await super.login(interactive);
-    await this.verifyLogin(interactive);
+    await this.commonLogin(interactive);
 
     // Link (until #155) or create the default address book.
     // TODO: Support user-added address books. Compare addressbook ID.

--- a/app/logic/Mail/EWS/EWSAccount.ts
+++ b/app/logic/Mail/EWS/EWSAccount.ts
@@ -47,9 +47,7 @@ export class EWSAccount extends MailAccount {
     return this.authMethod != AuthMethod.OAuth2 || this.oAuth2?.isLoggedIn;
   }
 
-  async login(interactive: boolean): Promise<void> {
-    await ensureLicensed();
-    await super.login(interactive);
+  async verifyLogin(interactive = true): Promise<void> {
     if (this.authMethod == AuthMethod.OAuth2) {
       if (!this.oAuth2) {
         let urls = OAuth2URLs.find(a => a.hostnames.includes(this.hostname));
@@ -61,6 +59,12 @@ export class EWSAccount extends MailAccount {
       await this.oAuth2.login(interactive);
     }
     await this.listFolders();
+  }
+
+  async login(interactive: boolean): Promise<void> {
+    await ensureLicensed();
+    await super.login(interactive);
+    await this.verifyLogin(interactive);
 
     // Link (until #155) or create the default address book.
     // TODO: Support user-added address books. Compare addressbook ID.

--- a/app/logic/Mail/EWS/EWSAccount.ts
+++ b/app/logic/Mail/EWS/EWSAccount.ts
@@ -48,10 +48,10 @@ export class EWSAccount extends MailAccount {
   }
 
   async verifyLogin(): Promise<void> {
-    await this.commonLogin(true);
+    await this.loginCommon(true);
   }
 
-  private async commonLogin(interactive): Promise<void> {
+  protected async loginCommon(interactive: boolean): Promise<void> {
     if (this.authMethod == AuthMethod.OAuth2) {
       if (!this.oAuth2) {
         let urls = OAuth2URLs.find(a => a.hostnames.includes(this.hostname));
@@ -68,7 +68,7 @@ export class EWSAccount extends MailAccount {
   async login(interactive: boolean): Promise<void> {
     await ensureLicensed();
     await super.login(interactive);
-    await this.commonLogin(interactive);
+    await this.loginCommon(interactive);
 
     // Link (until #155) or create the default address book.
     // TODO: Support user-added address books. Compare addressbook ID.

--- a/app/logic/Mail/MailAccount.ts
+++ b/app/logic/Mail/MailAccount.ts
@@ -127,7 +127,6 @@ export class MailAccount extends TCPAccount {
   async save(): Promise<void> {
     console.log("mail account save", this.protocol, this.name, this, "outgoing", this.outgoing, "mainaccount", this.mainAccount, "storage", this.storage);
     await this.storage?.saveAccount(this);
-    await super.save();
   }
 
   async deleteIt(): Promise<void> {

--- a/app/logic/Mail/MailAccount.ts
+++ b/app/logic/Mail/MailAccount.ts
@@ -126,8 +126,8 @@ export class MailAccount extends TCPAccount {
 
   async save(): Promise<void> {
     console.log("mail account save", this.protocol, this.name, this, "outgoing", this.outgoing, "mainaccount", this.mainAccount, "storage", this.storage);
-    await super.save();
     await this.storage?.saveAccount(this);
+    await super.save();
   }
 
   async deleteIt(): Promise<void> {

--- a/app/logic/Mail/OWA/OWAAccount.ts
+++ b/app/logic/Mail/OWA/OWAAccount.ts
@@ -73,9 +73,7 @@ export class OWAAccount extends MailAccount {
    * OWA full page login resembles OAuth2, so we label it as such,
    * although it's actually Office 365 itself doing its own OAuth2.
    */
-  async login(interactive: boolean): Promise<void> {
-    await ensureLicensed();
-    await super.login(interactive);
+  async verifyLogin(interactive = true): Promise<void> {
     if (this.authMethod == AuthMethod.OAuth2) {
       // The backend has the logic for posing the login page
       // using the correct cookie jar and auto-filling it.
@@ -103,6 +101,12 @@ export class OWAAccount extends MailAccount {
         await this.listFolders();
       }
     }
+  }
+
+  async login(interactive: boolean, verifyOnly?: boolean): Promise<void> {
+    await ensureLicensed();
+    await super.login(interactive);
+    await this.verifyLogin(interactive);
     this.hasLoggedIn = true;
 
     // Link (until #155) or create the default address book.

--- a/app/logic/Mail/OWA/OWAAccount.ts
+++ b/app/logic/Mail/OWA/OWAAccount.ts
@@ -77,7 +77,7 @@ export class OWAAccount extends MailAccount {
    * OWA full page login resembles OAuth2, so we label it as such,
    * although it's actually Office 365 itself doing its own OAuth2.
    */
-  async commonLogin(interactive): Promise<void> {
+  private async commonLogin(interactive): Promise<void> {
     if (this.authMethod == AuthMethod.OAuth2) {
       // The backend has the logic for posing the login page
       // using the correct cookie jar and auto-filling it.

--- a/app/logic/Mail/OWA/OWAAccount.ts
+++ b/app/logic/Mail/OWA/OWAAccount.ts
@@ -69,11 +69,15 @@ export class OWAAccount extends MailAccount {
     return this.hasLoggedIn;
   }
 
+  async verifyLogin(): Promise<void> {
+    await this.commonLogin(true);
+  }
+
   /**
    * OWA full page login resembles OAuth2, so we label it as such,
    * although it's actually Office 365 itself doing its own OAuth2.
    */
-  async verifyLogin(interactive = true): Promise<void> {
+  async commonLogin(interactive): Promise<void> {
     if (this.authMethod == AuthMethod.OAuth2) {
       // The backend has the logic for posing the login page
       // using the correct cookie jar and auto-filling it.
@@ -106,7 +110,7 @@ export class OWAAccount extends MailAccount {
   async login(interactive: boolean, verifyOnly?: boolean): Promise<void> {
     await ensureLicensed();
     await super.login(interactive);
-    await this.verifyLogin(interactive);
+    await this.commonLogin(interactive);
     this.hasLoggedIn = true;
 
     // Link (until #155) or create the default address book.

--- a/app/logic/Mail/OWA/OWAAccount.ts
+++ b/app/logic/Mail/OWA/OWAAccount.ts
@@ -70,14 +70,14 @@ export class OWAAccount extends MailAccount {
   }
 
   async verifyLogin(): Promise<void> {
-    await this.commonLogin(true);
+    await this.loginCommon(true);
   }
 
   /**
    * OWA full page login resembles OAuth2, so we label it as such,
    * although it's actually Office 365 itself doing its own OAuth2.
    */
-  private async commonLogin(interactive): Promise<void> {
+  protected async loginCommon(interactive: boolean): Promise<void> {
     if (this.authMethod == AuthMethod.OAuth2) {
       // The backend has the logic for posing the login page
       // using the correct cookie jar and auto-filling it.
@@ -110,7 +110,7 @@ export class OWAAccount extends MailAccount {
   async login(interactive: boolean, verifyOnly?: boolean): Promise<void> {
     await ensureLicensed();
     await super.login(interactive);
-    await this.commonLogin(interactive);
+    await this.loginCommon(interactive);
     this.hasLoggedIn = true;
 
     // Link (until #155) or create the default address book.

--- a/app/logic/Meet/MeetAccount.ts
+++ b/app/logic/Meet/MeetAccount.ts
@@ -26,8 +26,8 @@ export class MeetAccount extends Account {
   }
 
   async save(): Promise<void> {
-    await super.save();
     await this.storage?.saveAccount(this);
+    await super.save();
   }
 
   async deleteIt(): Promise<void> {

--- a/app/logic/Meet/MeetAccount.ts
+++ b/app/logic/Meet/MeetAccount.ts
@@ -27,7 +27,6 @@ export class MeetAccount extends Account {
 
   async save(): Promise<void> {
     await this.storage?.saveAccount(this);
-    await super.save();
   }
 
   async deleteIt(): Promise<void> {


### PR DESCRIPTION
As mentioned in #574:
- accounts are trying to save their dependent accounts first, which doesn't work
- EWS and OWA accounts need a "light" `verifyLogin` which doesn't try to create dependent accounts