### PR TITLE
Calendar: HTML descriptions

### DIFF
--- a/app/frontend/Util/util.ts
+++ b/app/frontend/Util/util.ts
@@ -40,6 +40,27 @@ export async function stringToDataURL(mimetype: string, content: string): Promis
   });
 }
 
+export function stringFromDataURL(dataURL: URLString, mimetype: string): string | null {
+  console.log("altrep URL", dataURL);
+  if (!dataURL || typeof (dataURL) != "string" ||
+      dataURL.substring(0, "data:".length + mimetype.length).toLowerCase() != "data:text/html") {
+    return null;
+  }
+  // There might be `;charset=utf-8` in-between
+  let comma = dataURL.indexOf(",");
+  console.log("comma", comma);
+  if (comma < 1) {
+    return null;
+  }
+  let htmlEncoded = dataURL.substring(comma + 1);
+  console.log("html encoded", htmlEncoded);
+  if (!htmlEncoded) {
+    return null;
+  }
+  console.log("html decoded", decodeURIComponent(htmlEncoded));
+  return decodeURIComponent(htmlEncoded);
+}
+
 /**
  * Gets the OS using the userAgent string.
  * @returns os name

--- a/app/logic/Calendar/Event.ts
+++ b/app/logic/Calendar/Event.ts
@@ -99,6 +99,9 @@ export class Event extends Observable {
     this._rawHTML = val;
     this._sanitizedHTML = null;
   }
+  get hasHTML(): boolean {
+    return !!this.rawHTMLDangerous;
+  }
 
   @notifyChangedProperty
   startTime: Date;

--- a/app/logic/Calendar/ICal/ICalEMailProcessor.ts
+++ b/app/logic/Calendar/ICal/ICalEMailProcessor.ts
@@ -21,7 +21,7 @@ export class ICalEMailProcessor extends EMailProcessor {
       return;
     }
     if (email.html) {
-      event.rawHTMLDangerous = email.html;
+      event.rawHTMLDangerous = email.rawHTMLDangerous;
     }
     email.event = event;
   }

--- a/app/logic/Calendar/ICal/ICalGenerator.ts
+++ b/app/logic/Calendar/ICal/ICalGenerator.ts
@@ -22,8 +22,10 @@ export function getICal(event: Event, method?: iCalMethod): string | null {
   }
   if (event.descriptionText) {
     if (event.hasHTML) {
-      // Plaintext, HTML Thunderbird
-      lines.push(["DESCRIPTION", "ALTREP", "data:text/html," + encodeURIComponent(event.descriptionHTML), event.descriptionText]);
+      // Plaintext, and HTML RFC 2445 4.2.1, 4.2, RFC 5545 3.2.1 and Thunderbird
+      // <https://datatracker.ietf.org/doc/html/rfc2445#section-4.2.1>
+      // <https://bugzilla.mozilla.org/show_bug.cgi?id=1607834>
+    lines.push(["DESCRIPTION", "ALTREP", "data:text/html," + encodeURIComponent(event.descriptionHTML), event.descriptionText]);
       // HTML RFC 9073 6.5 <https://www.rfc-editor.org/rfc/rfc9073.html#name-styled-description>
       lines.push(["STYLED-DESCRIPTION", "VALUE", "TEXT", "FMTTYPE", "text/html", event.descriptionHTML]);
       // HTML Outlook

--- a/app/logic/Calendar/ICal/ICalGenerator.ts
+++ b/app/logic/Calendar/ICal/ICalGenerator.ts
@@ -21,7 +21,11 @@ export function getICal(event: Event, method?: iCalMethod): string | null {
     lines.push(["SUMMARY", event.title]);
   }
   if (event.descriptionText) {
-    lines.push(["DESCRIPTION", event.descriptionText]);
+    if (event.rawHTMLDangerous) { // Testing for HTML without conversion
+      lines.push(["DESCRIPTION", "ALTREP", "data:text/html," + encodeURIComponent(event.descriptionHTML), event.descriptionText]);
+    } else {
+      lines.push(["DESCRIPTION", event.descriptionText]);
+    }
   }
   if (event.allDay) {
     lines.push(["DTSTART", "VALUE", "DATE", date2ical(event.startTime)]);

--- a/app/logic/Calendar/ICal/ICalGenerator.ts
+++ b/app/logic/Calendar/ICal/ICalGenerator.ts
@@ -21,9 +21,15 @@ export function getICal(event: Event, method?: iCalMethod): string | null {
     lines.push(["SUMMARY", event.title]);
   }
   if (event.descriptionText) {
-    if (event.rawHTMLDangerous) { // Testing for HTML without conversion
+    if (event.hasHTML) {
+      // Plaintext, HTML Thunderbird
       lines.push(["DESCRIPTION", "ALTREP", "data:text/html," + encodeURIComponent(event.descriptionHTML), event.descriptionText]);
+      // HTML RFC 9073 6.5 <https://www.rfc-editor.org/rfc/rfc9073.html#name-styled-description>
+      lines.push(["STYLED-DESCRIPTION", "VALUE", "TEXT", "FMTTYPE", "text/html", event.descriptionHTML]);
+      // HTML Outlook
+      lines.push(["X-ALT-DESC", "FMTTYPE", "text/html", event.descriptionHTML]);
     } else {
+      // Plaintext
       lines.push(["DESCRIPTION", event.descriptionText]);
     }
   }

--- a/app/logic/Calendar/ICal/ICalToEvent.ts
+++ b/app/logic/Calendar/ICal/ICalToEvent.ts
@@ -5,6 +5,7 @@ import { ParticipationStatus, InvitationResponse } from "../Invitation/Invitatio
 import ICalParser from "./ICalParser";
 import WindowsToIANATimezone from "./WindowsToIANATimezone";
 import { sanitize } from "../../../../lib/util/sanitizeDatatypes";
+import { stringFromDataURL } from "../../../frontend/Util/util";
 
 /**
  * @param ics iCal / ICS contents to be parsed
@@ -33,16 +34,28 @@ export function convertICalParserToEvent(ics: ICalParser, event: Event): boolean
     event.title = vevent.entries.summary[0].value;
   }
   if (vevent.entries.description) {
+    // Plaintext
     event.descriptionText = vevent.entries.description[0].value;
+    // HTML Thunderbird
     let altrep = vevent.entries.description[0].properties.altrep;
-    if (altrep?.toLowerCase().startsWith("data:text/html,")) {
-      event.rawHTMLDangerous = decodeURIComponent(altrep.slice(15));
+    event.rawHTMLDangerous = stringFromDataURL(altrep, "text/html");
+  }
+  // HTML RFC 9073 6.5 <https://www.rfc-editor.org/rfc/rfc9073.html#name-styled-description>
+  // Preference order: 1. RFC, 2. Thunderbird, 3. Outlook
+  if (vevent.entries.styleddescription) {
+    let entry = vevent.entries.styleddescription.find(entry =>
+      (!entry.properties.fmttype || entry.properties.fmttype.toLowerCase() == "text/html") &&
+      entry.properties.value.toUpperCase() == "TEXT");
+    if (entry) {
+      event.rawHTMLDangerous = entry.value;
     }
   }
-  if (vevent.entries.xaltdesc) {
-    let fmttype = vevent.entries.xaltdesc[0].properties.fmttype;
-    if (fmttype?.toLowerCase() == "text/html") {
-      event.rawHTMLDangerous = vevent.entries.xaltdesc[0].value;
+  // HTML Outlook
+  if (vevent.entries.xaltdesc && !event.hasHTML) {
+    let entry = vevent.entries.xaltdesc.find(entry =>
+      (!entry.properties.fmttype || entry.properties.fmttype.toLowerCase() == "text/html"));
+    if (entry) {
+      event.rawHTMLDangerous = entry.value;
     }
   }
   if (vevent.entries.dtstart) {

--- a/app/logic/Calendar/ICal/ICalToEvent.ts
+++ b/app/logic/Calendar/ICal/ICalToEvent.ts
@@ -36,12 +36,14 @@ export function convertICalParserToEvent(ics: ICalParser, event: Event): boolean
   if (vevent.entries.description) {
     // Plaintext
     event.descriptionText = vevent.entries.description[0].value;
-    // HTML Thunderbird
+    // HTML RFC 2445 4.2.1, 4.2, RFC 5545 3.2.1 and Thunderbird
+    // <https://datatracker.ietf.org/doc/html/rfc2445#section-4.2.1>
+    // <https://bugzilla.mozilla.org/show_bug.cgi?id=1607834>
     let altrep = vevent.entries.description[0].properties.altrep;
     event.rawHTMLDangerous = stringFromDataURL(altrep, "text/html");
   }
   // HTML RFC 9073 6.5 <https://www.rfc-editor.org/rfc/rfc9073.html#name-styled-description>
-  // Preference order: 1. RFC, 2. Thunderbird, 3. Outlook
+  // Preference order: 1. RFC 9075, 2. Thunderbird, 3. Outlook
   if (vevent.entries.styleddescription) {
     let entry = vevent.entries.styleddescription.find(entry =>
       (!entry.properties.fmttype || entry.properties.fmttype.toLowerCase() == "text/html") &&

--- a/app/logic/Calendar/ICal/ICalToEvent.ts
+++ b/app/logic/Calendar/ICal/ICalToEvent.ts
@@ -34,6 +34,16 @@ export function convertICalParserToEvent(ics: ICalParser, event: Event): boolean
   }
   if (vevent.entries.description) {
     event.descriptionText = vevent.entries.description[0].value;
+    let altrep = vevent.entries.description[0].properties.altrep;
+    if (altrep?.toLowerCase().startsWith("data:text/html,")) {
+      event.rawHTMLDangerous = decodeURIComponent(altrep.slice(15));
+    }
+  }
+  if (vevent.entries.xaltdesc) {
+    let fmttype = vevent.entries.xaltdesc[0].properties.fmttype;
+    if (fmttype?.toLowerCase() == "text/html") {
+      event.rawHTMLDangerous = vevent.entries.xaltdesc[0].value;
+    }
   }
   if (vevent.entries.dtstart) {
     [event.startTime, event.timezone] = parseDate(vevent.entries.dtstart[0]);


### PR DESCRIPTION
* Read HTML description from iCal
* Save HTML description to iCal

In 3 formats:
* [RFC 2445 4.2.1](https://datatracker.ietf.org/doc/html/rfc2445#section-4.2.1), 4.2, [RFC 5545 3.2.1](https://www.rfc-editor.org/rfc/rfc5545#section-3.2.1) ([iCal.org descr](https://icalendar.org/iCalendar-RFC-5545/3-2-1-alternate-text-representation.html)) and [Thunderbird](https://bugzilla.mozilla.org/show_bug.cgi?id=1607834) format: `DESCRIPTION` property with parameter `ALTREP` with `data:text/html` URL as value of the parameter
* [RFC 9073 6.5](https://www.rfc-editor.org/rfc/rfc9073.html#name-styled-description) format: `STYLED-DESCRIPTION` property with parameter `FMTTYPE="text/html"` and HTML as value of the property
* Outlook format: `X-ALT-DESC` property with parameter `FMTTYPE="text/html"` and HTML as value of the property

Preference order: 1. RFC 9075, 2. Thunderbird, 3. Outlook