### PR TITLE
Fix parsing and generating of iCal timezone

### DIFF
--- a/app/logic/Calendar/ICal/ICalToEvent.ts
+++ b/app/logic/Calendar/ICal/ICalToEvent.ts
@@ -89,9 +89,11 @@ function parseDate(icalDate: { value: string, properties: { tzid?: string } }): 
   }
   // Convert to regular Date string format.
   value = value.replace(icalDateRegex, "$1-$2-$3:$4:$5");
-  if (value.endsWith("Z") || !tzid) {
-    // Either UTC or floating.
-    return [new Date(value), tzid];
+  if (value.endsWith("Z")) { // UTC
+    return [new Date(value), tzid || "UTC"];
+  }
+  if (!tzid) { // floating
+    return [new Date(value), null];
   }
   if (tzid in WindowsToIANATimezone) {
     tzid = WindowsToIANATimezone[tzid];


### PR DESCRIPTION
DTSTART/DTEND has three formats:
- for all day events, VALUE=DATE with just a YYYYmmdd date
- for events in UTC, VALUE=DATE-TIME with a YYYYmmddThhmmssZ timestamp
- otherwise, VALUE=DATETIME and TZID=zone with a YYYYmmddThhmmss time

As this was getting complicated, I rewrote the code to make it clearer.

We were also parsing UTC times incorrectly, giving them a local time zone; this PR also fixes that.