### PR TITLE
Mobile Backend: Make capacitor-nodejs start an ESM module (#583)

### DIFF
--- a/mobile/android/app/src/main/AndroidManifest.xml
+++ b/mobile/android/app/src/main/AndroidManifest.xml
@@ -7,7 +7,8 @@
         android:label="@string/app_name"
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
-        android:theme="@style/AppTheme">
+        android:theme="@style/AppTheme"
+        android:usesCleartextTraffic="true">
 
         <activity
             android:configChanges="orientation|keyboardHidden|keyboard|screenSize|locale|smallestScreenSize|screenLayout|uiMode|navigation"

--- a/mobile/android/app/src/main/AndroidManifest.xml
+++ b/mobile/android/app/src/main/AndroidManifest.xml
@@ -9,6 +9,10 @@
         android:supportsRtl="true"
         android:theme="@style/AppTheme"
         android:usesCleartextTraffic="true">
+        <!--
+          TODO: Replace `android:usesCleartextTraffic="true"`
+          with https://developer.android.com/privacy-and-security/security-config#CleartextTrafficPermitted
+          -->
 
         <activity
             android:configChanges="orientation|keyboardHidden|keyboard|screenSize|locale|smallestScreenSize|screenLayout|uiMode|navigation"

--- a/mobile/backend/package-deploy.json
+++ b/mobile/backend/package-deploy.json
@@ -1,0 +1,3 @@
+{
+  "main": "./index.mjs"
+}

--- a/mobile/backend/package.json
+++ b/mobile/backend/package.json
@@ -5,6 +5,7 @@
   "main": "./index.ts",
   "type": "module",
   "dependencies": {
+    "vite-plugin-static-copy": "^2.3.1",
     "ws": "^8.16.0"
   },
   "resolutions": {

--- a/mobile/backend/vite.config.ts
+++ b/mobile/backend/vite.config.ts
@@ -27,12 +27,12 @@ export default defineConfig({
       targets: [
         {
           src: 'dist/index.js',
-          dest: '../../android/app/src/main/assets/public/nodejs',
+          dest: '../../../app/dist/nodejs',
           rename: 'index.mjs',
         },
         {
           src: 'package-deploy.json',
-          dest: '../../android/app/src/main/assets/public/nodejs',
+          dest: '../../../app/dist/nodejs',
           rename: 'package.json',
         },
       ]

--- a/mobile/backend/vite.config.ts
+++ b/mobile/backend/vite.config.ts
@@ -1,5 +1,6 @@
 import { defineConfig } from 'vite';
 import nodeExternals from 'rollup-plugin-node-externals';
+import { viteStaticCopy } from 'vite-plugin-static-copy';
 
 export default defineConfig({
   ssr: { noExternal: true },
@@ -7,12 +8,13 @@ export default defineConfig({
     target: 'node18',
     lib: {
       name: 'index',
-      fileName: () => 'indexs.js',
       formats: ['es'],
       entry: './index.ts'
     },
-    outDir: '../android/app/src/main/assets/public/nodejs',
-    emptyOutDir: false,
+    //outDir: '../android/app/src/main/assets/public/nodejs',
+    //emptyOutDir: false,
+    outDir: 'dist',
+    emptyOutDir: true,
     minify: false,
     ssr: true,
   },
@@ -20,6 +22,20 @@ export default defineConfig({
     nodeExternals({
       deps: false,
       devDeps: true, // Use node.js internal modules
-    })
+    }),
+    viteStaticCopy({
+      targets: [
+        {
+          src: 'dist/index.js',
+          dest: '../../android/app/src/main/assets/public/nodejs',
+          rename: 'index.mjs',
+        },
+        {
+          src: 'package-deploy.json',
+          dest: '../../android/app/src/main/assets/public/nodejs',
+          rename: 'package.json',
+        },
+      ]
+    }),
   ],
 });

--- a/mobile/backend/vite.config.ts
+++ b/mobile/backend/vite.config.ts
@@ -11,8 +11,6 @@ export default defineConfig({
       formats: ['es'],
       entry: './index.ts'
     },
-    //outDir: '../android/app/src/main/assets/public/nodejs',
-    //emptyOutDir: false,
     outDir: 'dist',
     emptyOutDir: true,
     minify: false,


### PR DESCRIPTION
- Make capacitor-nodejs start an ESM module
- Allow clear text traffic for now to connect the frontend to the backend
- Copy the backend files to the `webDir` so it's copied to the android build files also and it prevents it from getting deleted by an overwrite
- Based on #584 