### PR TITLE
Invitation: Auto-process replies and cancellations #619

### DIFF
--- a/app/frontend/Calendar/DisplayEvent/Invitation.svelte
+++ b/app/frontend/Calendar/DisplayEvent/Invitation.svelte
@@ -76,7 +76,13 @@
         </ButtonMenu>
       {/if}
     {:else if $message.invitationMessage && incomingInvitation}
-      <Button label={$t`Update calendar`} disabled={updateDisabled} onClick={onUpdate} classes="font-normal" />
+      {#await onUpdate()}
+        <!-- Update processing -->
+      {:then}
+        <!-- Update processed -->
+      {:catch ex}
+        <ErrorMessageInline {ex} />
+      {/await}
     {/if}
   </hbox>
 </vbox>
@@ -88,6 +94,7 @@
   import type { IncomingInvitation } from "../../../logic/Calendar/Invitation/IncomingInvitation";
   import { InvitationMessage, InvitationResponse, type InvitationResponseInMessage } from "../../../logic/Calendar/Invitation/InvitationStatus";
   import InvitationDisplay from "./InvitationDisplay.svelte";
+  import ErrorMessageInline from "../../Shared/ErrorMessageInline.svelte";
   import ButtonMenu from "../../Shared/Menu/ButtonMenu.svelte";
   import MenuItem from "../../Shared/Menu/MenuItem.svelte";
   import Button from "../../Shared/Button.svelte";
@@ -147,7 +154,6 @@
   }
   async function onUpdate() {
     await incomingInvitation.updateFromOtherInvitationMessage();
-    updateDisabled = gt`This update has already been processed`;
   }
 </script>
 

--- a/app/logic/Abstract/PersonUID.ts
+++ b/app/logic/Abstract/PersonUID.ts
@@ -3,7 +3,6 @@ import { Group } from "./Group";
 import { ContactEntry, Person } from "./Person";
 import { appGlobal } from "../app";
 import { Observable, notifyChangedProperty } from "../util/Observable";
-import { NotReached } from "../util/util";
 import { ArrayColl } from "svelte-collections";
 
 export class PersonUID extends Observable {
@@ -14,6 +13,10 @@ export class PersonUID extends Observable {
   emailAddress: string;
   @notifyChangedProperty
   person?: Person;
+  // Used so that autocompleted meeting participants have a default value.
+  // They should really be Participant objects, but I'm cheating for now.
+  @notifyChangedProperty
+  protected response = 0;
 
   constructor(emailAddress?: string, name?: string) {
     super();
@@ -56,15 +59,6 @@ export class PersonUID extends Observable {
    * but a mailling list or messaging system */
   get isProxyAddress(): boolean {
     return this.name?.includes(" via ") || this.name?.endsWith("@invalid");
-  }
-
-  /** Used so that autocompleted meeting participants have a default value.
-   * They should really be Participant objects, but I'm cheating for now. */
-  get response() {
-    return 0;
-  }
-  set response(val: any) {
-    throw new NotReached("Only valid on Participant class, not PersonUID");
   }
 
   toString() {

--- a/app/logic/Abstract/PersonUID.ts
+++ b/app/logic/Abstract/PersonUID.ts
@@ -3,6 +3,7 @@ import { Group } from "./Group";
 import { ContactEntry, Person } from "./Person";
 import { appGlobal } from "../app";
 import { Observable, notifyChangedProperty } from "../util/Observable";
+import { NotReached } from "../util/util";
 import { ArrayColl } from "svelte-collections";
 
 export class PersonUID extends Observable {
@@ -13,10 +14,6 @@ export class PersonUID extends Observable {
   emailAddress: string;
   @notifyChangedProperty
   person?: Person;
-  // Used so that autocompleted meeting participants have a default value.
-  // They should really be Participant objects, but I'm cheating for now.
-  @notifyChangedProperty
-  protected response = 0;
 
   constructor(emailAddress?: string, name?: string) {
     super();
@@ -59,6 +56,15 @@ export class PersonUID extends Observable {
    * but a mailling list or messaging system */
   get isProxyAddress(): boolean {
     return this.name?.includes(" via ") || this.name?.endsWith("@invalid");
+  }
+
+  /** Used so that autocompleted meeting participants have a default value.
+   * They should really be Participant objects, but I'm cheating for now. */
+  get response() {
+    return 0;
+  }
+  set response(val: any) {
+    throw new NotReached("Only valid on Participant class, not PersonUID");
   }
 
   toString() {

--- a/app/logic/Calendar/ActiveSync/ActiveSyncIncomingInvitation.ts
+++ b/app/logic/Calendar/ActiveSync/ActiveSyncIncomingInvitation.ts
@@ -42,6 +42,13 @@ export class ActiveSyncIncomingInvitation {
     await this.calendar.listEvents(); // Exchange will have created a calendar item if there wasn't one already
   }
 
+  async updateCancelled() {
+    await this.updateFromOtherInvitationMessage();
+  }
+  async updateParticipantReply() {
+    await this.updateFromOtherInvitationMessage();
+  }
+  /** Exchange server auto-processes these */
   async updateFromOtherInvitationMessage() {
     await this.calendar.listEvents();
   }

--- a/app/logic/Calendar/EWS/EWSIncomingInvitation.ts
+++ b/app/logic/Calendar/EWS/EWSIncomingInvitation.ts
@@ -36,6 +36,13 @@ export class EWSIncomingInvitation {
     await this.calendar.listEvents(); // Exchange will have created a calendar item if there wasn't one already
   }
 
+  async updateCancelled() {
+    await this.updateFromOtherInvitationMessage();
+  }
+  async updateParticipantReply() {
+    await this.updateFromOtherInvitationMessage();
+  }
+  /** Exchange server auto-processes these */
   async updateFromOtherInvitationMessage() {
     await this.calendar.listEvents();
   }

--- a/app/logic/Calendar/Event.ts
+++ b/app/logic/Calendar/Event.ts
@@ -209,7 +209,7 @@ export class Event extends Observable {
   unedited: Event | null = null;
   /** DTSTAMP when the status was sent that is captured in this object.
    * Used during auto-update to avoid overwriting with older info.
-  * We don't need to track local changes, only those sent by others.
+   * We don't need to track local changes, only those sent by others.
    * Local changes sent to others will always get the current timestamp in `ICalGenerator` */
   lastUpdateTime: Date | null;
   /** Includes changes to `alarm`, lastUpdateTime does not consider to be a change */
@@ -354,6 +354,7 @@ export class Event extends Observable {
     this.onlineMeetingURL = original.onlineMeetingURL;
     this.participants.replaceAll(original.participants);
     this.myParticipation = original.myParticipation;
+    this.lastUpdateTime = original.lastUpdateTime;
   }
 
   fromExtraJSON(json: any) {

--- a/app/logic/Calendar/Event.ts
+++ b/app/logic/Calendar/Event.ts
@@ -206,6 +206,12 @@ export class Event extends Observable {
    * Set be `startEditing()` and `stopEditing()` */
   @notifyChangedProperty
   unedited: Event | null = null;
+  /** DTSTAMP when the status was sent that is captured in this object.
+   * Used during auto-update to avoid overwriting with older info.
+  * We don't need to track local changes, only those sent by others.
+   * Local changes sent to others will always get the current timestamp in `ICalGenerator` */
+  lastUpdateTime: Date | null;
+  /** Includes changes to `alarm`, lastUpdateTime does not consider to be a change */
   @notifyChangedProperty
   lastMod = new Date();
   @notifyChangedProperty

--- a/app/logic/Calendar/Event.ts
+++ b/app/logic/Calendar/Event.ts
@@ -10,6 +10,7 @@ import { k1DayS, k1HourS, k1MinuteS } from "../../frontend/Util/date";
 import { convertHTMLToText, convertTextToHTML, sanitizeHTML } from "../util/convertHTML";
 import { Observable, notifyChangedAccessor, notifyChangedProperty, notifyChangedObservable } from "../util/Observable";
 import { Lock } from "../util/Lock";
+import { sanitize } from "../../../lib/util/sanitizeDatatypes";
 import { assert, randomID } from "../util/util";
 import { backgroundError } from "../../frontend/Util/error";
 import { gt } from "../../l10n/l10n";
@@ -358,10 +359,12 @@ export class Event extends Observable {
   fromExtraJSON(json: any) {
     assert(typeof (json) == "object", "Must be a JSON object");
     this.syncState = json.syncState;
+    this.lastUpdateTime = sanitize.date(json.lastUpdateTime, null);
   }
   toExtraJSON(): any {
     let json: any = {};
     json.syncState = this.syncState;
+    json.lastUpdateTime = this.lastUpdateTime;
     return json;
   }
 

--- a/app/logic/Calendar/ICal/ICalEMailProcessor.ts
+++ b/app/logic/Calendar/ICal/ICalEMailProcessor.ts
@@ -24,6 +24,10 @@ export class ICalEMailProcessor extends EMailProcessor {
       event.rawHTMLDangerous = email.rawHTMLDangerous;
     }
     email.event = event;
+
+    // TODO Call IncomingInvitation.update()
+    // let incomingInvitation = selectedCalendar.getIncomingInvitationFor(message);
+    // incomingInvitation.updateFromOtherInvitationMessage();
   }
 }
 

--- a/app/logic/Calendar/ICal/ICalEMailProcessor.ts
+++ b/app/logic/Calendar/ICal/ICalEMailProcessor.ts
@@ -25,9 +25,14 @@ export class ICalEMailProcessor extends EMailProcessor {
     }
     email.event = event;
 
-    // TODO Call IncomingInvitation.update()
-    // let incomingInvitation = selectedCalendar.getIncomingInvitationFor(message);
-    // incomingInvitation.updateFromOtherInvitationMessage();
+    if (email.invitationMessage == InvitationMessage.ParticipantReply ||
+        email.invitationMessage == InvitationMessage.CancelledEvent) {
+      let foundEventInCalendars = email.getUpdateCalendars();
+      for (let calendar of foundEventInCalendars) {
+        let incomingInvitation = calendar.getIncomingInvitationFor(email);
+        await incomingInvitation.updateFromOtherInvitationMessage();
+      }
+    }
   }
 }
 

--- a/app/logic/Calendar/ICal/ICalToEvent.ts
+++ b/app/logic/Calendar/ICal/ICalToEvent.ts
@@ -69,6 +69,9 @@ export function convertICalParserToEvent(ics: ICalParser, event: Event): boolean
   if (vevent.entries.recurrenceid) {
     [event.recurrenceStartTime] = parseDate(vevent.entries.recurrenceid[0]);
   }
+  if (vevent.entries.dtstamp) {
+    [event.lastUpdateTime] = parseDate(vevent.entries.dtstamp[0]);
+  }
   if (vevent.entries.dtstart?.[0].properties.value?.toLowerCase() == "date") {
     event.allDay = true;
   }

--- a/app/logic/Calendar/Invitation/IncomingInvitation.ts
+++ b/app/logic/Calendar/Invitation/IncomingInvitation.ts
@@ -52,6 +52,7 @@ export class IncomingInvitation {
     let organizer = event.participants.find(participant => participant.response == InvitationResponse.Organizer);
     if (organizer) {
       organizer.response = InvitationResponse.Decline;
+      event.lastUpdateTime = this.event.lastUpdateTime;
       await event.save();
     }
   }

--- a/app/logic/Calendar/Invitation/IncomingInvitation.ts
+++ b/app/logic/Calendar/Invitation/IncomingInvitation.ts
@@ -44,6 +44,10 @@ export class IncomingInvitation {
   async updateCancelled() {
     assert(this.invitationMessage && this.invitationMessage != InvitationMessage.Invitation, "Can't update from an invitation");
     let event = this.calEvent();
+    assert(event, "Cannot process invitation update: The event was not found in your calendar");
+    if (this.event?.lastUpdateTime <= event?.lastUpdateTime) {
+      return;
+    }
     // Is this action reversible? If so, need to check timestamp.
     let organizer = event.participants.find(participant => participant.response == InvitationResponse.Organizer);
     if (organizer) {
@@ -56,6 +60,7 @@ export class IncomingInvitation {
   async updateParticipantReply() {
     assert(this.invitationMessage && this.invitationMessage != InvitationMessage.Invitation, "Can't update from an invitation");
     let event = this.calEvent();
+    assert(event, "Cannot process invitation update: The event was not found in your calendar");
     let invitee = this.event.participants.find(participant => participant.response != InvitationResponse.Organizer);
     let participant = event.participants.find(participant => participant.emailAddress == invitee.emailAddress);
     let timestamp = this.message.sent; // TODO Use DTSTAMP from ICS

--- a/app/logic/Calendar/OWA/OWAIncomingInvitation.ts
+++ b/app/logic/Calendar/OWA/OWAIncomingInvitation.ts
@@ -47,6 +47,13 @@ export class OWAIncomingInvitation {
     }
   }
 
+  async updateCancelled() {
+    await this.updateFromOtherInvitationMessage();
+  }
+  async updateParticipantReply() {
+    await this.updateFromOtherInvitationMessage();
+  }
+  /** Exchange server auto-processes these */
   async updateFromOtherInvitationMessage() {
     assert(this.itemID, "UI should have been disabled");
     await this.calendar.getEvents([this.itemID], new ArrayColl<OWAEvent>());

--- a/app/logic/Calendar/Participant.ts
+++ b/app/logic/Calendar/Participant.ts
@@ -4,12 +4,23 @@ import { notifyChangedProperty } from "../util/Observable";
 
 export class Participant extends PersonUID {
   @notifyChangedProperty
-  response: InvitationResponse;
+  _response: InvitationResponse;
+  /** DTSTAMP when the status was sent that is captured in this object.
+   * Used during auto-update to avoid overwriting with older info. */
+  lastUpdateTime: Date | null;
 
   constructor(emailAddress: string, name: string, response: InvitationResponse) {
     let person = findPerson(emailAddress);
     super(emailAddress, name ?? person?.name ?? emailAddress);
     this.person = person;
-    this.response = response;
+    this._response = response;
+  }
+
+  get response(): InvitationResponse {
+    return this._response;
+  }
+  set response(val: InvitationResponse) {
+    this._response = val;
+    this.lastUpdateTime = new Date();
   }
 }

--- a/app/logic/Calendar/Participant.ts
+++ b/app/logic/Calendar/Participant.ts
@@ -4,23 +4,17 @@ import { notifyChangedProperty } from "../util/Observable";
 
 export class Participant extends PersonUID {
   @notifyChangedProperty
-  _response: InvitationResponse;
+  response: InvitationResponse;
   /** DTSTAMP when the status was sent that is captured in this object.
-   * Used during auto-update to avoid overwriting with older info. */
+   * Used during auto-update to avoid overwriting with older info.
+   * We don't need to track local changes, only those sent by others.
+   * Local changes sent to others will always get the current timestamp in `ICalGenerator` */
   lastUpdateTime: Date | null;
 
   constructor(emailAddress: string, name: string, response: InvitationResponse) {
     let person = findPerson(emailAddress);
     super(emailAddress, name ?? person?.name ?? emailAddress);
     this.person = person;
-    this._response = response;
-  }
-
-  get response(): InvitationResponse {
-    return this._response;
-  }
-  set response(val: InvitationResponse) {
-    this._response = val;
-    this.lastUpdateTime = new Date();
+    this.response = response;
   }
 }


### PR DESCRIPTION
When we receive:
* A reply from a participant to an meeting that we organize
* A cancellation from an organizer

we should automatically update the information in the event in our calendar, so that the event has the most up-to-date status about all participants that responded, and can show that an event that we were previously invited to was now cancelled.

The processing should happen
a) immediately once we received the email
b) when the user reads the email