### PR TITLE
Calendar: Recurrence: Rename more startDate into seriesStartTime

### DIFF
--- a/app/frontend/Calendar/DisplayEvent/DisplayEvent.svelte
+++ b/app/frontend/Calendar/DisplayEvent/DisplayEvent.svelte
@@ -81,7 +81,7 @@
       <Radio class="inline" label="{$t`For `}" bind:group={end} value="count" disabled />&nbsp;<input class="auto" type="number" min={1} max={99} bind:value={count} disabled> end = "count"}>&nbsp;{$plural(count, { one: 'time', other: 'times' })}
     </hbox>
     <hbox>
-      <Radio class="inline" label="{$t`Until`}" bind:group={end} value="date" disabled />&nbsp;<DateInput date={endDate} disabled />
+      <Radio class="inline" label="{$t`Until`}" bind:group={end} value="date" disabled />&nbsp;<DateInput date={seriesEndTime} disabled />
     </hbox>
   {/if}
   <Checkbox label={$t`Alarm`} checked={!!event.alarm} disabled />
@@ -115,7 +115,7 @@
   let weekdays = event.recurrenceRule?.weekdays || [event.startTime.getDay()];
   let week = event.recurrenceRule?.week || 0;
   let end = event.recurrenceRule?.seriesEndTime ? "date" : Number.isFinite(event.recurrenceRule?.count) ? "count" : "none";
-  let endDate = event.recurrenceRule?.seriesEndTime || event.startTime;
+  let seriesEndTime = event.recurrenceRule?.seriesEndTime || event.startTime;
   let minDate = event.startTime;
   let yearWeekOptions, monthWeekOptions, weekdayOptions;
 
@@ -148,9 +148,9 @@
       label: date.toLocaleDateString(getUILocale(), { weekday: "narrow" }),
     }));
 
-    if (endDate <= event.startTime) {
-      endDate = new Date(event.startTime);
-      endDate.setHours(23, 59, 59, 0);
+    if (seriesEndTime <= event.startTime) {
+      seriesEndTime = new Date(event.startTime);
+      seriesEndTime.setHours(23, 59, 59, 0);
     }
     minDate = event.startTime;
     event.endTime.setFullYear(event.startTime.getFullYear(), event.startTime.getMonth(), event.startTime.getDate());

--- a/app/frontend/Calendar/EditEvent/RepeatBox.svelte
+++ b/app/frontend/Calendar/EditEvent/RepeatBox.svelte
@@ -65,7 +65,7 @@
 </hbox>
 <hbox>
   <Radio class="inline" label="{$t`Until`}" bind:group={end} value="date" />
-  <DateInput date={endDate} min={minDate} on:change={() => end = "date"} />
+  <DateInput date={seriesEndTime} min={minDate} on:change={() => end = "date"} />
 </hbox>
   // import DateInput from "./DateInput.svelte";
   // import { Radio } from "@svelteuidev/core";
@@ -89,8 +89,8 @@
   // end // let count = Number.isFinite(event.recurrenceRule?.count) ? event.recurrenceRule.count : 1;
   let weekdays = master.recurrenceRule?.weekdays?.slice() || [event.startTime.getDay()];
   let week = master.recurrenceRule?.week || 0;
-  // end // let end = event.recurrenceRule?.endDate ? "date" : Number.isFinite(event.recurrenceRule?.count) ? "count" : "none";
-  // end // let endDate = master.recurrenceRule?.endDate || event.startTime;
+  // end // let end = event.recurrenceRule?.seriesEndTime ? "date" : Number.isFinite(event.recurrenceRule?.count) ? "count" : "none";
+  // end // let seriesEndTime = master.recurrenceRule?.seriesEndTime || event.startTime;
   let minDate = event.startTime;
   let daily = "everyday";
   let dailyOptions: RadioOption[] = [
@@ -137,9 +137,9 @@
     }));
 
     /* end
-    if (endDate <= event.startTime) {
-      endDate = new Date(event.startTime);
-      endDate.setHours(23, 59, 59, 0);
+    if (seriesEndTime <= event.startTime) {
+      seriesEndTime = new Date(event.startTime);
+      seriesEndTime.setHours(23, 59, 59, 0);
     }
     */
     minDate = event.startTime;
@@ -179,12 +179,12 @@
   }
 
   export function newRecurrenceRule(): RecurrenceRule {
-    let init: RecurrenceInit = { startDate: event.startTime, frequency, interval };
+    let init: RecurrenceInit = { seriesStartTime: event.startTime, frequency, interval };
     /* end
     if (end == "count") {
       init.count = count;
     } else if (end == "date") {
-      init.endDate = endDate;
+      init.seriesEndTime = seriesEndTime;
     }
     */
     if (frequency == Frequency.Weekly) {

--- a/app/logic/Calendar/ActiveSync/ActiveSyncEvent.ts
+++ b/app/logic/Calendar/ActiveSync/ActiveSyncEvent.ts
@@ -77,15 +77,15 @@ export class ActiveSyncEvent extends Event {
   }
 
   newRecurrenceRule(wbxmljs: any): RecurrenceRule {
-    let startDate = this.startTime;
-    let endDate = wbxmljs.Until ? fromCompact(wbxmljs.Until) : null;
+    let seriesStartTime = this.startTime;
+    let seriesEndTime = wbxmljs.Until ? fromCompact(wbxmljs.Until) : null;
     let count = sanitize.integer(wbxmljs.Occurrences, Infinity);
     let frequency = kRecurrenceTypes[wbxmljs.Type];
     let interval = sanitize.integer(wbxmljs.Interval, 1);
     let weekdays = extractWeekdays(wbxmljs.DayOfWeek);
     let week = sanitize.integer(wbxmljs.WeekOfMonth, 0);
     let first = sanitize.integer(wbxmljs.FirstDayOfWeek, Weekday.Monday);
-    return new RecurrenceRule({ startDate, endDate, count, frequency, interval, weekdays, week, first });
+    return new RecurrenceRule({ seriesStartTime, seriesEndTime, count, frequency, interval, weekdays, week, first });
   }
 
   toFields(exceptions: { Exception: any } | { Exception: any }[] = []) {

--- a/app/logic/Calendar/EWS/EWSEvent.ts
+++ b/app/logic/Calendar/EWS/EWSEvent.ts
@@ -117,17 +117,17 @@ export class EWSEvent extends Event {
   }
 
   newRecurrenceRule(xmljs: any): RecurrenceRule {
-    let startDate = this.startTime;
-    let endDate: Date | null = null;
+    let seriesStartTime = this.startTime;
+    let seriesEndTime: Date | null = null;
     if (xmljs.EndDateRecurrence) {
       // These dates don't have a time, but they do have a time zone suffixed.
-      if (!startDate) {
-        this.startTime = startDate = sanitize.date(xmljs.EndDateRecurrence.StartDate.slice(0, 10));
+      if (!seriesStartTime) {
+        this.startTime = seriesStartTime = sanitize.date(xmljs.EndDateRecurrence.StartDate.slice(0, 10));
       }
-      endDate = sanitize.date(xmljs.EndDateRecurrence.EndDate.slice(0, 10));
+      seriesEndTime = sanitize.date(xmljs.EndDateRecurrence.EndDate.slice(0, 10));
       // RecurrenceRule wants this to be at least the same time as the endTime
-      endDate.setDate(endDate.getDate() + 1);
-      endDate.setTime(endDate.getTime() - 1000);
+      seriesEndTime.setDate(seriesEndTime.getDate() + 1);
+      seriesEndTime.setTime(seriesEndTime.getTime() - 1000);
     }
     let count = sanitize.integer(xmljs.NumberedRecurrence?.NumberOfOccurrences, Infinity);
     let key = Object.keys(RecurrenceType).find(key => key in xmljs);
@@ -137,7 +137,7 @@ export class EWSEvent extends Event {
     let weekdays = extractWeekdays(pattern.DaysOfWeek);
     let week = sanitize.integer(WeekOfMonth[pattern.DayOfWeekIndex], 0);
     let first = sanitize.integer(Weekday[pattern.FirstDayOfWeek], Weekday.Monday);
-    return new RecurrenceRule({ startDate, endDate, count, frequency, interval, weekdays, week, first });
+    return new RecurrenceRule({ seriesStartTime, seriesEndTime, count, frequency, interval, weekdays, week, first });
   }
 
   get outgoingInvitation() {

--- a/app/logic/Calendar/Event.ts
+++ b/app/logic/Calendar/Event.ts
@@ -573,12 +573,12 @@ export class Event extends Observable {
    * Ensures that all recurring instances exist up to the provided date.
    * Must only be called on recurring master events.
    */
-  fillRecurrences(endDate: Date = new Date(Date.now() + 1e11)): Collection<Event> {
+  fillRecurrences(seriesEndTime: Date = new Date(Date.now() + 1e11)): Collection<Event> {
     assert(this.recurrenceCase == RecurrenceCase.Master, "Not a recurrence master");
     if (this.instances.hasItems) {
       return this.instances;
     }
-    let occurrences = this.recurrenceRule.getOccurrencesByDate(endDate);
+    let occurrences = this.recurrenceRule.getOccurrencesByDate(seriesEndTime);
     for (let i = 0; i < occurrences.length; i++) {
       let occurrence = occurrences[i];
       let instance = this.calendar.newEvent(this);
@@ -637,8 +637,8 @@ export class Event extends Observable {
     let count = master.instances.contents.slice(pos + 1).findLastIndex(event => event?.dbID) + pos + 1;
     this.calendar.events.removeAll(master.instances.splice(count).contents.filter(Boolean));
     if (master.recurrenceRule.getOccurrenceByIndex(count + 1)) {
-      let { seriesStartTime: startDate, frequency, interval, weekdays, week, first } = master.recurrenceRule;
-      master.recurrenceRule = new RecurrenceRule({ startDate, count, frequency, interval, weekdays, week, first });
+      let { seriesStartTime, frequency, interval, weekdays, week, first } = master.recurrenceRule;
+      master.recurrenceRule = new RecurrenceRule({ seriesStartTime, count, frequency, interval, weekdays, week, first });
       await master.saveToServer();
     }
     let exclusions = [];

--- a/app/logic/Calendar/OWA/OWAEvent.ts
+++ b/app/logic/Calendar/OWA/OWAEvent.ts
@@ -115,17 +115,17 @@ export class OWAEvent extends Event {
   }
 
   protected newRecurrenceRule(json: any): RecurrenceRule {
-    let startDate = this.startTime;
-    let endDate: Date | null = null;
+    let seriesStartTime = this.startTime;
+    let seriesEndTime: Date | null = null;
     if (json.RecurrenceRange.EndDate) {
       // These dates don't have a time, but they do have a time zone suffixed.
-      if (!startDate) {
-        this.startTime = startDate = sanitize.date(json.RecurrenceRange.StartDate.slice(0, 10));
+      if (!seriesStartTime) {
+        this.startTime = seriesStartTime = sanitize.date(json.RecurrenceRange.StartDate.slice(0, 10));
       }
-      endDate = sanitize.date(json.RecurrenceRange.EndDate.slice(0, 10));
+      seriesEndTime = sanitize.date(json.RecurrenceRange.EndDate.slice(0, 10));
       // RecurrenceRule wants this to be at least the same time as the endTime
-      endDate.setDate(endDate.getDate() + 1);
-      endDate.setTime(endDate.getTime() - 1000);
+      seriesEndTime.setDate(seriesEndTime.getDate() + 1);
+      seriesEndTime.setTime(seriesEndTime.getTime() - 1000);
     }
     let count = sanitize.integer(json.RecurrenceRange.NumberOfOccurrences, Infinity);
     let pattern = json.RecurrencePattern;
@@ -134,7 +134,7 @@ export class OWAEvent extends Event {
     let weekdays = extractWeekdays(pattern.DaysOfWeek);
     let week = sanitize.integer(WeekOfMonth[pattern.DayOfWeekIndex], 0);
     let first = sanitize.integer(Weekday[pattern.FirstDayOfWeek], Weekday.Monday);
-    return new RecurrenceRule({ startDate, endDate, count, frequency, interval, weekdays, week, first });
+    return new RecurrenceRule({ seriesStartTime, seriesEndTime, count, frequency, interval, weekdays, week, first });
   }
 
   get outgoingInvitation() {

--- a/app/logic/Calendar/RecurrenceRule.test.ts
+++ b/app/logic/Calendar/RecurrenceRule.test.ts
@@ -5,7 +5,7 @@ function check(calString: string, data: RecurrenceInit, expected: [number, numbe
   let rule = new RecurrenceRule(data);
   if (calString) {
     expect(rule.getCalString()).toEqual(calString);
-    let ruleFromString = RecurrenceRule.fromCalString(data.startDate, calString);
+    let ruleFromString = RecurrenceRule.fromCalString(data.seriesStartTime, calString);
     expect(rule).toEqual(ruleFromString);
   }
   expect(rule.getOccurrenceByIndex(2)).toEqual(new Date(...expected[1]));
@@ -14,8 +14,8 @@ function check(calString: string, data: RecurrenceInit, expected: [number, numbe
 
 test("Daily with interval and end date", () => {
   check("RRULE:FREQ=DAILY;UNTIL=20000105T000000;INTERVAL=2", {
-    startDate: new Date(2000, 0, 1),
-    endDate: new Date(2000, 0, 5),
+    seriesStartTime: new Date(2000, 0, 1),
+    seriesEndTime: new Date(2000, 0, 5),
     frequency: Frequency.Daily,
     interval: 2,
   }, [[2000, 0, 1], [2000, 0, 3], [2000, 0, 5]]);
@@ -23,7 +23,7 @@ test("Daily with interval and end date", () => {
 
 test("Daily with interval and count", () => {
   check("RRULE:FREQ=DAILY;COUNT=3;INTERVAL=2", {
-    startDate: new Date(2000, 0, 1),
+    seriesStartTime: new Date(2000, 0, 1),
     count: 3,
     frequency: Frequency.Daily,
     interval: 2,
@@ -32,8 +32,8 @@ test("Daily with interval and count", () => {
 
 test("Daily with days and end date", () => {
   check("RRULE:FREQ=DAILY;UNTIL=20000105T000000;BYDAY=SA,MO,WE", {
-    startDate: new Date(2000, 0, 1),
-    endDate: new Date(2000, 0, 5),
+    seriesStartTime: new Date(2000, 0, 1),
+    seriesEndTime: new Date(2000, 0, 5),
     frequency: Frequency.Daily,
     weekdays: [Weekday.Saturday, Weekday.Monday, Weekday.Wednesday],
   }, [[2000, 0, 1], [2000, 0, 3], [2000, 0, 5]]);
@@ -41,7 +41,7 @@ test("Daily with days and end date", () => {
 
 test("Daily with days and count", () => {
   check("RRULE:FREQ=DAILY;COUNT=3;BYDAY=SA,SU", {
-    startDate: new Date(2000, 0, 1),
+    seriesStartTime: new Date(2000, 0, 1),
     count: 3,
     frequency: Frequency.Daily,
     weekdays: [Weekday.Saturday, Weekday.Sunday],
@@ -50,8 +50,8 @@ test("Daily with days and count", () => {
 
 test("Weekly with interval and end date", () => {
   check("RRULE:FREQ=WEEKLY;UNTIL=20000131T000000;INTERVAL=2", {
-    startDate: new Date(2000, 0, 1),
-    endDate: new Date(2000, 0, 31),
+    seriesStartTime: new Date(2000, 0, 1),
+    seriesEndTime: new Date(2000, 0, 31),
     frequency: Frequency.Weekly,
     interval: 2,
   }, [[2000, 0, 1], [2000, 0, 15], [2000, 0, 29]]);
@@ -59,7 +59,7 @@ test("Weekly with interval and end date", () => {
 
 test("Weekly with interval and count", () => {
   check("RRULE:FREQ=WEEKLY;COUNT=3;INTERVAL=2", {
-    startDate: new Date(2000, 0, 1),
+    seriesStartTime: new Date(2000, 0, 1),
     count: 3,
     frequency: Frequency.Weekly,
     interval: 2,
@@ -68,8 +68,8 @@ test("Weekly with interval and count", () => {
 
 test("Weekly with days and end date", () => {
   check("RRULE:FREQ=WEEKLY;UNTIL=20000131T000000;INTERVAL=3;BYDAY=SA,SU", {
-    startDate: new Date(2000, 0, 1),
-    endDate: new Date(2000, 0, 31),
+    seriesStartTime: new Date(2000, 0, 1),
+    seriesEndTime: new Date(2000, 0, 31),
     frequency: Frequency.Weekly,
     interval: 3,
     weekdays: [Weekday.Saturday, Weekday.Sunday],
@@ -78,7 +78,7 @@ test("Weekly with days and end date", () => {
 
 test("Weekly with days and count", () => {
   check("RRULE:FREQ=WEEKLY;COUNT=3;INTERVAL=3;BYDAY=SA,SU", {
-    startDate: new Date(2000, 0, 1),
+    seriesStartTime: new Date(2000, 0, 1),
     count: 3,
     frequency: Frequency.Weekly,
     interval: 3,
@@ -88,8 +88,8 @@ test("Weekly with days and count", () => {
 
 test("Monthly with date and end date", () => {
   check("RRULE:FREQ=MONTHLY;UNTIL=20001230T000000;INTERVAL=3", {
-    startDate: new Date(2000, 0, 31),
-    endDate: new Date(2000, 11, 30),
+    seriesStartTime: new Date(2000, 0, 31),
+    seriesEndTime: new Date(2000, 11, 30),
     frequency: Frequency.Monthly,
     interval: 3,
   }, [[2000, 0, 31], [2000, 3, 30], [2000, 6, 31], [2000, 9, 31]]);
@@ -97,7 +97,7 @@ test("Monthly with date and end date", () => {
 
 test("Monthly with date and count", () => {
   check("RRULE:FREQ=MONTHLY;COUNT=3;INTERVAL=3", {
-    startDate: new Date(2000, 0, 31),
+    seriesStartTime: new Date(2000, 0, 31),
     count: 3,
     frequency: Frequency.Monthly,
     interval: 3,
@@ -106,8 +106,8 @@ test("Monthly with date and count", () => {
 
 test("Monthly with day of week of month and end date", () => {
   check("RRULE:FREQ=MONTHLY;UNTIL=20001201T000000;INTERVAL=3;BYDAY=2SU", {
-    startDate: new Date(2000, 0, 9),
-    endDate: new Date(2000, 11, 1),
+    seriesStartTime: new Date(2000, 0, 9),
+    seriesEndTime: new Date(2000, 11, 1),
     frequency: Frequency.Monthly,
     interval: 3,
     weekdays: [Weekday.Sunday],
@@ -117,7 +117,7 @@ test("Monthly with day of week of month and end date", () => {
 
 test("Monthly with day of week of month and count", () => {
   check("RRULE:FREQ=MONTHLY;COUNT=3;INTERVAL=3;BYDAY=2SU", {
-    startDate: new Date(2000, 0, 9),
+    seriesStartTime: new Date(2000, 0, 9),
     count: 3,
     frequency: Frequency.Monthly,
     interval: 3,
@@ -128,8 +128,8 @@ test("Monthly with day of week of month and count", () => {
 
 test("Monthly with day of last week of month and end date", () => {
   check("RRULE:FREQ=MONTHLY;UNTIL=20001201T000000;INTERVAL=3;BYDAY=-1SU", {
-    startDate: new Date(2000, 0, 30),
-    endDate: new Date(2000, 11, 1),
+    seriesStartTime: new Date(2000, 0, 30),
+    seriesEndTime: new Date(2000, 11, 1),
     frequency: Frequency.Monthly,
     interval: 3,
     weekdays: [Weekday.Sunday],
@@ -139,7 +139,7 @@ test("Monthly with day of last week of month and end date", () => {
 
 test("Monthly with day of last week of month and count", () => {
   check("RRULE:FREQ=MONTHLY;COUNT=3;INTERVAL=3;BYDAY=-1SU", {
-    startDate: new Date(2000, 0, 30),
+    seriesStartTime: new Date(2000, 0, 30),
     count: 3,
     frequency: Frequency.Monthly,
     interval: 3,
@@ -150,15 +150,15 @@ test("Monthly with day of last week of month and count", () => {
 
 test("Yearly with date and end date", () => {
   check("RRULE:FREQ=YEARLY;UNTIL=20021201T000000", {
-    startDate: new Date(2000, 1, 29),
-    endDate: new Date(2002, 11, 1),
+    seriesStartTime: new Date(2000, 1, 29),
+    seriesEndTime: new Date(2002, 11, 1),
     frequency: Frequency.Yearly,
   }, [[2000, 1, 29], [2001, 1, 28], [2002, 1, 28]]);
 });
 
 test("Yearly with date and count", () => {
   check("RRULE:FREQ=YEARLY;COUNT=3", {
-    startDate: new Date(2000, 1, 29),
+    seriesStartTime: new Date(2000, 1, 29),
     count: 3,
     frequency: Frequency.Yearly,
   }, [[2000, 1, 29], [2001, 1, 28], [2002, 1, 28]]);
@@ -166,8 +166,8 @@ test("Yearly with date and count", () => {
 
 test("Yearly with day of week of month and end date", () => {
   check("RRULE:FREQ=YEARLY;UNTIL=20021201T000000;BYDAY=2SU", {
-    startDate: new Date(2000, 0, 9),
-    endDate: new Date(2002, 11, 1),
+    seriesStartTime: new Date(2000, 0, 9),
+    seriesEndTime: new Date(2002, 11, 1),
     frequency: Frequency.Yearly,
     weekdays: [Weekday.Sunday],
     week: 2,
@@ -176,7 +176,7 @@ test("Yearly with day of week of month and end date", () => {
 
 test("Yearly with day of week of month and count", () => {
   check("RRULE:FREQ=YEARLY;COUNT=3;BYDAY=2SU", {
-    startDate: new Date(2000, 0, 9),
+    seriesStartTime: new Date(2000, 0, 9),
     count: 3,
     frequency: Frequency.Yearly,
     weekdays: [Weekday.Sunday],
@@ -186,8 +186,8 @@ test("Yearly with day of week of month and count", () => {
 
 test("Yearly with day of last week of month and end date", () => {
   check("RRULE:FREQ=YEARLY;UNTIL=20021201T000000;BYDAY=-1SU", {
-    startDate: new Date(2000, 0, 30),
-    endDate: new Date(2002, 11, 1),
+    seriesStartTime: new Date(2000, 0, 30),
+    seriesEndTime: new Date(2002, 11, 1),
     frequency: Frequency.Yearly,
     weekdays: [Weekday.Sunday],
     week: 5,
@@ -196,7 +196,7 @@ test("Yearly with day of last week of month and end date", () => {
 
 test("Yearly with day of last week of month and count", () => {
   check("RRULE:FREQ=YEARLY;COUNT=3;BYDAY=-1SU", {
-    startDate: new Date(2000, 0, 30),
+    seriesStartTime: new Date(2000, 0, 30),
     count: 3,
     frequency: Frequency.Yearly,
     weekdays: [Weekday.Sunday],


### PR DESCRIPTION
You remember why I had `class RecurrenceRule extends Readonly<RecurrenceInit>`? Well, this is why.