### PR TITLE
Calendar: Edit: Reminder: Fix to allow editing it

### DIFF
--- a/app/frontend/Calendar/EditEvent/DurationUnit.svelte
+++ b/app/frontend/Calendar/EditEvent/DurationUnit.svelte
@@ -10,7 +10,6 @@
   import { t } from "../../../l10n/l10n";
   import { createEventDispatcher } from 'svelte';
   import { k1DayS, k1HourS, k1MinuteS } from "../../Util/date";
-  const dispatch = createEventDispatcher<{ change: number }>();
 
   export let durationInSeconds: number; /* in/out */
   export let durationInUnit: number; /* in/out */
@@ -46,11 +45,7 @@
   }
 
   $: durationInSeconds, onDurationChanged()
-  export function onDurationChanged() {
-    if (durationInSeconds <= 0) {
-      durationInSeconds = 60;
-    }
-
+  function onDurationChanged() {
     // Adapt unit
     if (durationInSeconds % k1DayS == 0) {
       newUnit(k1DayS);
@@ -59,7 +54,6 @@
     } else if (unitInSeconds != k1MinuteS) {
       newUnit(k1MinuteS);
     }
-    dispatch("change", durationInSeconds);
   }
 
   function newUnit(aUnitInSeconds: number) {

--- a/app/frontend/Calendar/EditEvent/ReminderBox.svelte
+++ b/app/frontend/Calendar/EditEvent/ReminderBox.svelte
@@ -1,6 +1,6 @@
 <hbox title={$t`Reminder`} flex>
-  <input class="duration" type="number" bind:value={durationInUnit} on:input={durationUnit.onDurationChanged} min={0} />
-  <DurationUnit bind:durationInSeconds={beforeInSec} bind:durationInUnit bind:this={durationUnit} on:change={onChanged} />
+  <input class="duration" type="number" bind:value={durationInUnit} on:input={durationUnit.onDurationInUnitChanged} min={0} />
+  <DurationUnit bind:durationInSeconds={beforeInSec} bind:durationInUnit bind:this={durationUnit} />
   {#if $event.alarm}
     <hbox class="label suffix">{$t`before, at`}</hbox>
     <hbox class="label time">{$event.alarm.toLocaleTimeString(getUILocale(), { hour: "numeric", minute: "numeric" })}</hbox>
@@ -27,16 +27,9 @@
 
   let durationUnit: DurationUnit;
   let durationInUnit: number;
-  $: beforeInSec = $event.alarm ? ($event.startTime.getTime() - $event.alarm.getTime()) / 1000 : 0;
+  let beforeInSec = $event.alarm ? ($event.startTime.getTime() - $event.alarm.getTime()) / 1000 : 0;
 
-  function onChanged(ev: CustomEvent<number>) {
-    let seconds = ev.detail;
-    if (!event.alarm) {
-      event.alarm = new Date();
-    }
-    event.alarm.setTime(event.startTime.getTime() - seconds * 1000);
-    event.notifyObservers();
-  }
+  $: event.alarm = new Date(event.startTime.getTime() - beforeInSec * 1000);
 
   function onRemove() {
     event.alarm = null;


### PR DESCRIPTION
The duration in unit was not calling the correct function to notify the duration unit widget of the change.

Furthermore, there was an update loop that prevented you from change the duration after changing the duration unit.

Additionally the `min={0}` was not actually achievable.

This meant that the only reminders possible were 5 minutes, 1 hour and 1 day.

I also checked to ensure that the event duration UI was unaffected.