### PR TITLE
MainWindow: Debounce sidebar variable (#588)

### DIFF
--- a/app/frontend/Calendar/DayView/WeekView.svelte
+++ b/app/frontend/Calendar/DayView/WeekView.svelte
@@ -58,16 +58,15 @@
 
   let scrollE: Scroll;
   let visibleHeight = 0;
-  let focusHour: number;
   $: pxPerHour =  visibleHeight / showHours;
   $: scrollHeight = pxPerHour * (endHour - startHour);
-  $: if (start) focusHour = start.toDateString() == new Date().toDateString()
+  $: focusHour = start.toDateString() == new Date().toDateString()
     ? new Date().getHours()
     : defaultFocusHour;
   $: if (scrollE) scrollE.scrollTo((focusHour - 0.5) * pxPerHour);
 
   let startTimes: Date[] = [];
-  $: if (start) setStartTimes();
+  $: start, setStartTimes();
   function setStartTimes() {
     let startTime = new Date(start);
     startTime.setMinutes(0);
@@ -81,7 +80,7 @@
   }
 
   let days: Date[] = [];
-  $: if (start) setDays();
+  $: start, setDays();
   function setDays() {
     let startTime = new Date(start);
     if (showDays > 3) {
@@ -99,7 +98,7 @@
   }
 
   let allDayEvents: Collection<Event>;
-  $: if (!!start && $events) setAllDayEvents();
+  $: start, $events, setAllDayEvents();
   function setAllDayEvents() {
     let end = new Date(start.getTime() + showDays * k1DayMS);
     allDayEvents = events.filter(ev => ev.allDay && ev.startTime < end && start < ev.endTime);

--- a/app/frontend/MainWindow/MainWindow.svelte
+++ b/app/frontend/MainWindow/MainWindow.svelte
@@ -57,13 +57,16 @@
   import { catchErrors, backgroundError } from "../Util/error";
   import { assert } from "../../logic/util/util";
   import { onMount } from "svelte";
+  import { useDebounce } from "@svelteuidev/composables";
   import { getUILocale, t } from "../../l10n/l10n";
   import { rtlLocales } from "../../l10n/list";
   import { appName } from "../../logic/build";
 
   // $: sidebarApp = $mustangApps.filter(app => app.showSidebar).first; // TODO watch `app` property changes
   $: $sidebarApp = $meetMustangApp.showSidebar ? meetMustangApp : null;
-  $: sidebar = $sidebarApp?.sidebar;
+  let sidebar;
+  const setSidebarDebounced = useDebounce(() => sidebar = $sidebarApp?.sidebar);
+  $: $sidebarApp?.sidebar, setSidebarDebounced();
   $: rtl = rtlLocales.includes(getUILocale()) ? 'rtl' : null;
 
   onMount(() => catchErrors(startup));


### PR DESCRIPTION
- The `sidebar` variable was switching too quickly
- debouncing setting the variable prevents it from mounting and destroying too quickly which causes svelte stores binded to those components to be set to `undefined`.