### PR TITLE
Make changing the recurrence rule clear exceptions again

### DIFF
--- a/app/logic/Calendar/Event.ts
+++ b/app/logic/Calendar/Event.ts
@@ -153,12 +153,14 @@ export class Event extends Observable {
    */
   private setRecurrenceRule(rule: RecurrenceRule) {
     assert(this.recurrenceCase == RecurrenceCase.Normal || this.recurrenceCase == RecurrenceCase.Master, "Instances can't themselves recur");
+    let timesMatch = this._recurrenceRule?.timesMatch(rule);
     this._recurrenceRule = rule;
     this.recurrenceCase = RecurrenceCase.Master; // notifies
-    if (!this._recurrenceRule?.timesMatch(rule)) {
+    if (timesMatch) {
+      this.generateRecurringInstances();
+    } else {
       this.clearExceptions();
     }
-    this.generateRecurringInstances();
   }
   /** Links back to the recurring master.
    * Only for RecurrenceCase == Instance or Exception */


### PR DESCRIPTION
`setRecurrenceRule` wants to be able to work while adding a rule to an event, which means that the recurrence case hasn't been set, which means we can't clear the exceptions yet. So we have to set a temporary flag to know whether we should clear exceptions.