### PR TITLE
EWS, OWA: Fix editing timezone

### DIFF
--- a/app/logic/Calendar/EWS/EWSEvent.ts
+++ b/app/logic/Calendar/EWS/EWSEvent.ts
@@ -385,10 +385,10 @@ class EWSUpdateOccurrenceRequest {
       field.t$FieldURI = { FieldURI };
     }
     if (value == null) {
-      this.itemChange.t$Updates.t$DeleteItemField.push(field);
+      this.itemChange.t$Updates.t$DeleteItemField.unshift(field);
     } else {
       field["t$" + type] = { ["t$" + key]: value };
-      this.itemChange.t$Updates.t$SetItemField.push(field);
+      this.itemChange.t$Updates.t$SetItemField.unshift(field); // reverse order for Event time zone
     }
   }
 }

--- a/app/logic/Calendar/OWA/Request/OWAUpdateOccurrenceRequest.ts
+++ b/app/logic/Calendar/OWA/Request/OWAUpdateOccurrenceRequest.ts
@@ -42,6 +42,6 @@ export default class OWAUpdateOccurrenceRequest extends OWARequest {
       };
       field.Item[key] = value;
     }
-    this.itemChange.Updates.push(field);
+    this.itemChange.Updates.unshift(field); // reverse order for Event time zone
   }
 }

--- a/app/logic/Mail/EWS/Request/EWSUpdateItemRequest.ts
+++ b/app/logic/Mail/EWS/Request/EWSUpdateItemRequest.ts
@@ -29,10 +29,10 @@ export default class EWSUpdateItemRequest {
       field.t$FieldURI = { FieldURI };
     }
     if (value == null) {
-      this.itemChange.t$Updates.t$DeleteItemField.push(field);
+      this.itemChange.t$Updates.t$DeleteItemField.unshift(field);
     } else {
       field["t$" + type] = { ["t$" + key]: value };
-      this.itemChange.t$Updates.t$SetItemField.push(field);
+      this.itemChange.t$Updates.t$SetItemField.unshift(field); // reverse order for Event time zone
     }
   }
 }

--- a/app/logic/Mail/OWA/Request/OWAUpdateItemRequest.ts
+++ b/app/logic/Mail/OWA/Request/OWAUpdateItemRequest.ts
@@ -38,6 +38,6 @@ export default class OWAUpdateItemRequest extends OWARequest {
       };
       field.Item[key] = value;
     }
-    this.itemChange.Updates.push(field);
+    this.itemChange.Updates.unshift(field); // reverse order for Event time zone
   }
 }


### PR DESCRIPTION
Current behaviour:
- ActiveSync
  - [X] Create event with custom time zone
  - [X] Update custom time zone
- Office 365
  - [X] Create event with custom time zone
  - [X] Update custom time zone
- Other OWA
  - [X] Create event with custom time zone
  - [ ] Update custom time zone
- EWS
  - [X] Create event with custom time zone
  - [ ] Update custom time zone

The problem is that the spec says that the time zone comes after the time when creating events but before it when updating events.

This change attempts to address the issue by reversing the order in which fields are updated for EWS and other OWA.