### PR TITLE
New outgoing messages should default to saving in the Sent folder

### DIFF
--- a/app/logic/Mail/MailAccount.ts
+++ b/app/logic/Mail/MailAccount.ts
@@ -95,7 +95,7 @@ export class MailAccount extends TCPAccount {
   }
 
   newEMailFrom(): EMail {
-    let folder = this.getSpecialFolder(SpecialFolder.Drafts);
+    let folder = this.getSpecialFolder(SpecialFolder.Sent);
     let email = folder.newEMail();
     email.compose.generateMessageID();
     email.needToLoadBody = false;


### PR DESCRIPTION
When `newEMailFrom` was originally created, its `folder` was set to Drafts, although drafts were not actually supported at the time. Additionally, sent messages were always saved in the Sent folder.

Draft processing has since been added, but this now explicitly finds the Drafts folder, as the email's folder is now used as the desired Sent folder.

This means that `newEMailFrom` needs to use the Sent folder by default.