### PR TITLE
Meet: Gallery: Scroll snap into top of video (#598)

### DIFF
--- a/app/frontend/Meet/View/Gallery.svelte
+++ b/app/frontend/Meet/View/Gallery.svelte
@@ -80,7 +80,7 @@
   .gallery :global(.scroll) {
     scroll-snap-type: y mandatory;
   }
-  .participants :global(.participant) {
+  .participants > :global(.participant) {
     scroll-snap-align: start;
   }
 </style>


### PR DESCRIPTION
- The inner name label element also had a participant class so the `scroll-snap-align` was also being applied to that.
- Even with this fixed the there's still a little half video at the bottom.
- Because the `clientWidth` and `clientHeight` of the gallery includes the scroll it causes the size to be miscalculated.
- There's a way to fix but it's not ideal you would need to get the `clientWidth` and `clientHeight` of the `<Scroll>` component.