### PR TITLE
Calendar: ActiveSync, EWS, OWA: Show correct organiser status

### DIFF
--- a/app/logic/Calendar/EWS/EWSCalendar.ts
+++ b/app/logic/Calendar/EWS/EWSCalendar.ts
@@ -200,6 +200,8 @@ export class EWSCalendar extends Calendar {
             }, {
               FieldURI: "calendar:IsAllDayEvent",
             }, {
+              FieldURI: "calendar:IsCancelled",
+            }, {
               FieldURI: "calendar:MyResponseType",
             }, {
               FieldURI: "calendar:RequiredAttendees",

--- a/app/logic/Calendar/OWA/Request/OWAEventRequests.ts
+++ b/app/logic/Calendar/OWA/Request/OWAEventRequests.ts
@@ -34,6 +34,9 @@ export function owaGetEventsRequest(eventIDs: string[]): OWARequest {
         FieldURI: "calendar:EnhancedLocation",
       }, {
         __type: "PropertyUri:#Exchange",
+        FieldURI: "calendar:IsCancelled",
+      }, {
+        __type: "PropertyUri:#Exchange",
         FieldURI: "calendar:MyResponseType",
       }, {
         __type: "PropertyUri:#Exchange",


### PR DESCRIPTION
The organiser sometimes show up in the attendee list but even then its status is not reliable so this ensures the organiser is displayed with the correct status.