### PR TITLE
IMAP: Gmail: Get new access on reconnect (#350)

### DIFF
--- a/app/logic/Auth/OAuth2.ts
+++ b/app/logic/Auth/OAuth2.ts
@@ -296,12 +296,8 @@ export class OAuth2 extends Observable {
     if (this.expiryTimout) {
       clearTimeout(this.expiryTimout);
     }
-    try {
-      if (this.refreshToken) {
-        await this.getAccessTokenFromRefreshToken(this.refreshToken);
-      }
-    } catch (ex) {
-      this.refreshErrorCallback(ex);
+    if (this.refreshToken) {
+      await this.getAccessTokenFromRefreshToken(this.refreshToken);
     }
   }
 

--- a/app/logic/Auth/OAuth2.ts
+++ b/app/logic/Auth/OAuth2.ts
@@ -293,9 +293,6 @@ export class OAuth2 extends Observable {
   }
 
   async refreshImmediately() {
-    if (this.expiryTimout) {
-      clearTimeout(this.expiryTimout);
-    }
     if (this.refreshToken) {
       await this.getAccessTokenFromRefreshToken(this.refreshToken);
     }

--- a/app/logic/Auth/OAuth2.ts
+++ b/app/logic/Auth/OAuth2.ts
@@ -292,6 +292,19 @@ export class OAuth2 extends Observable {
     }
   }
 
+  async refreshImmediately() {
+    if (this.expiryTimout) {
+      clearTimeout(this.expiryTimout);
+    }
+    try {
+      if (this.refreshToken) {
+        await this.getAccessTokenFromRefreshToken(this.refreshToken);
+      }
+    } catch (ex) {
+      this.refreshErrorCallback(ex);
+    }
+  }
+
   refreshInSeconds(seconds: number): void {
     if (this.expiryTimout) {
       clearTimeout(this.expiryTimout);

--- a/app/logic/Mail/IMAP/IMAPAccount.ts
+++ b/app/logic/Mail/IMAP/IMAPAccount.ts
@@ -231,7 +231,7 @@ export class IMAPAccount extends MailAccount {
         !this.oAuth2?.isLoggedIn) {
       await this.oAuth2.login(false);
     }
-    if (this.isGMail()) {
+    if (this.alwaysNewOAuth2AccessToken) {
       await this.oAuth2.refreshImmediately();
     }
     if (!(this.password || this.oAuth2?.isLoggedIn)) {

--- a/app/logic/Mail/IMAP/IMAPAccount.ts
+++ b/app/logic/Mail/IMAP/IMAPAccount.ts
@@ -14,7 +14,6 @@ import { appName, appVersion, siteRoot } from "../../build";
 import { ArrayColl, MapColl, type Collection } from "svelte-collections";
 import type { ImapFlow } from "../../../../backend/node_modules/imapflow";
 import { gt } from "../../../l10n/l10n";
-import { notifyChangedProperty } from "../../util/Observable";
 
 export class IMAPAccount extends MailAccount {
   readonly protocol: string = "imap";
@@ -56,6 +55,8 @@ export class IMAPAccount extends MailAccount {
     this.notifyObservers();
     (this.inbox as IMAPFolder).startPolling();
 
+    // Gmail access tokens are only valid for a single continuous connection
+    // <https://developers.google.com/workspace/gmail/imap/imap-smtp#session_length_limits>
     this.alwaysNewToken = this.hostname.endsWith("gmail.com");
   }
 

--- a/app/logic/Mail/IMAP/IMAPAccount.ts
+++ b/app/logic/Mail/IMAP/IMAPAccount.ts
@@ -18,6 +18,9 @@ import { gt } from "../../../l10n/l10n";
 export class IMAPAccount extends MailAccount {
   readonly protocol: string = "imap";
   acceptOldTLS = false;
+  /** Whether to get a new access token on reconnect.
+   * Gmail requires a new token on reconnecting */
+  alwaysNewToken = this.hostname.endsWith("gmail.com");
   pathDelimiter: string; /** Separator in folder path. E.g. '.' or '/', depending on server */
   deleteStrategy: DeleteStrategy = DeleteStrategy.MoveToTrash;
   /** if polling is enabled, how often to poll.
@@ -217,7 +220,7 @@ export class IMAPAccount extends MailAccount {
     this.notifyObservers();
 
     if (this.authMethod == AuthMethod.OAuth2 && this.oAuth2 &&
-        !this.oAuth2?.isLoggedIn) {
+        !this.oAuth2?.isLoggedIn || this.alwaysNewToken) {
       await this.oAuth2.login(false);
     }
     if (!(this.password || this.oAuth2?.isLoggedIn)) {

--- a/app/logic/Mail/IMAP/IMAPAccount.ts
+++ b/app/logic/Mail/IMAP/IMAPAccount.ts
@@ -20,7 +20,7 @@ export class IMAPAccount extends MailAccount {
   acceptOldTLS = false;
   /** Whether to get a new access token on reconnect.
    * Gmail requires a new token on reconnecting */
-  alwaysNewToken = false;
+  alwaysNewOAuth2AccessToken = false;
   pathDelimiter: string; /** Separator in folder path. E.g. '.' or '/', depending on server */
   deleteStrategy: DeleteStrategy = DeleteStrategy.MoveToTrash;
   /** if polling is enabled, how often to poll.
@@ -57,7 +57,11 @@ export class IMAPAccount extends MailAccount {
 
     // Gmail access tokens are only valid for a single continuous connection
     // <https://developers.google.com/workspace/gmail/imap/imap-smtp#session_length_limits>
-    this.alwaysNewToken = this.hostname.endsWith("gmail.com");
+    this.alwaysNewOAuth2AccessToken = this.isGMail();
+  }
+
+  isGMail(): boolean {
+    return this.hostname.endsWith("gmail.com");
   }
 
   async verifyLogin(): Promise<void> {
@@ -224,7 +228,7 @@ export class IMAPAccount extends MailAccount {
     this.notifyObservers();
 
     if (this.authMethod == AuthMethod.OAuth2 && this.oAuth2 &&
-        !this.oAuth2?.isLoggedIn || this.alwaysNewToken) {
+        !this.oAuth2?.isLoggedIn) {
       await this.oAuth2.login(false);
     }
     if (!(this.password || this.oAuth2?.isLoggedIn)) {

--- a/app/logic/Mail/IMAP/IMAPAccount.ts
+++ b/app/logic/Mail/IMAP/IMAPAccount.ts
@@ -14,13 +14,14 @@ import { appName, appVersion, siteRoot } from "../../build";
 import { ArrayColl, MapColl, type Collection } from "svelte-collections";
 import type { ImapFlow } from "../../../../backend/node_modules/imapflow";
 import { gt } from "../../../l10n/l10n";
+import { notifyChangedProperty } from "../../util/Observable";
 
 export class IMAPAccount extends MailAccount {
   readonly protocol: string = "imap";
   acceptOldTLS = false;
   /** Whether to get a new access token on reconnect.
    * Gmail requires a new token on reconnecting */
-  alwaysNewToken = this.hostname.endsWith("gmail.com");
+  alwaysNewToken = false;
   pathDelimiter: string; /** Separator in folder path. E.g. '.' or '/', depending on server */
   deleteStrategy: DeleteStrategy = DeleteStrategy.MoveToTrash;
   /** if polling is enabled, how often to poll.
@@ -54,6 +55,8 @@ export class IMAPAccount extends MailAccount {
     await this.listFolders();
     this.notifyObservers();
     (this.inbox as IMAPFolder).startPolling();
+
+    this.alwaysNewToken = this.hostname.endsWith("gmail.com");
   }
 
   async verifyLogin(): Promise<void> {

--- a/app/logic/Mail/IMAP/IMAPAccount.ts
+++ b/app/logic/Mail/IMAP/IMAPAccount.ts
@@ -232,7 +232,7 @@ export class IMAPAccount extends MailAccount {
       await this.oAuth2.login(false);
     }
     if (this.isGMail()) {
-      this.oAuth2.refreshInSeconds(0);
+      await this.oAuth2.refreshImmediately();
     }
     if (!(this.password || this.oAuth2?.isLoggedIn)) {
       throw new LoginError(new Error(), "Reconnect failed due to missing login");

--- a/app/logic/Mail/IMAP/IMAPAccount.ts
+++ b/app/logic/Mail/IMAP/IMAPAccount.ts
@@ -231,6 +231,9 @@ export class IMAPAccount extends MailAccount {
         !this.oAuth2?.isLoggedIn) {
       await this.oAuth2.login(false);
     }
+    if (this.isGMail()) {
+      this.oAuth2.refreshInSeconds(0);
+    }
     if (!(this.password || this.oAuth2?.isLoggedIn)) {
       throw new LoginError(new Error(), "Reconnect failed due to missing login");
     }


### PR DESCRIPTION
- Gmail access tokens are only valid for a single continuous connection, therefore we getting an error whenever reconnecting without getting a new access token
- You have to set `alwaysNewToken` after or during login because on initialization `hostname` is not set yet