### PR TITLE
Windows: Code signing

### DIFF
--- a/.github/workflows/installer-windows-parula.yml
+++ b/.github/workflows/installer-windows-parula.yml
@@ -26,6 +26,8 @@ jobs:
     - run: cd e2; yarn run build:release:win
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        CSC_LINK: ${{ secrets.CSC_LINK_WIN_PARULA }}
+        CSC_KEY_PASSWORD: ${{ secrets.CSC_KEY_PASSWORD_WIN_PARULA }}
         SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
         # For Sentry source maps. Otherwise, vite build is out of memory
         NODE_OPTIONS: '--max-old-space-size=32768'

--- a/.github/workflows/installer-windows.yml
+++ b/.github/workflows/installer-windows.yml
@@ -26,6 +26,8 @@ jobs:
     - run: cd e2; yarn run build:release:win
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        CSC_LINK: ${{ secrets.CSC_LINK_WIN_MUSTANG }}
+        CSC_KEY_PASSWORD: ${{ secrets.CSC_KEY_PASSWORD_WIN_MUSTANG }}
         SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
         # For Sentry source maps. Otherwise, vite build is out of memory
         NODE_OPTIONS: '--max-old-space-size=32768'


### PR DESCRIPTION
- Here are changes for CI to code sign our app
- We need to test if setting these env variables on a local machine code signs successfully and doesn't break the code
- I've set different CSC_* secret names so we can have one for Parula and one for Mustang
- If we're setting the CSC_LINK directly in base64-encoding then we might get a character limit error, then we need fix that by creating a file and writing the certificate there and link to that