### PR TITLE
Mobile: Backend: Vite config target for Node.js & ESM

### DIFF
--- a/mobile/backend/vite.config.ts
+++ b/mobile/backend/vite.config.ts
@@ -2,17 +2,19 @@ import { defineConfig } from 'vite';
 import nodeExternals from 'rollup-plugin-node-externals';
 
 export default defineConfig({
+  ssr: { noExternal: true },
   build: {
     target: 'node18',
     lib: {
       name: 'index',
       fileName: () => 'index.js',
-      formats: ['cjs'],
+      formats: ['es'],
       entry: './index.ts'
     },
     outDir: '../android/app/src/main/assets/public/nodejs',
     emptyOutDir: false,
-    minify: false
+    minify: false,
+    ssr: true,
   },
   plugins: [
     nodeExternals({


### PR DESCRIPTION
**Errors**

1. Our code is ESM and needs to be compiled to ESM
2. Vite lib mode targets to browser

**Notes**

- I remembered that we changed all modules to ESM so the build needs to target ESM otherwise there would be an error.
- I tried the `cjs` format but I kept getting errors. Was there a reason for setting the build to CJS?
- Another error, was that vite in `lib` mode only targets browser so it was bundling for the browser. [link](https://github.com/vitejs/vite/issues/8910#issuecomment-1174779427)
- I tried another fix by removing the `browser` from `resolve.mainFields`. [link](https://github.com/vitejs/vite/issues/8910#issuecomment-2128107137)
- So the fix that worked for me was setting `build.ssr` to true and` ssr: { noExternal: true }`. [link](https://github.com/vitejs/vite/issues/8910#issuecomment-1999152627)