### PR TITLE
Default mail client / mailto: handling

### DIFF
--- a/backend/backend.ts
+++ b/backend/backend.ts
@@ -54,6 +54,8 @@ async function createSharedAppObject() {
     showFileInFolder,
     onScreenSharingSelect,
     restartApp,
+    setAsDefaultMailClient,
+    listenForURL,
     setTheme,
     openMenu,
     getConfigDir,
@@ -288,6 +290,14 @@ function isOSNotificationSupported(): boolean {
 function restartApp() {
   app.relaunch();
   app.quit();
+}
+
+function setAsDefaultMailClient() {
+  return app.setAsDefaultProtocolClient('mailto');
+}
+
+function listenForURL(callback: (event: Event, url: string) => void) {
+  app.on('open-url', callback);
 }
 
 function setTheme(theme: "system" | "light" | "dark") {

--- a/e2/electron-builder.yml
+++ b/e2/electron-builder.yml
@@ -51,6 +51,10 @@ appImage:
   artifactName: ${name}-${version}.${ext}
 deb:
   packageName: mustang-mail
+protocols:
+  name: EMail Address
+  schemes:
+    - mailto
 npmRebuild: true
 publish:
   - provider: github


### PR DESCRIPTION
This is just working code that works and tested on MacOS

**Working**

- MacOS `mailto` link when Mustang is running and not running

**Not Working**

- No option to not set Mustang as defualt mail client
- No option to explicitly set Mustang as default mail client
- Might have an error if the users machine is slow because everything is based on `setTimeout()` at the moment