### PR TITLE
Don't restart editing an event when the editor is refeshed

### DIFF
--- a/app/logic/Calendar/Event.ts
+++ b/app/logic/Calendar/Event.ts
@@ -241,9 +241,11 @@ export class Event extends Observable {
   }
 
   /**
-   * Starts editing an event, if it hasn't already started being edited.
-   * This can happen when switching between the event editor and another
-   * screen, or certain updates within editing events can also trigger it.
+   * Starts editing an event.
+   *
+   * If it is already being edited, this is a no-op. This can happen when switching
+   * between the event editor and another screen, or certain updates within
+   * editing events can also trigger it.
    */
   startEditing() {
     if (this.unedited) {

--- a/app/logic/Calendar/Event.ts
+++ b/app/logic/Calendar/Event.ts
@@ -240,7 +240,15 @@ export class Event extends Observable {
     );
   }
 
+  /**
+   * Starts editing an event, if it hasn't already started being edited.
+   * This can happen when switching between the event editor and another
+   * screen, or certain updates within editing events can also trigger it.
+   */
   startEditing() {
+    if (this.unedited) {
+      return;
+    }
     this.timezone ||= Intl.DateTimeFormat().resolvedOptions().timeZone;
     this.unedited = this.calendar.newEvent();
     this.unedited.copyFrom(this);


### PR DESCRIPTION
Certain actions can cause the dialog header element to refresh, which will then attempt to restart editing of the event.