### PR TITLE
Invitation: Rename more EMail.scheduling to .invitationMessage

### DIFF
--- a/app/frontend/Calendar/DisplayEvent/Invitation.svelte
+++ b/app/frontend/Calendar/DisplayEvent/Invitation.svelte
@@ -1,7 +1,7 @@
 <vbox class="invitation">
   {#if $message.event}
     <InvitationDisplay event={message.event} />
-  {:else if message.scheduling}
+  {:else if message.invitationMessage}
     {#await message.loadEvent()}
       {$t`Loading event...`}
     {:then}
@@ -14,7 +14,7 @@
       {ex?.message ?? ex}
     {/await}
   {/if}
-  {#if message.scheduling == InvitationMessage.Invitation}
+  {#if message.invitationMessage == InvitationMessage.Invitation}
     <hbox class="buttons">
       <Button
         label={$t`Confirm *=> Confirm to attend the meeting`}

--- a/app/frontend/Mail/Message/MessageDisplay.svelte
+++ b/app/frontend/Mail/Message/MessageDisplay.svelte
@@ -4,7 +4,7 @@
   >
   <MessageHeader {message} />
   <MessageAttachments {message} />
-  {#if $message.event || $message.scheduling}
+  {#if $message.event || $message.invitationMessage}
     <Invitation {message} />
   {/if}
   <vbox class="body" flex>


### PR DESCRIPTION
These changes were overlooked in 825bb5cef0c5ad126fc88e24634ad5ecdadac787.

With this, the scheduling buttons appear consistently for invitations as expected.