### PR TITLE
Safely fix newlines, since the value could be null

### DIFF
--- a/app/logic/util/convertHTML.ts
+++ b/app/logic/util/convertHTML.ts
@@ -43,7 +43,7 @@ export function convertTextToHTML(plaintext: string): string {
 }
 
 export function fixNewlines(text: string): string {
-  return text.replace(/\r?\n/g, "\r\n");
+  return text?.replace(/\r?\n/g, "\r\n");
 }
 
 export function sanitizeHTML(html: string): string {


### PR DESCRIPTION
If either the text or HTML of an email is `null` (which is a legal value), this code crashes as part of trying to create the MIME.