### PR TITLE
Followup to changing future events of a series

### DIFF
--- a/app/frontend/Calendar/EditEvent/DateInput.svelte
+++ b/app/frontend/Calendar/EditEvent/DateInput.svelte
@@ -29,7 +29,7 @@
   function onChange() {
     let [fullYear, month, day] = value.split("-");
     date.setFullYear(parseInt(fullYear), parseInt(month) - 1, parseInt(day));
-    date = date;
+    date = new Date(date);
   }
 </script>
 

--- a/app/frontend/Calendar/EditEvent/DialogHeader.svelte
+++ b/app/frontend/Calendar/EditEvent/DialogHeader.svelte
@@ -36,7 +36,7 @@
             <RoundButton
              label={$t`Delete remainder of series`}
              icon={DeleteIcon}
-             onClick={onDeleteForward}
+             onClick={onDeleteRemainder}
              classes="plain delete"
              border={false}
              iconSize="16px"
@@ -81,7 +81,7 @@
             <RoundButton
              label={$t`Change remainder of series`}
              icon={SaveIcon}
-             onClick={onChangeForward}
+             onClick={onChangeRemainder}
              classes="plain save-or-close"
              filled={true}
              iconSize="16px"
@@ -217,7 +217,7 @@
     onClose();
   }
 
-  async function onChangeForward() {
+  async function onChangeRemainder() {
     let master = event.calendar.newEvent();
     master.copyEditableFieldsFrom(event);
     master.calUID = null;
@@ -251,7 +251,7 @@
     onClose();
   }
 
-  async function onDeleteForward() {
+  async function onDeleteRemainder() {
     await event.truncateRecurrence();
     onClose();
   }

--- a/app/frontend/Calendar/EditEvent/DialogHeader.svelte
+++ b/app/frontend/Calendar/EditEvent/DialogHeader.svelte
@@ -167,7 +167,7 @@
     } else {
       let rule = repeatBox.newRecurrenceRule();
       if (master.recurrenceRule) {
-        if (rule.isCompatible(master.recurrenceRule)) {
+        if (rule.isCompatible(master.recurrenceRule) && event.duration == master.duration) {
           return true;
         }
         if (!confirm($t`This change will reset all of your series to default values.`)) {

--- a/app/frontend/Calendar/EditEvent/DialogHeader.svelte
+++ b/app/frontend/Calendar/EditEvent/DialogHeader.svelte
@@ -189,6 +189,10 @@
   }
 
   async function onSave() {
+    await saveEvent(event);
+  }
+
+  async function saveEvent(event) {
     // Turning a single event into a series.
     // (The reverse is done in `onChangeAll`.)
     if (repeatBox) {
@@ -221,11 +225,7 @@
     let master = event.calendar.newEvent();
     master.copyEditableFieldsFrom(event);
     master.calUID = null;
-    master.recurrenceRule = repeatBox.newRecurrenceRule();
-    master.recurrenceCase = RecurrenceCase.Master;
-    master.fillRecurrences(new Date(Date.now() + 1e11));
-    await master.saveToServer();
-    await master.save();
+    await saveEvent(master);
     await event.truncateRecurrence();
     onClose();
   }

--- a/app/frontend/Calendar/EditEvent/DialogHeader.svelte
+++ b/app/frontend/Calendar/EditEvent/DialogHeader.svelte
@@ -88,7 +88,7 @@
              />
           {/if}
         {/if}
-        {#if canSave && !(event.parentEvent && repeatBox)}
+        {#if canSave && ($event.hasChanged() || repeatBox && !event.parentEvent)}
           <RoundButton
             label={$t`Revert`}
             icon={RevertIcon}
@@ -149,7 +149,7 @@
 
   $: event.startEditing(); // not `$event`
   $: canSave = event && $event.title && $event.startTime && $event.endTime &&
-      event.startTime.getTime() <= event.endTime.getTime() && (repeatBox || $event.hasChanged());
+      event.startTime.getTime() <= event.endTime.getTime();
   $: seriesStatus = event.seriesStatus;
 
   function confirmAndChangeRecurrenceRule(): boolean {

--- a/app/frontend/Calendar/EditEvent/EditEvent.svelte
+++ b/app/frontend/Calendar/EditEvent/EditEvent.svelte
@@ -92,8 +92,8 @@
   import { t } from "../../../l10n/l10n";
 
   export let event: Event;
+  let showRepeat = event.recurrenceRule || event.parentEvent && event.isNew;
 
-  $: showRepeat = false;
   $: showReminder = !!$event.alarm;
   $: showParticipants = $event.participants.hasItems;
   $: showLocation = !!$event.location;

--- a/app/frontend/Calendar/EditEvent/RepeatBox.svelte
+++ b/app/frontend/Calendar/EditEvent/RepeatBox.svelte
@@ -102,7 +102,7 @@
   $: $event.startTime, updateDateUI();
   function updateDateUI() {
     yearWeekOptions = [{ label: $t`On ${event.startTime.toLocaleDateString(getUILocale(), { day: "numeric", month: "long" })}`, value: 0 }];
-    monthWeekOptions = [{ label: $t`On day ${event.startTime.toLocaleDateString(getUILocale(), { day: "numeric" })} of every month`, value: 0 }];
+    monthWeekOptions = [{ label: $t`On ${event.startTime.toLocaleDateString(getUILocale(), { day: "numeric" })}. of every month`, value: 0 }];
 
     let weekday = event.startTime.toLocaleDateString(getUILocale(), { weekday: "long" });
     let weekno = Math.ceil(event.startTime.getDate() / 7);

--- a/app/frontend/Calendar/EditEvent/RepeatBox.svelte
+++ b/app/frontend/Calendar/EditEvent/RepeatBox.svelte
@@ -85,7 +85,7 @@
   let frequency = master.recurrenceRule?.frequency || Frequency.Daily;
   let interval = master.recurrenceRule?.interval || 1;
   // end // let count = Number.isFinite(event.recurrenceRule?.count) ? event.recurrenceRule.count : 1;
-  let weekdays = master.recurrenceRule?.weekdays || [event.startTime.getDay()];
+  let weekdays = master.recurrenceRule?.weekdays.slice() || [event.startTime.getDay()];
   let week = master.recurrenceRule?.week || 0;
   // end // let end = event.recurrenceRule?.endDate ? "date" : Number.isFinite(event.recurrenceRule?.count) ? "count" : "none";
   // end // let endDate = master.recurrenceRule?.endDate || event.startTime;

--- a/app/frontend/Calendar/EditEvent/RepeatBox.svelte
+++ b/app/frontend/Calendar/EditEvent/RepeatBox.svelte
@@ -81,13 +81,14 @@
   export let event: Event;
   export let showRepeat: boolean;
 
-  let frequency = event.recurrenceRule?.frequency || Frequency.Daily;
-  let interval = event.recurrenceRule?.interval || 1;
-  let count = Number.isFinite(event.recurrenceRule?.count) ? event.recurrenceRule.count : 1;
-  let weekdays = event.recurrenceRule?.weekdays || [event.startTime.getDay()];
-  let week = event.recurrenceRule?.week || 0;
-  let end = event.recurrenceRule?.endDate ? "date" : Number.isFinite(event.recurrenceRule?.count) ? "count" : "none";
-  let endDate = event.recurrenceRule?.endDate || event.startTime;
+  let master = event.parentEvent || event;
+  let frequency = master.recurrenceRule?.frequency || Frequency.Daily;
+  let interval = master.recurrenceRule?.interval || 1;
+  // end // let count = Number.isFinite(event.recurrenceRule?.count) ? event.recurrenceRule.count : 1;
+  let weekdays = master.recurrenceRule?.weekdays || [event.startTime.getDay()];
+  let week = master.recurrenceRule?.week || 0;
+  // end // let end = event.recurrenceRule?.endDate ? "date" : Number.isFinite(event.recurrenceRule?.count) ? "count" : "none";
+  // end // let endDate = master.recurrenceRule?.endDate || event.startTime;
   let minDate = event.startTime;
   let daily = "everyday";
   let dailyOptions: RadioOption[] = [
@@ -101,7 +102,7 @@
   $: $event.startTime, updateDateUI();
   function updateDateUI() {
     yearWeekOptions = [{ label: $t`On ${event.startTime.toLocaleDateString(getUILocale(), { day: "numeric", month: "long" })}`, value: 0 }];
-    monthWeekOptions = [{ label: $t`On ${event.startTime.toLocaleDateString(getUILocale(), { day: "numeric" })}. of every month`, value: 0 }];
+    monthWeekOptions = [{ label: $t`On day ${event.startTime.toLocaleDateString(getUILocale(), { day: "numeric" })} of every month`, value: 0 }];
 
     let weekday = event.startTime.toLocaleDateString(getUILocale(), { weekday: "long" });
     let weekno = Math.ceil(event.startTime.getDate() / 7);
@@ -120,18 +121,26 @@
       week = weekno;
     }
 
+    if (!weekdays.includes(event.startTime.getDay())) {
+      if (weekdays.length == 1) {
+        weekdays[0] = event.startTime.getDay();
+      } else {
+        weekdays.push(event.startTime.getDay());
+      }
+    }
     weekdayOptions = [1, 2, 3, 4, 5, 6, 7].map(day => new Date(2010, 2, day)).map(date => ({
       value: date.getDay(),
       disabled: date.getDay() == event.startTime.getDay(),
       label: date.toLocaleDateString(getUILocale(), { weekday: "narrow" }),
     }));
 
+    /* end
     if (endDate <= event.startTime) {
       endDate = new Date(event.startTime);
       endDate.setHours(23, 59, 59, 0);
     }
+    */
     minDate = event.startTime;
-    event.endTime.setFullYear(event.startTime.getFullYear(), event.startTime.getMonth(), event.startTime.getDate());
     event.notifyObservers();
   }
 
@@ -169,11 +178,13 @@
 
   export function newRecurrenceRule(): RecurrenceRule {
     let init: RecurrenceInit = { startDate: event.startTime, frequency, interval };
+    /* end
     if (end == "count") {
       init.count = count;
     } else if (end == "date") {
       init.endDate = endDate;
     }
+    */
     if (frequency == Frequency.Weekly) {
       init.weekdays = weekdays;
     } else if (frequency == Frequency.Monthly || frequency == Frequency.Yearly) {

--- a/app/frontend/Calendar/EditEvent/TimeBox.svelte
+++ b/app/frontend/Calendar/EditEvent/TimeBox.svelte
@@ -93,6 +93,7 @@
   export let event: Event;
 
   $: showTimezone = $event.timezone != myTimezone();
+  $: $event.endTime, checkEndTime();
   $: isMultipleDays = $event.startTime && $event.endTime && $event.endTime.toLocaleDateString() != $event.startTime.toLocaleDateString();
   let durationUnit: DurationUnit;
   let durationInUnit: number;
@@ -138,7 +139,6 @@
     event.notifyObservers();
   }
 
-  $: $event.endTime, checkEndTime()
   function checkEndTime() {
     if (event.endTime.getTime() <= event.startTime.getTime()) {
       event.endTime.setTime(event.startTime.getTime() + 1);

--- a/app/logic/Calendar/Event.ts
+++ b/app/logic/Calendar/Event.ts
@@ -355,7 +355,7 @@ export class Event extends Observable {
 
   /** Delete multiple instances */
   async makeExclusions(indices: number[]) {
-    let exclusions = [];
+    let exclusions: Event[] = [];
     for (let index of indices) {
       let previous = this.instances.get(index);
       this.instances.set(index, null);
@@ -365,7 +365,7 @@ export class Event extends Observable {
     }
     this.calendar.events.removeAll(exclusions);
     for (let exclusion of exclusions) {
-      if (!exclusion.isNew()) {
+      if (!exclusion.isNew) {
         await this.calendar.storage.deleteEvent(exclusion);
       }
     }

--- a/app/logic/Calendar/Event.ts
+++ b/app/logic/Calendar/Event.ts
@@ -27,14 +27,8 @@ export class Event extends Observable {
 
   @notifyChangedProperty
   startTime: Date;
-  _endTime: Date;
-  @notifyChangedAccessor
-  set endTime(val) {
-    this._endTime = val;
-  }
-  get endTime() {
-    return this._endTime;
-  }
+@notifyChangedProperty
+  endTime: Date;
   @notifyChangedProperty
   allDay = false;
   /** IANA timezone name, e.g. "Europe/Berlin" */

--- a/app/logic/Calendar/RecurrenceRule.ts
+++ b/app/logic/Calendar/RecurrenceRule.ts
@@ -183,8 +183,10 @@ export class RecurrenceRule implements Readonly<RecurrenceInit> {
   }
 
   /**
-   * Checks whether this rule will invalidate existing occurrences.
-   * We don't check the series length though, as the UI never sets one.
+   * When you change the entire series, that could include changing when it
+   * recurs. The UI uses this function to tell whether the recurrence was
+   * edited, as this will cause all exceptions and exclusions to be reset.
+   * But we can't check the series length though, as the UI never sets one.
    */
   isCompatible(rule: RecurrenceRule) {
     let allWeekdays = [0, 1, 2, 3, 4, 5, 6];


### PR DESCRIPTION
The repeat box now shows automatically for unedited instances allowing you to easily change all future events. Also fixes #591 and fixes #592.

Other bugs that were fixed:
- Changing event duration needs to reset exceptions and removes exclusions
- Repeat box wasn't noticing the change to the event's start date
- Repeat box was erroneously mutating the recurrence rule's weekdays
- Save all icon wasn't appearing correctly
- Code in `makeExclusions` was broken