### PR TITLE
Calendar: ReminderBox: Don't set event.alarm if null (#643)

### DIFF
--- a/app/frontend/Calendar/EditEvent/ReminderBox.svelte
+++ b/app/frontend/Calendar/EditEvent/ReminderBox.svelte
@@ -29,7 +29,7 @@
   let durationInUnit: number;
   let beforeInSec = $event.alarm ? ($event.startTime.getTime() - $event.alarm.getTime()) / 1000 : 0;
 
-  $: event.alarm = new Date(event.startTime.getTime() - beforeInSec * 1000);
+  $: if (event.alarm) event.alarm = new Date(event.startTime.getTime() - beforeInSec * 1000);
 
   function onRemove() {
     event.alarm = null;


### PR DESCRIPTION
- We we're setting `event.alarm` with a new Date after `onRemoved` has set it to `null`
- I've made it not to set event.alarm if null