### PR TITLE
Update UI after simple event is deleted or made recurring

### DIFF
--- a/app/logic/Calendar/Event.ts
+++ b/app/logic/Calendar/Event.ts
@@ -146,6 +146,7 @@ export class Event extends Observable {
       this.clearExceptions();
       this._recurrenceRule = null;
       this.recurrenceCase = RecurrenceCase.Normal; // notifies
+      this.instances.replaceAll([this]);
     }
   }
   /**
@@ -157,11 +158,10 @@ export class Event extends Observable {
     let timesMatch = this._recurrenceRule?.timesMatch(rule);
     this._recurrenceRule = rule;
     this.recurrenceCase = RecurrenceCase.Master; // notifies
-    if (timesMatch) {
-      this.generateRecurringInstances();
-    } else {
+    if (!timesMatch) {
       this.clearExceptions();
     }
+    this.generateRecurringInstances();
   }
   /** Links back to the recurring master.
    * Only for RecurrenceCase == Instance or Exception */
@@ -179,7 +179,9 @@ export class Event extends Observable {
    * For RecurrenceCase == Instance, it's identical to `startTime`.
    */
   recurrenceStartTime: Date | null = null;
-  /** Only for recurringCase == Master.
+  /** Contains all instances that should be displayed for this event.
+   *
+   * For master events only:
    *
    * Contains all Instances generated from the master.
    * Does *not* contain:
@@ -187,10 +189,13 @@ export class Event extends Observable {
    * - Exceptions
    * - Exclusions
    *
+   * For other events:
+   *   Contains the event itself.
+   *
    * This is a dynamic collection, and will be updated automatically
    * when the master changes or the recurrence rule changes.
    */
-  readonly instances = new ArrayColl<Event>;
+  readonly instances = new ArrayColl<Event>([this]);
   /**
    * Only for RecurrenceCase == Master
    *
@@ -702,7 +707,6 @@ export class Event extends Observable {
     }
     this.exceptions.clear();
     this.exclusions.clear();
-    this.generateRecurringInstances();
   }
 
   /**

--- a/app/logic/Calendar/Event.ts
+++ b/app/logic/Calendar/Event.ts
@@ -181,7 +181,7 @@ export class Event extends Observable {
   recurrenceStartTime: Date | null = null;
   /** Contains all instances that should be displayed for this event.
    *
-   * For master events only:
+   * For recurringCase == Master:
    *
    * Contains all Instances generated from the master.
    * Does *not* contain:
@@ -189,7 +189,7 @@ export class Event extends Observable {
    * - Exceptions
    * - Exclusions
    *
-   * For other events:
+   * For recurringCase == Normal and Exception:
    *   Contains the event itself.
    *
    * This is a dynamic collection, and will be updated automatically

--- a/app/logic/Calendar/RecurrenceColl.ts
+++ b/app/logic/Calendar/RecurrenceColl.ts
@@ -2,13 +2,5 @@ import { Event, RecurrenceCase } from "./Event";
 import { mergeColls, ArrayColl } from "svelte-collections";
 
 export function recurrenceColl(events: ArrayColl<Event>) {
-  return mergeColls(events.map(mapToEvents));
-}
-
-function mapToEvents(event: Event): ArrayColl<Event> {
-  if (event.recurrenceCase == RecurrenceCase.Master) {
-    return event.instances;
-  } else {
-    return new ArrayColl([event]);
-  }
+  return mergeColls(events.map(event => event.instances));
 }


### PR DESCRIPTION
`mapToCollection` has a problem, and that is that it assumes that the mapping function is idempotent, i.e. it always returns the same value each time.

This is not true with our current `mapToEvents` function, except in the edge case where you only create and delete recurring events (which does work on current code).

Now there may be another way to achieve this which allows a dynamic mapping function, but I chose to go the other way and make the mapping function idempotent.

To this end, the `instances` collection of the event should contain itself if it's a single event or an exception otherwise it should contain its occurrences.

While I was there I noticed that changing a recurring event to a single event didn't remove its occurrences (because clearExceptions regenerates them) so I rearranged the code so that this works too.

I was tempted to remove `RecurrenceColl.ts`...