### PR TITLE
Calendar: WeekView: Only use start if it's not undefined (#588)

### DIFF
--- a/app/frontend/Calendar/DayView/WeekView.svelte
+++ b/app/frontend/Calendar/DayView/WeekView.svelte
@@ -58,15 +58,16 @@
 
   let scrollE: Scroll;
   let visibleHeight = 0;
+  let focusHour: number;
   $: pxPerHour =  visibleHeight / showHours;
   $: scrollHeight = pxPerHour * (endHour - startHour);
-  $: focusHour = start.toDateString() == new Date().toDateString()
+  $: if (start) focusHour = start.toDateString() == new Date().toDateString()
     ? new Date().getHours()
     : defaultFocusHour;
   $: if (scrollE) scrollE.scrollTo((focusHour - 0.5) * pxPerHour);
 
   let startTimes: Date[] = [];
-  $: start, setStartTimes();
+  $: if (start) setStartTimes();
   function setStartTimes() {
     let startTime = new Date(start);
     startTime.setMinutes(0);
@@ -80,7 +81,7 @@
   }
 
   let days: Date[] = [];
-  $: start, setDays();
+  $: if (start) setDays();
   function setDays() {
     let startTime = new Date(start);
     if (showDays > 3) {
@@ -98,7 +99,7 @@
   }
 
   let allDayEvents: Collection<Event>;
-  $: start, $events, setAllDayEvents();
+  $: if (!!start && $events) setAllDayEvents();
   function setAllDayEvents() {
     let end = new Date(start.getTime() + showDays * k1DayMS);
     allDayEvents = events.filter(ev => ev.allDay && ev.startTime < end && start < ev.endTime);


### PR DESCRIPTION
- Calendar: WeekView: Only use start if it's not undefined
- This seems to be the bug where when you switch apps the variable binding happens after mount so it's intially `undefined`