### PR TITLE
Allow invitations to be deleted from the calendar

### DIFF
--- a/app/frontend/Calendar/EditEvent/DialogHeader.svelte
+++ b/app/frontend/Calendar/EditEvent/DialogHeader.svelte
@@ -13,19 +13,19 @@
             iconSize="16px"
             />
         {/if}
-        {#if !event.isIncomingMeeting}
-          {#if $event.recurrenceCase == RecurrenceCase.Instance}
-            <ButtonMenu bind:isMenuOpen={isDeleteSeriesOpen}>
-              <RoundButton
-                slot="control"
-                label={$t`Delete event`}
-                icon={DeleteIcon}
-                onClick={event => { isDeleteSeriesOpen = !isDeleteSeriesOpen; event.stopPropagation(); }}
-                classes="plain delete"
-                border={false}
-                iconSize="16px"
-                />
+        {#if $event.recurrenceCase == RecurrenceCase.Instance}
+          <ButtonMenu bind:isMenuOpen={isDeleteSeriesOpen}>
+            <RoundButton
+              slot="control"
+              label={$t`Delete event`}
+              icon={DeleteIcon}
+              onClick={event => { isDeleteSeriesOpen = !isDeleteSeriesOpen; event.stopPropagation(); }}
+              classes="plain delete"
+              border={false}
+              iconSize="16px"
+              />
 
+            {#if !event.isIncomingMeeting}
               <MenuItem
                 label={$t`Delete only this instance`}
                 onClick={onDelete}
@@ -36,22 +36,22 @@
                   onClick={onDeleteRemainder}
                   classes="font-normal" />
               {/if}
-              <MenuItem
-                label={$t`Delete entire series`}
-                onClick={onDeleteAll}
-                classes="font-normal" />
-            </ButtonMenu>
-          {:else}
-            <RoundButton
-              label={$t`Delete event`}
-              icon={DeleteIcon}
-              onClick={onDelete}
-              disabled={!event.dbID && !event.parentEvent}
-              classes="plain delete"
-              border={false}
-              iconSize="16px"
-              />
-          {/if}
+            {/if}
+            <MenuItem
+              label={$t`Delete entire series`}
+              onClick={onDeleteAll}
+              classes="font-normal" />
+          </ButtonMenu>
+        {:else}
+          <RoundButton
+            label={$t`Delete event`}
+            icon={DeleteIcon}
+            onClick={onDelete}
+            disabled={!event.dbID && !event.parentEvent}
+            classes="plain delete"
+            border={false}
+            iconSize="16px"
+            />
         {/if}
       </hbox>
       <hbox class="account-icon">

--- a/app/logic/Calendar/Event.ts
+++ b/app/logic/Calendar/Event.ts
@@ -583,7 +583,12 @@ export class Event extends Observable {
       // TODO Move code to `IncomingInvitation` class
       for (let participant of this.participants) {
         if (participant.response == InvitationResponse.Organizer) {
-          await this.respondToInvitation(InvitationResponse.Decline);
+          // Can't use `respondToInvitation` because that wants to save
+          let { identity, myParticipant } = this.participantMe();
+          if (myParticipant.response != InvitationResponse.Decline) {
+            myParticipant.response = InvitationResponse.Decline;
+            await this.sendInvitationResponse(myParticipant, identity.account);
+          }
         }
       }
     }


### PR DESCRIPTION
(The diff looks much nicer if you hide whitespace.)

In the case of a recurring master, I show the menu with only the "Delete entire series" option, as that's the only one that makes sense. Otherwise, I just show the usual delete button.

(Which makes me think... how do we handle the possibility of the user wanting to accept an entire series? They can (only!) do that from the initial message but not from the calendar.)

I also discovered that there was a bug in the delete code as it wants to send a cancellation notification to the organiser but the `respondToInvitation` function assumes you're saving rather than deleting and so the invitation reappears when you restart.