### PR TITLE
MailComposer: Save draft in correct folder (#646)

### DIFF
--- a/app/frontend/Mail/Composer/MailComposer.svelte
+++ b/app/frontend/Mail/Composer/MailComposer.svelte
@@ -238,7 +238,7 @@
   $: fromIdentity && setAuthor()
   function setAuthor() {
     mail.identity = fromIdentity;
-    mail.folder = fromIdentity.account.getSpecialFolder(SpecialFolder.Sent)
+    mail.folder ??= fromIdentity.account.getSpecialFolder(SpecialFolder.Sent)
       ?? fromIdentity.account.inbox;
     if (fromIdentity == mail.identity) {
       return; // don't overwrite concrete email address for catch-all identity

--- a/app/frontend/Mail/Composer/MailComposer.svelte
+++ b/app/frontend/Mail/Composer/MailComposer.svelte
@@ -306,6 +306,7 @@
   }
 
   async function onSave() {
+    mail.folder = fromIdentity.account.getSpecialFolder(SpecialFolder.Drafts);
     await mail.compose.saveAsDraft();
     onClose();
   }

--- a/app/frontend/Mail/Composer/MailComposer.svelte
+++ b/app/frontend/Mail/Composer/MailComposer.svelte
@@ -306,7 +306,6 @@
   }
 
   async function onSave() {
-    mail.folder = fromIdentity.account.getSpecialFolder(SpecialFolder.Drafts);
     await mail.compose.saveAsDraft();
     onClose();
   }

--- a/app/frontend/Mail/Composer/MailComposer.svelte
+++ b/app/frontend/Mail/Composer/MailComposer.svelte
@@ -238,7 +238,7 @@
   $: fromIdentity && setAuthor()
   function setAuthor() {
     mail.identity = fromIdentity;
-    mail.folder ??= fromIdentity.account.getSpecialFolder(SpecialFolder.Sent)
+    mail.folder = fromIdentity.account.getSpecialFolder(SpecialFolder.Sent)
       ?? fromIdentity.account.inbox;
     if (fromIdentity == mail.identity) {
       return; // don't overwrite concrete email address for catch-all identity

--- a/app/logic/Mail/ComposeActions.ts
+++ b/app/logic/Mail/ComposeActions.ts
@@ -246,7 +246,7 @@ export class ComposeActions {
   }
 
   async saveAsDraft(): Promise<void> {
-    let account = this.email.folder?.account ?? this.email.identity?.account;
+    let account = this.email.identity.account;
     assert(account, "Need mail account to save draft");
     let draftFolder = account.getSpecialFolder(SpecialFolder.Drafts);
     if (!draftFolder) {

--- a/app/logic/Mail/ComposeActions.ts
+++ b/app/logic/Mail/ComposeActions.ts
@@ -1,5 +1,6 @@
 import type { EMail } from "./EMail";
 import { SpecialFolder } from "./Folder";
+import { CreateMIME } from "./SMTP/CreateMIME";
 import { Attachment, ContentDisposition } from "../Abstract/Attachment";
 import { PersonUID } from "../Abstract/PersonUID";
 import { MailIdentity, findIdentityForEMailAddress } from "./MailIdentity";
@@ -257,6 +258,7 @@ export class ComposeActions {
     let previousDrafts = this.getDrafts();
 
     this.email.isDraft = true;
+    this.email.mime = await CreateMIME.getMIME(this.email);
     await draftFolder.addMessage(this.email);
 
     await this.deleteDrafts(previousDrafts);


### PR DESCRIPTION
- Emails were saving to the initial identity even when the identity is changed
- The `mail.folder` is now set before saving