### PR TITLE
FastList: Scroll speed normalized (#361)

### DIFF
--- a/app/frontend/Shared/FastList.svelte
+++ b/app/frontend/Shared/FastList.svelte
@@ -1,5 +1,5 @@
 <hbox class="fast-list"
-  on:wheel={event => onScrollWheelThrottled(event)}
+  on:wheel={event => onScrollWheel(event)}
   on:keydown={event => onKey(event)}
   tabindex={0}
   bind:this={listE}>
@@ -57,7 +57,6 @@
   import { Collection, CollectionObserver, ArrayColl } from "svelte-collections"
   import { onMount, tick } from "svelte";
   import debounce from "lodash/debounce";
-  import { useThrottle } from "@svelteuidev/composables";
 
   type T = $$Generic;
 
@@ -232,7 +231,6 @@
   }
 
   // Throttle scroll speed for trackpad scrolling
-  const onScrollWheelThrottled = useThrottle(onScrollWheel, 30);
   function onScrollWheel(event: WheelEvent) {
     let scrollRows = Math.round(Math.abs(event.deltaY * 0.1)); // How many rows to scroll each time
     if (event.deltaY > 0) {

--- a/app/frontend/Shared/FastList.svelte
+++ b/app/frontend/Shared/FastList.svelte
@@ -227,16 +227,14 @@
     if (index >= scrollPos && index < scrollPos + showRows - 1) {
       return;
     }
-    scrollPos = Math.min(index, Math.max(0, items.length - showRows));
+    scrollPos = Math.min(Math.max(scrollPos, 0), items.length - showRows);
   }
 
   function onScrollWheel(event: WheelEvent) {
-    let scrollRows = Math.round(Math.abs(event.deltaY * 0.1)); // How many rows to scroll each time
-    if (event.deltaY > 0) {
-      scrollPos = Math.min(scrollPos + scrollRows, items.length - showRows);
-    } else if (event.deltaY < 0) {
-      scrollPos = Math.max(scrollPos - scrollRows, 0);
-    }
+    // How many rows to scroll each time
+    let scrollRows = Math.round(event.deltaY / (rowHeight || 20)); // 3 rows
+    scrollPos += scrollRows;
+    scrollPos = Math.min(Math.max(scrollPos, 0), items.length - showRows);
   }
 
   let scrollPosByScrollBar: NodeJS.Timeout = null;

--- a/app/frontend/Shared/FastList.svelte
+++ b/app/frontend/Shared/FastList.svelte
@@ -231,7 +231,7 @@
   }
 
   function onScrollWheel(event: WheelEvent) {
-    // How many rows to scroll each time
+    // How many rows to scroll each time, in either direction (+/-)
     let scrollRows = Math.round(event.deltaY / (rowHeight || 20)); // 3 rows
     scrollPos += scrollRows;
     scrollPos = Math.min(Math.max(scrollPos, 0), items.length - showRows);

--- a/app/frontend/Shared/FastList.svelte
+++ b/app/frontend/Shared/FastList.svelte
@@ -230,7 +230,6 @@
     scrollPos = Math.min(index, Math.max(0, items.length - showRows));
   }
 
-  // Throttle scroll speed for trackpad scrolling
   function onScrollWheel(event: WheelEvent) {
     let scrollRows = Math.round(Math.abs(event.deltaY * 0.1)); // How many rows to scroll each time
     if (event.deltaY > 0) {

--- a/app/frontend/Shared/FastList.svelte
+++ b/app/frontend/Shared/FastList.svelte
@@ -1,5 +1,5 @@
 <hbox class="fast-list"
-  on:wheel={event => onScrollWheel(event)}
+  on:wheel={event => onScrollWheelThrottled(event)}
   on:keydown={event => onKey(event)}
   tabindex={0}
   bind:this={listE}>
@@ -57,6 +57,7 @@
   import { Collection, CollectionObserver, ArrayColl } from "svelte-collections"
   import { onMount, tick } from "svelte";
   import debounce from "lodash/debounce";
+  import { useThrottle } from "@svelteuidev/composables";
 
   type T = $$Generic;
 
@@ -230,8 +231,10 @@
     scrollPos = Math.min(index, Math.max(0, items.length - showRows));
   }
 
+  // Throttle scroll speed for trackpad scrolling
+  const onScrollWheelThrottled = useThrottle(onScrollWheel, 30);
   function onScrollWheel(event: WheelEvent) {
-    let scrollRows = 3; // How many rows to scroll each time
+    let scrollRows = Math.round(Math.abs(event.deltaY * 0.1)); // How many rows to scroll each time
     if (event.deltaY > 0) {
       scrollPos = Math.min(scrollPos + scrollRows, items.length - showRows);
     } else if (event.deltaY < 0) {


### PR DESCRIPTION
- the wheel event seems to be triggering a lot per second which caused the scrolling to be too fast, however, the deltaY was only 1 or 2
- when you use a scroll wheel there's less events triggered per second but the deltaY was much more
- I'm proposing throttling onWheel callback to prevent scrolling too fast for trackpads but also we need to adjust the scroll based on the deltaY for scroll wheels otherwise it would be too slow for scroll wheels
- this will be a little different since we're not scrolling 3 items on each scroll