### PR TITLE
Create explicit property to check for incoming meetings

### DIFF
--- a/app/frontend/Calendar/EditEvent/DialogHeader.svelte
+++ b/app/frontend/Calendar/EditEvent/DialogHeader.svelte
@@ -13,7 +13,7 @@
             iconSize="16px"
             />
         {/if}
-        {#if event.myParticipation == InvitationResponse.Unknown || event.myParticipation == InvitationResponse.Organizer}
+        {#if !event.isIncomingMeeting}
           <RoundButton
             label={$t`Delete Event`}
             icon={DeleteIcon}

--- a/app/frontend/Calendar/EditEvent/EditEvent.svelte
+++ b/app/frontend/Calendar/EditEvent/EditEvent.svelte
@@ -58,7 +58,7 @@
       </vbox>
     </vbox>
   </Scroll>
-  {#if event.myParticipation != InvitationResponse.Unknown && event.myParticipation != InvitationResponse.Organizer}
+  {#if event.isIncomingMeeting}
     <hbox class="buttons">
       <InvitationResponseButtons {event} />
     </hbox>

--- a/app/frontend/Calendar/EditEvent/InvitationResponseButtons.svelte
+++ b/app/frontend/Calendar/EditEvent/InvitationResponseButtons.svelte
@@ -1,5 +1,5 @@
 <hbox class="buttons">
-  {#if event.myParticipation == InvitationResponse.Unknown || event.myParticipation == InvitationResponse.Organizer}
+  {#if event.isIncomingMeeting}
     <Button label={$t`Accept`} onClick={onAccept} />
     <hbox class="spacer" />
     <Button label={$t`Reject`} onClick={onDecline} />

--- a/app/logic/Calendar/ActiveSync/ActiveSyncEvent.ts
+++ b/app/logic/Calendar/ActiveSync/ActiveSyncEvent.ts
@@ -191,7 +191,7 @@ export class ActiveSyncEvent extends Event {
   }
 
   async respondToInvitation(response: InvitationResponseInMessage): Promise<void> {
-    assert(this.myParticipation > InvitationResponse.Organizer, "Only invitations can be responded to");
+    assert(this.isIncomingMeeting, "Only invitations can be responded to");
     let request = {
       Request: {
         UserResponse: ActiveSyncResponse[response],

--- a/app/logic/Calendar/EWS/EWSEvent.ts
+++ b/app/logic/Calendar/EWS/EWSEvent.ts
@@ -309,7 +309,7 @@ export class EWSEvent extends Event {
   }
 
   async respondToInvitation(response: InvitationResponseInMessage): Promise<void> {
-    assert(this.myParticipation > InvitationResponse.Organizer, "Only invitations can be responded to");
+    assert(this.isIncomingMeeting, "Only invitations can be responded to");
     let request = new EWSCreateItemRequest({MessageDisposition: "SendAndSaveCopy"});
     request.addField(ResponseTypes[response], "ReferenceItemId", { Id: this.itemID });
     await this.calendar.account.callEWS(request);

--- a/app/logic/Calendar/Invitation/OutgoingInvitation.ts
+++ b/app/logic/Calendar/Invitation/OutgoingInvitation.ts
@@ -16,7 +16,7 @@ export default class OutgoingInvitation {
 
   createOrganizer() {
     assert(this.event.participants.isEmpty, "This is already a meeting");
-    assert(this.event.myParticipation <= InvitationResponse.Organizer, "This is a meeting you have been invitated to. You cannot be the organizer.");
+    assert(!this.event.isIncomingMeeting, "This is a meeting you have been invitated to. You cannot be the organizer.");
     this.event.myParticipation = InvitationResponse.Organizer;
     let identity = this.identity;
     this.event.participants.add(new Participant(identity.emailAddress, identity.realname, InvitationResponse.Organizer));

--- a/app/logic/Calendar/OWA/OWAEvent.ts
+++ b/app/logic/Calendar/OWA/OWAEvent.ts
@@ -327,7 +327,7 @@ export class OWAEvent extends Event {
   }
 
   async respondToInvitation(response: InvitationResponseInMessage): Promise<void> {
-    assert(this.myParticipation > InvitationResponse.Organizer, "Only invitations can be responded to");
+    assert(this.isIncomingMeeting, "Only invitations can be responded to");
     let request = new OWACreateItemRequest({MessageDisposition: "SendAndSaveCopy"});
     request.addField(ResponseTypes[response], "ReferenceItemId", {
       __type: "ItemId:#Exchange",


### PR DESCRIPTION
I am confused as to why `EditEvent` has a check, then an `<hbox>`, then an `InvitationResponseButtons`, which itself then contains an `<hbox>` and a check, but I wasn't sure which could be removed.