### PR TITLE
Align with iCal for the end time of all day events

### DIFF
--- a/app/frontend/Calendar/EditEvent/TimeBox.svelte
+++ b/app/frontend/Calendar/EditEvent/TimeBox.svelte
@@ -95,7 +95,9 @@
 
   $: showTimezone = $event.timezone != myTimezone();
   $: $event.endTime, checkEndTime();
-  $: isMultipleDays = $event.startTime && $event.endTime && new Date($event.endTime.getTime() - event.allDay).toDateString() != $event.startTime.toDateString();
+  $: isMultipleDays = $event.startTime && $event.endTime &&
+    // all day events have the non-inclusive next day as end
+    new Date($event.endTime.getTime() - ($event.allDay ? 80000 : 0)).toDateString() != $event.startTime.toDateString();
   let durationUnit: DurationUnit;
   let durationInUnit: number;
   let previousTimezone: string = null;

--- a/app/frontend/Calendar/EditEvent/TimeBox.svelte
+++ b/app/frontend/Calendar/EditEvent/TimeBox.svelte
@@ -126,7 +126,7 @@
       previousEndTime = new Date(event.endTime);
       clearTime(event.startTime);
       clearTime(event.endTime);
-      // Advance to next midnight if the time is not already midnight.
+      // Advance to next midnight if the time is not already midnight. RFC 5545 section 3.6.1
       if (event.endTime.getTime() < previousEndTime.getTime()) {
         event.endTime.setDate(event.endTime.getDate() + 1);
       }

--- a/app/logic/Calendar/Event.ts
+++ b/app/logic/Calendar/Event.ts
@@ -137,6 +137,7 @@ export class Event extends Observable {
     assert(seconds >= 0, "Duration must be >= 0");
     if (this.allDay) {
       this.endTime.setTime(this.startTime.getTime());
+      // End date is non-inclusive next day. RFC 5545 section 3.6.1
       this.endTime.setDate(this.endTime.getDate() + Math.round(seconds / k1DayS));
     } else {
       this.endTime.setTime(this.startTime.getTime() + seconds * 1000);

--- a/app/logic/Calendar/Event.ts
+++ b/app/logic/Calendar/Event.ts
@@ -136,9 +136,11 @@ export class Event extends Observable {
   set duration(seconds: number) {
     assert(seconds >= 0, "Duration must be >= 0");
     if (this.allDay) {
-      seconds = Math.round(Math.ceil(seconds / k1DayS) * k1DayS) - 1; // set to 23:59:59
+      this.endTime.setTime(this.startTime.getTime());
+      this.endTime.setDate(this.endTime.getDate() + Math.round(seconds / k1DayS));
+    } else {
+      this.endTime.setTime(this.startTime.getTime() + seconds * 1000);
     }
-    this.endTime.setTime(this.startTime.getTime() + seconds * 1000);
   }
 
   /** in minutes */


### PR DESCRIPTION
As per RFC5545 section 3.6.1 I also disable the time zone for all day events. I also set the minimum for the end date picker for convenience.