### PR TITLE
OAuth2: Set the correct port for authDoneURL (#581)

### DIFF
--- a/app/logic/Auth/OAuth2.ts
+++ b/app/logic/Auth/OAuth2.ts
@@ -8,6 +8,7 @@ import { Observable, notifyChangedProperty } from "../util/Observable";
 import { sanitize } from "../../../lib/util/sanitizeDatatypes";
 import { assert, type URLString } from "../util/util";
 import pkceChallenge from "pkce-challenge";
+import { production } from "../build";
 
 /**
  * Implements login via OAuth2
@@ -30,7 +31,7 @@ export class OAuth2 extends Observable {
   tokenURL: URLString;
   tokenURLPasswordAuth?: URLString;
   authURL: URLString;
-  authDoneURL: URLString = "http://localhost:5455/login-success";
+  authDoneURL: URLString = `http://localhost:${production ? 5455 : 5453}/login-success`;
   scope: string;
   clientID = "open";
   clientSecret: string | null = null;

--- a/app/logic/Auth/UI/OAuth2Embed.ts
+++ b/app/logic/Auth/UI/OAuth2Embed.ts
@@ -26,7 +26,7 @@ export class OAuth2Embed extends OAuth2UI {
     });
   }
   urlChanged(url: URLString) {
-    console.log("OAuth2 page change to", url);
+    console.log("OAuth2 page change to", url, "doneURL is", this.oAuth2.authDoneURL);
     if (this.oAuth2.isAuthDoneURL(url)) {
       this.success(url);
     }


### PR DESCRIPTION
- The port was still 5455 in dev mode, even though the correct port is 5453
- That means Gmail logins always got stuck after the consent screen because the authDoneURL didn't match
- Added extra authDoneURL logging for debugging in production if it still happens in production