### PR TITLE
Calendar: Edit: Recurrence

### DIFF
--- a/app/frontend/Calendar/DisplayEvent/DisplayEvent.svelte
+++ b/app/frontend/Calendar/DisplayEvent/DisplayEvent.svelte
@@ -13,8 +13,8 @@
     </PersonsAutocomplete>
   </vbox>
   <grid class="location">
-    <Checkbox bind:checked={event.isOnline} label={$t`Online`} disabled />
-    <input type="url" bind:value={event.onlineMeetingURL} disabled />
+    <Checkbox checked={event.isOnline} label={$t`Online`} disabled />
+    <input type="url" value={event.onlineMeetingURL} disabled />
     <hbox class="buttons">
       <Button
         label={$t`Copy`}
@@ -36,7 +36,7 @@
         />
     </hbox>
     <Checkbox checked={!!event.location} label={$t`In Presence`} disabled />
-    <input type="url" bind:value={event.location} disabled />
+    <input type="url" value={event.location} disabled />
   </grid>
   <hbox>{$t`When`}</hbox>
   <grid class="time">
@@ -51,37 +51,42 @@
 
     <label for="duration">{$t`Duration`}</label>
     <hbox>
-      <input class="duration" type="number" bind:value={durationInUnit} disabled />
-      <DurationUnit bind:durationInSeconds={event.duration} bind:durationInUnit bind:this={durationUnit} disabled />
+      <input class="duration" type="number" value={durationInUnit} disabled />
+      <DurationUnit durationInSeconds={event.duration} bind:durationInUnit bind:this={durationUnit} disabled />
     </hbox>
   </grid>
-  <Checkbox label={$t`All day`} bind:checked={event.allDay} disabled />
+  <Checkbox label={$t`All day`} checked={event.allDay} disabled />
   <Checkbox label={$t`Repeated`} checked={event.recurrenceCase != RecurrenceCase.Normal} disabled />
   {#if event.recurrenceCase != RecurrenceCase.Normal}
     <hbox>
-      <label>{`Every`}</label>&nbsp;<input class="auto" type="number" disabled bind:value={interval} />&nbsp;
-      <select bind:value={frequency} disabled>
-        <option value="{Frequency.Daily}">{$plural(interval, { one: 'day', other: 'days' })}</option>
-        <option value="{Frequency.Weekly}">{$plural(interval, { one: 'week', other: 'weeks' })}</option>
-        <option value="{Frequency.Monthly}">{$plural(interval, { one: 'month', other: 'months' })}</option>
-        <option value="{Frequency.Yearly}">{$plural(interval, { one: 'year', other: 'years' })}</option>
+      <hbox>{$t`Every *=> Every 2 weeks`}</hbox>
+      &nbsp;
+      {#if interval > 1}
+        <hbox class="value">{interval}</hbox>
+        &nbsp;
+      {/if}
+      <select value={frequency} disabled>
+        <option value={Frequency.Daily}>{$plural(interval, { one: 'day', other: 'days' })}</option>
+        <option value={Frequency.Weekly}>{$plural(interval, { one: 'week', other: 'weeks' })}</option>
+        <option value={Frequency.Monthly}>{$plural(interval, { one: 'month', other: 'months' })}</option>
+        <option value={Frequency.Yearly}>{$plural(interval, { one: 'year', other: 'years' })}</option>
       </select>
     </hbox>
     {#if frequency == Frequency.Yearly }
-      <RadioGroup bind:group={week} items={yearWeekOptions} disabled />
+      <RadioGroup group={week} items={yearWeekOptions} disabled />
     {:else if frequency == Frequency.Monthly }
-      <RadioGroup bind:group={week} items={monthWeekOptions} disabled />
+      <RadioGroup group={week} items={monthWeekOptions} disabled />
     {:else if frequency == Frequency.Weekly }
-      <CheckboxGroup size="sm" radius="xl" bind:group={weekdays} label={$t`On days`} items={weekdayOptions} disabled />
+      <CheckboxGroup size="sm" radius="xl" group={weekdays} label={$t`On days`} items={weekdayOptions} disabled />
     {/if}
     <hbox>
-      <Radio label="{$t`Forever`}" bind:group={end} value="none" disabled />
+      <Radio label="{$t`Forever`}" group={end} value="none" disabled />
     </hbox>
     <hbox>
-      <Radio class="inline" label="{$t`For `}" bind:group={end} value="count" disabled />&nbsp;<input class="auto" type="number" min={1} max={99} bind:value={count} disabled> end = "count"}>&nbsp;{$plural(count, { one: 'time', other: 'times' })}
+      <Radio class="inline" label="{$t`For `}" group={end} value="count" disabled />&nbsp;<input class="auto" type="number" min={1} max={99} value={count} disabled> end = "count"}>&nbsp;{$plural(count, { one: 'time', other: 'times' })}
     </hbox>
     <hbox>
-      <Radio class="inline" label="{$t`Until`}" bind:group={end} value="date" disabled />&nbsp;<DateInput date={seriesEndTime} disabled />
+      <Radio class="inline" label="{$t`Until`}" group={end} value="date" disabled />&nbsp;<DateInput date={seriesEndTime} disabled />
     </hbox>
   {/if}
   <Checkbox label={$t`Alarm`} checked={!!event.alarm} disabled />
@@ -107,17 +112,19 @@
 
   export let event: Event;
 
+  $: frequency = event.recurrenceRule?.frequency || Frequency.Daily;
+  $: interval = event.recurrenceRule?.interval || 1;
+  $: count = Number.isFinite(event.recurrenceRule?.count) ? event.recurrenceRule.count : 1;
+  $: weekdays = event.recurrenceRule?.weekdays || [event.startTime.getDay()];
+  $: week = event.recurrenceRule?.week || 0;
+  $: end = event.recurrenceRule?.seriesEndTime ? "date" : Number.isFinite(event.recurrenceRule?.count) ? "count" : "none";
+  $: seriesEndTime = event.recurrenceRule?.seriesEndTime || event.startTime;
+  $: minDate = event.startTime;
   let durationUnit: DurationUnit;
   let durationInUnit: number;
-  let frequency = event.recurrenceRule?.frequency || Frequency.Daily;
-  let interval = event.recurrenceRule?.interval || 1;
-  let count = Number.isFinite(event.recurrenceRule?.count) ? event.recurrenceRule.count : 1;
-  let weekdays = event.recurrenceRule?.weekdays || [event.startTime.getDay()];
-  let week = event.recurrenceRule?.week || 0;
-  let end = event.recurrenceRule?.seriesEndTime ? "date" : Number.isFinite(event.recurrenceRule?.count) ? "count" : "none";
-  let seriesEndTime = event.recurrenceRule?.seriesEndTime || event.startTime;
-  let minDate = event.startTime;
-  let yearWeekOptions, monthWeekOptions, weekdayOptions;
+  let yearWeekOptions;
+  let monthWeekOptions;
+  let weekdayOptions;
 
   updateDateUI();
   function updateDateUI() {

--- a/app/frontend/Calendar/DisplayEvent/DisplayEvent.svelte
+++ b/app/frontend/Calendar/DisplayEvent/DisplayEvent.svelte
@@ -73,9 +73,9 @@
       </select>
     </hbox>
     {#if frequency == Frequency.Yearly }
-      <RadioGroup group={week} items={yearWeekOptions} disabled />
+      <RadioGroup value={week} items={yearWeekOptions} disabled />
     {:else if frequency == Frequency.Monthly }
-      <RadioGroup group={week} items={monthWeekOptions} disabled />
+      <RadioGroup value={week} items={monthWeekOptions} disabled />
     {:else if frequency == Frequency.Weekly }
       <CheckboxGroup size="sm" radius="xl" group={weekdays} label={$t`On days`} items={weekdayOptions} disabled />
     {/if}

--- a/app/frontend/Calendar/EditEvent/DialogHeader.svelte
+++ b/app/frontend/Calendar/EditEvent/DialogHeader.svelte
@@ -101,7 +101,7 @@
               {#if canSaveSingle}
                 <MenuItem
                   label={$t`Change only this instance`}
-                  onClick={onSave}
+                  onClick={onSaveException}
                   classes="font-normal" />
               {/if}
               {#if $event.seriesStatus == "middle"}
@@ -241,6 +241,12 @@
     await saveEvent(master);
     master.finishEditing();
     await event.truncateRecurrence();
+    onClose();
+  }
+
+  async function onSaveException() {
+    await saveEvent(event);
+    event.parentEvent?.cancelEditing();
     onClose();
   }
 

--- a/app/frontend/Calendar/EditEvent/DialogHeader.svelte
+++ b/app/frontend/Calendar/EditEvent/DialogHeader.svelte
@@ -186,11 +186,11 @@
 
   function confirmAndChangeRecurrenceRule(): boolean {
     let master = event.parentEvent || event;
-    if (!master.recurrenceRule && master.unedited.recurrenceRule) {
+    if (!master.recurrenceRule && master.unedited?.recurrenceRule) {
       if (!confirm($t`Are you sure you want to remove this unfortunate series of events?`)) {
         return false;
       }
-    } else if (master.recurrenceRule && master.unedited.recurrenceRule &&
+    } else if (master.recurrenceRule && master.unedited?.recurrenceRule &&
         !master.unedited.recurrenceRule.timesMatch(master.recurrenceRule)) {
       if (!confirm($t`This change will remove all exceptions and exclusions for this series.`)) {
         return false;

--- a/app/frontend/Calendar/EditEvent/DialogHeader.svelte
+++ b/app/frontend/Calendar/EditEvent/DialogHeader.svelte
@@ -148,7 +148,6 @@
   import { openApp, selectedApp } from "../../AppsBar/selectedApp";
   import { appGlobal } from "../../../logic/app";
   import Stack from "../../Shared/Stack.svelte";
-  import type RepeatBox from "./RepeatBox.svelte";
   import AccountDropDown from "../../Shared/AccountDropDown.svelte";
   import ButtonMenu from "../../Shared/Menu/ButtonMenu.svelte";
   import RoundButton from "../../Shared/RoundButton.svelte";
@@ -200,9 +199,9 @@
   }
 
   function onCancel() {
-    assert(event.unedited, "need unedited state");
-    event.copyFrom(event.unedited);
-    event.finishEditing();
+    // assert(event.unedited, "need unedited state");
+    event.cancelEditing();
+    event.parentEvent?.cancelEditing(); // master, when recurrence was changed
     onClose();
   }
 

--- a/app/frontend/Calendar/EditEvent/DialogHeader.svelte
+++ b/app/frontend/Calendar/EditEvent/DialogHeader.svelte
@@ -162,7 +162,6 @@
   import CloseIcon from "lucide-svelte/icons/x";
   import RevertIcon from "lucide-svelte/icons/undo-2";
   import { catchErrors } from "../../Util/error";
-  import { assert } from "../../../logic/util/util";
   import { t } from "../../../l10n/l10n";
 
   export let event: Event;

--- a/app/frontend/Calendar/EditEvent/DialogHeader.svelte
+++ b/app/frontend/Calendar/EditEvent/DialogHeader.svelte
@@ -170,12 +170,13 @@
   $: newCalendar = event.calendar; // not `$event`
   $: hasMinimalProps = event && $event.title && $event.startTime && $event.endTime &&
       event.startTime.getTime() <= event.endTime.getTime();
-  $: hasMinimalPropsChanged = hasMinimalProps && $event.hasChanged;
-  $: canSaveSeries = hasMinimalProps && $event.recurrenceCase == RecurrenceCase.Instance;
-  $: canSaveSingle = hasMinimalProps && (
-    $event.hasChanged() ||
-    event.recurrenceRule && !event.parentEvent || // Change single event into series
-    newCalendar != event.calendar);
+  $: hasMinimalPropsChanged = hasMinimalProps && $event.hasChanged();
+  $: parentEvent = $event.parentEvent;
+  $: canSaveSeries = hasMinimalPropsChanged && $event.recurrenceCase == RecurrenceCase.Instance ||
+    $parentEvent?.hasChanged();
+  $: canSaveSingle = hasMinimalPropsChanged || // Single changed
+    hasMinimalProps && event.recurrenceRule && !event.parentEvent || // Change single event into series
+    newCalendar != event.calendar;
   $: participants = event.participants;
   $: willSend = $participants.hasItems && !$event.isIncomingMeeting;
   $: isFullWindow = $selectedApp instanceof EventEditMustangApp;

--- a/app/frontend/Calendar/EditEvent/EditEvent.svelte
+++ b/app/frontend/Calendar/EditEvent/EditEvent.svelte
@@ -67,6 +67,7 @@
 
 <script lang="ts">
   import type { Event } from "../../../logic/Calendar/Event";
+  import { Frequency } from "../../../logic/Calendar/RecurrenceRule";
   import { InvitationResponse } from "../../../logic/Calendar/Invitation/InvitationStatus";
   import TitleBox from "./TitleBox.svelte";
   import TimeBox from "./TimeBox.svelte";
@@ -90,7 +91,6 @@
   import LocationIcon from "lucide-svelte/icons/map-pin";
   import DescriptionIcon from "lucide-svelte/icons/notebook-pen";
   import { t } from "../../../l10n/l10n";
-  import { Frequency } from "../../../logic/Calendar/RecurrenceRule";
 
   export let event: Event;
 

--- a/app/frontend/Calendar/EditEvent/EditEvent.svelte
+++ b/app/frontend/Calendar/EditEvent/EditEvent.svelte
@@ -1,5 +1,5 @@
 <vbox flex class="event-edit-window">
-  <DialogHeader bind:event {repeatBox} />
+  <DialogHeader bind:event />
   <Scroll>
     <vbox class="columns" flex class:show-description={showDescription}>
       <vbox class="column1">
@@ -19,7 +19,7 @@
         </Section>
         {#if showRepeat}
           <Section label={$t`Repeat`} icon={RepeatIcon}>
-            <RepeatBox {event} bind:this={repeatBox} bind:showRepeat />
+            <RepeatBox {event} bind:this={repeatBox} />
           </Section>
         {/if}
         {#if showReminder}
@@ -90,10 +90,11 @@
   import LocationIcon from "lucide-svelte/icons/map-pin";
   import DescriptionIcon from "lucide-svelte/icons/notebook-pen";
   import { t } from "../../../l10n/l10n";
+  import { Frequency } from "../../../logic/Calendar/RecurrenceRule";
 
   export let event: Event;
 
-  let showRepeat = event.recurrenceRule || event.parentEvent && event.isNew;
+  $: showRepeat = !!event.recurrenceRule || event.parentEvent && event.isNew;
   $: showReminder = !!$event.alarm;
   $: showParticipants = $event.participants.hasItems;
   $: showLocation = !!$event.location;
@@ -103,7 +104,7 @@
   let repeatBox: RepeatBox;
 
   function expandRepeat(): void {
-    // `showRepeat = true` set by `<ExpanderButton>` click handler
+    event.newRecurrenceRule(Frequency.Weekly);
   }
 
   const kDefaultReminderMins = 5;

--- a/app/frontend/Calendar/EditEvent/RadioGroup.svelte
+++ b/app/frontend/Calendar/EditEvent/RadioGroup.svelte
@@ -5,9 +5,8 @@
     <hbox>
       <input type="radio"
         value={item.value}
-        checked={item.value === group}
-        on:change={() => group = item.value}
-        on:change
+        checked={item.value === value}
+        on:change={() => onChanged(item)}
         {disabled}
         id={"radio" + i}
         />
@@ -17,10 +16,20 @@
 </radiogroup>
 
 <script lang="ts">
+  import { createEventDispatcher } from 'svelte';
+  const dispatchEvent = createEventDispatcher<{ change: any }>();
+
   export let items: RadioOption[] = [];
-  export let group: any;
+  export let value: any;
   export let disabled = false;
   export let vertical = false;
+
+  $: console.log("radiogroup", value, "items", items);
+
+  function onChanged(item: any) {
+    value = item.value;
+    dispatchEvent("change", item);
+  }
 </script>
 <script lang="ts" context="module">
   export type RadioOption = {label: string, value: any, disabled?: boolean};

--- a/app/frontend/Calendar/EditEvent/RadioGroup.svelte
+++ b/app/frontend/Calendar/EditEvent/RadioGroup.svelte
@@ -24,8 +24,6 @@
   export let disabled = false;
   export let vertical = false;
 
-  $: console.log("radiogroup", value, "items", items);
-
   function onChanged(item: any) {
     value = item.value;
     dispatchEvent("change", item);

--- a/app/frontend/Calendar/EditEvent/RepeatBox.svelte
+++ b/app/frontend/Calendar/EditEvent/RepeatBox.svelte
@@ -82,7 +82,6 @@
   import { getUILocale, t, plural } from "../../../l10n/l10n";
 
   export let event: Event;
-  export let showRepeat: boolean;
 
   let master = event.parentEvent || event;
   let frequency = master.recurrenceRule?.frequency || Frequency.Weekly;
@@ -175,28 +174,10 @@
 
   function onFrequencyChanged(_newValue: string) {
     if (frequency == Frequency.None) {
-      showRepeat = false;
+      event.recurrenceRule = null;
+    } else if (frequency != master.recurrenceRule.frequency) {
+      event.newRecurrenceRule(master.recurrenceRule.frequency);
     }
-  }
-
-  export function newRecurrenceRule(): RecurrenceRule {
-    let init: RecurrenceInit = { masterDuration: event.duration, seriesStartTime: event.startTime, frequency, interval };
-    /* end
-    if (end == "count") {
-      init.count = count;
-    } else if (end == "date") {
-      init.seriesEndTime = seriesEndTime;
-    }
-    */
-    if (frequency == Frequency.Weekly) {
-      init.weekdays = weekdays;
-    } else if (frequency == Frequency.Monthly || frequency == Frequency.Yearly) {
-      init.week = week;
-      if (week) {
-        init.weekdays = [event.startTime.getDay()];
-      }
-    }
-    return new RecurrenceRule(init);
   }
 </script>
 

--- a/app/frontend/Calendar/EditEvent/RepeatBox.svelte
+++ b/app/frontend/Calendar/EditEvent/RepeatBox.svelte
@@ -1,6 +1,10 @@
 <SectionTitle label={$t`Repeat`}>
   <hbox>
+<<<<<<< HEAD
     <select bind:value={frequency} class="selector" on:change={ev => catchErrors(() => onFrequencyChanged(ev.currentTarget.value))}>
+=======
+    <select value={frequency} class="selector" on:change={(ev) => catchErrors(() => onFrequencyChanged(ev.currentTarget?.value))}>
+>>>>>>> 9a189dfd (Propagate UI changes to event)
       <option value={Frequency.None}>{$t`none`}</option>
       <option value={Frequency.Daily}>{$t`daily`}</option>
       <option value={Frequency.Weekly}>{$t`weekly`}</option>
@@ -72,23 +76,24 @@
 -->
 
 <script lang="ts">
-  import { RecurrenceCase, type Event } from "../../../logic/Calendar/Event";
-  import { Frequency, RecurrenceRule, type RecurrenceInit } from "../../../logic/Calendar/RecurrenceRule";
+  import type { Event } from "../../../logic/Calendar/Event";
+  import { Frequency } from "../../../logic/Calendar/RecurrenceRule";
   import SectionTitle from './SectionTitle.svelte';
   import RadioGroup, { type RadioOption } from "./RadioGroup.svelte";
   import RoundButton from '../../Shared/RoundButton.svelte';
   import { catchErrors } from "../../Util/error";
   import { arrayRemove } from '../../../logic/util/util';
-  import { getUILocale, t, plural } from "../../../l10n/l10n";
+  import { catchErrors } from "../../Util/error";
 
   export let event: Event;
 
-  let master = event.parentEvent || event;
-  let frequency = master.recurrenceRule?.frequency || Frequency.Weekly;
-  let interval = master.recurrenceRule?.interval || 1;
+  $: master = $event.parentEvent ?? event;
+  $: frequency = $master.recurrenceRule?.frequency ?? Frequency.Weekly;
+  $: console.log("frequency", frequency, "master freq", $master.recurrenceRule?.frequency);
+  $: interval = $master.recurrenceRule?.interval ?? 1;
   // end // let count = Number.isFinite(event.recurrenceRule?.count) ? event.recurrenceRule.count : 1;
-  let weekdays = master.recurrenceRule?.weekdays?.slice() || [event.startTime.getDay()];
-  let week = master.recurrenceRule?.week || 0;
+  $: weekdays = $master.recurrenceRule?.weekdays?.slice() ?? [$event.startTime.getDay()];
+  $: week = $master.recurrenceRule?.week ?? 0;
   // end // let end = event.recurrenceRule?.seriesEndTime ? "date" : Number.isFinite(event.recurrenceRule?.count) ? "count" : "none";
   // end // let seriesEndTime = master.recurrenceRule?.seriesEndTime || event.startTime;
   let minDate = event.startTime;
@@ -160,23 +165,26 @@
     interval = 1;
     frequency = Frequency.Weekly;
     daily = "everyday";
+    onFrequencyChanged(frequency);
   }
 
   function onWeekdayChanged(weekday: number) {
-    console.log("weekdays changed", weekday, weekdays);
     if (weekdays.includes(weekday)) {
       arrayRemove(weekdays, weekday);
     } else {
       weekdays.push(weekday);
     }
-    weekdayOptions = weekdayOptions; // force UI update
+    console.log("weekdays changed", weekday, weekdays);
+    master.newRecurrenceRule(frequency, interval, weekdays, week);
   }
 
-  function onFrequencyChanged(_newValue: string) {
-    if (frequency == Frequency.None) {
+  function onFrequencyChanged(newValue: string) {
+    console.log("frequency changed cur", frequency, "to", newValue);
+    let newFrequency = newValue as Frequency;
+    if (newFrequency == Frequency.None || !newFrequency) {
       event.recurrenceRule = null;
-    } else if (frequency != master.recurrenceRule.frequency) {
-      event.newRecurrenceRule(master.recurrenceRule.frequency);
+    } else if (newFrequency != master.recurrenceRule.frequency) {
+      master.newRecurrenceRule(newFrequency, interval, weekdays, week);
     }
   }
 </script>

--- a/app/frontend/Calendar/EditEvent/RepeatBox.svelte
+++ b/app/frontend/Calendar/EditEvent/RepeatBox.svelte
@@ -14,7 +14,7 @@
 {#if frequency != Frequency.None }
   <vbox class="frequency">
     {#if frequency == Frequency.Daily }
-      <RadioGroup bind:group={daily} items={dailyOptions} vertical={true}
+      <RadioGroup bind:value={daily} items={dailyOptions} vertical={true}
         on:change={() => catchErrors(onDailyOptionChanged)}
         disabled={$event.startTime.getDay() == 0 || $event.startTime.getDay() == 6}
         />
@@ -37,18 +37,20 @@
         </hbox>
       </hbox>
     {:else if frequency == Frequency.Monthly }
-      <RadioGroup bind:group={week} items={monthWeekOptions} vertical={true} />
-    {:else if frequency == Frequency.Yearly }
-      <RadioGroup bind:group={week} items={yearWeekOptions} vertical={true} />
-    {/if}
+      <RadioGroup value={week} items={monthWeekOptions} vertical={true}
+      on:change={(ev) => catchErrors(() => onWeekChanged(ev.detail))} />
+      {:else if frequency == Frequency.Yearly }
+      <RadioGroup value={week} items={yearWeekOptions} vertical={true}
+        on:change={(ev) => catchErrors(() => onWeekChanged(ev.detail))} />
+      {/if}
   </vbox>
 
   <hbox class="every">
     <label for="every">{$t`Every`}</label>
-    <input class="auto" type="number" min={1} max={99} bind:value={interval} id="every"
-      on:change={() => catchErrors(() => onIntervalChanged)} />
+    <input class="auto" type="number" min={1} max={99} value={interval} id="every"
+      on:change={(ev) => catchErrors(() => onIntervalChanged(ev.currentTarget.value))} />
     <select value={frequency} class="selector"
-      on:change={(ev) => catchErrors(() => onFrequencyChanged(ev.currentTarget?.value))}>
+      on:change={(ev) => catchErrors(() => onFrequencyChanged(ev.currentTarget.value))}>
       <option value={Frequency.Daily}>{$plural(interval, { one: 'day', other: 'days' })}</option>
       <option value={Frequency.Weekly}>{$plural(interval, { one: 'week', other: 'weeks' })}</option>
       <option value={Frequency.Monthly}>{$plural(interval, { one: 'month', other: 'months' })}</option>
@@ -81,7 +83,7 @@
   import RadioGroup, { type RadioOption } from "./RadioGroup.svelte";
   import RoundButton from '../../Shared/RoundButton.svelte';
   import { catchErrors } from "../../Util/error";
-  import { arrayRemove } from '../../../logic/util/util';
+  import { arrayRemove, assert } from '../../../logic/util/util';
   import { getUILocale, t, plural } from "../../../l10n/l10n";
 
   export let event: Event;
@@ -114,13 +116,14 @@
     let weekno = Math.ceil(event.startTime.getDate() / 7);
     if (weekno < 5) {
       let weekname = [$t`first`, $t`second`, $t`third`, $t`fourth`][weekno - 1];
-      yearWeekOptions.push({ label: $t`On the ${weekname} ${weekday} in ${event.startTime.toLocaleDateString(getUILocale(), { month: "long" })}`, value: weekno });
-      monthWeekOptions.push({ label: $t`On the ${weekname} ${weekday}`, value: weekno });
+      yearWeekOptions.push({ label: $t`On the ${weekname} ${weekday} in ${event.startTime.toLocaleDateString(getUILocale(), { month: "long" })} *=> On the third Wednesday in September`, value: weekno });
+      monthWeekOptions.push({ label: $t`On the ${weekname} ${weekday} *=> On the third Wednesday of the month`, value: weekno });
     }
 
     if (isLastWeekOfMonth(event.startTime)) {
-      yearWeekOptions.push({ label: $t`On the last ${weekday} in ${event.startTime.toLocaleDateString(getUILocale(), { month: "long" })}`, value: 5 });
-      monthWeekOptions.push({ label: $t`On the last ${weekday}`, value: 5 });
+      let weekname = $t`last`;
+      yearWeekOptions.push({ label: $t`On the ${weekname} ${weekday} in ${event.startTime.toLocaleDateString(getUILocale(), { month: "long" })} *=> On the third Wednesday in September`, value: 5 });
+      monthWeekOptions.push({ label: $t`On the ${weekname} ${weekday} *=> On the third Wednesday of the month`, value: 5 });
     }
 
     if (week && (week < 5 || yearWeekOptions.length == 2)) {
@@ -165,33 +168,44 @@
     frequency = Frequency.Weekly;
     daily = "everyday";
     master.startEditing();
-    master.newRecurrenceRule(frequency, interval, weekdays, week);
+    master.newRecurrenceRule(frequency, interval, week, weekdays);
+  }
+
+  function onWeekChanged(item: RadioOption) {
+    console.log("on week changed", item, "before", week, "set to", item.value);
+    let newWeek = item.value;
+    master.startEditing();
+    master.newRecurrenceRule(frequency, interval, newWeek, weekdays);
+    console.log("week is now", master.recurrenceRule.week, master.recurrenceRule.frequency);
   }
 
   function onWeekdayChanged(weekday: number) {
-    if (weekdays.includes(weekday)) {
+    if (weekdays.includes(weekday)) { // toggle
       arrayRemove(weekdays, weekday);
     } else {
       weekdays.push(weekday);
     }
     console.log("weekdays changed", weekday, weekdays);
     master.startEditing();
-    master.newRecurrenceRule(frequency, interval, weekdays, week);
+    master.newRecurrenceRule(frequency, interval, week, weekdays);
   }
 
-  function onIntervalChanged() {
+  function onIntervalChanged(newValue: string) {
+    console.log("new interval", newValue, typeof newValue);
+    interval = Number(newValue);
     master.startEditing();
-    master.newRecurrenceRule(frequency, interval, weekdays, week);
+    master.newRecurrenceRule(frequency, interval, week, weekdays);
   }
 
   async function onFrequencyChanged(newValue: string) {
     console.log("frequency changed cur", frequency, "to", newValue);
-    let newFrequency = newValue as Frequency;
-    if (newFrequency == Frequency.None || !newFrequency) {
+    frequency = newValue as Frequency;
+    assert(frequency, "Need frequency");
+    if (frequency == Frequency.None) {
       master.recurrenceRule = null;
-    } else if (newFrequency != master.recurrenceRule?.frequency) {
+    } else if (frequency != master.recurrenceRule?.frequency) {
       master.startEditing();
-      master.newRecurrenceRule(newFrequency, interval, weekdays, week);
+      master.newRecurrenceRule(frequency, interval, week, weekdays);
     }
   }
 </script>

--- a/app/frontend/Calendar/EditEvent/RepeatBox.svelte
+++ b/app/frontend/Calendar/EditEvent/RepeatBox.svelte
@@ -1,10 +1,6 @@
 <SectionTitle label={$t`Repeat`}>
   <hbox>
-<<<<<<< HEAD
-    <select bind:value={frequency} class="selector" on:change={ev => catchErrors(() => onFrequencyChanged(ev.currentTarget.value))}>
-=======
     <select value={frequency} class="selector" on:change={(ev) => catchErrors(() => onFrequencyChanged(ev.currentTarget?.value))}>
->>>>>>> 9a189dfd (Propagate UI changes to event)
       <option value={Frequency.None}>{$t`none`}</option>
       <option value={Frequency.Daily}>{$t`daily`}</option>
       <option value={Frequency.Weekly}>{$t`weekly`}</option>
@@ -83,7 +79,7 @@
   import RoundButton from '../../Shared/RoundButton.svelte';
   import { catchErrors } from "../../Util/error";
   import { arrayRemove } from '../../../logic/util/util';
-  import { catchErrors } from "../../Util/error";
+  import { getUILocale, t, plural } from "../../../l10n/l10n";
 
   export let event: Event;
 

--- a/app/frontend/Calendar/EditEvent/RepeatBox.svelte
+++ b/app/frontend/Calendar/EditEvent/RepeatBox.svelte
@@ -89,7 +89,7 @@
   export let event: Event;
 
   $: master = $event.parentEvent ?? event;
-  $: frequency = $master.recurrenceRule?.frequency ?? Frequency.Weekly;
+  $: frequency = $master.recurrenceRule?.frequency ?? Frequency.None;
   $: interval = $master.recurrenceRule?.interval ?? 1;
   // end // let count = Number.isFinite(event.recurrenceRule?.count) ? event.recurrenceRule.count : 1;
   $: weekdays = $master.recurrenceRule?.weekdays?.slice() ?? [$event.startTime.getDay()];
@@ -195,7 +195,8 @@
   async function onFrequencyChanged(newValue: string) {
     frequency = newValue as Frequency;
     assert(frequency, "Need frequency");
-    if (frequency == Frequency.None) {
+    if (frequency == Frequency.None && master.recurrenceRule) {
+      master.startEditing();
       master.recurrenceRule = null;
     } else if (frequency != master.recurrenceRule?.frequency) {
       master.startEditing();

--- a/app/frontend/Calendar/EditEvent/RepeatBox.svelte
+++ b/app/frontend/Calendar/EditEvent/RepeatBox.svelte
@@ -38,11 +38,11 @@
       </hbox>
     {:else if frequency == Frequency.Monthly }
       <RadioGroup value={week} items={monthWeekOptions} vertical={true}
-      on:change={(ev) => catchErrors(() => onWeekChanged(ev.detail))} />
-      {:else if frequency == Frequency.Yearly }
+        on:change={(ev) => catchErrors(() => onWeekChanged(ev.detail))} />
+    {:else if frequency == Frequency.Yearly }
       <RadioGroup value={week} items={yearWeekOptions} vertical={true}
         on:change={(ev) => catchErrors(() => onWeekChanged(ev.detail))} />
-      {/if}
+    {/if}
   </vbox>
 
   <hbox class="every">
@@ -116,13 +116,13 @@
     if (weekno < 5) {
       let weekname = [$t`first`, $t`second`, $t`third`, $t`fourth`][weekno - 1];
       yearWeekOptions.push({ label: $t`On the ${weekname} ${weekday} in ${event.startTime.toLocaleDateString(getUILocale(), { month: "long" })} *=> On the third Wednesday in September`, value: weekno });
-      monthWeekOptions.push({ label: $t`On the ${weekname} ${weekday} *=> On the third Wednesday of the month`, value: weekno });
+      monthWeekOptions.push({ label: $t`On the ${weekname} ${weekday} *=> On the third Wednesday of each month`, value: weekno });
     }
 
     if (isLastWeekOfMonth(event.startTime)) {
       let weekname = $t`last`;
       yearWeekOptions.push({ label: $t`On the ${weekname} ${weekday} in ${event.startTime.toLocaleDateString(getUILocale(), { month: "long" })} *=> On the third Wednesday in September`, value: 5 });
-      monthWeekOptions.push({ label: $t`On the ${weekname} ${weekday} *=> On the third Wednesday of the month`, value: 5 });
+      monthWeekOptions.push({ label: $t`On the ${weekname} ${weekday} *=> On the third Wednesday of each month`, value: 5 });
     }
 
     if (week && (week < 5 || yearWeekOptions.length == 2)) {

--- a/app/frontend/Calendar/EditEvent/RepeatBox.svelte
+++ b/app/frontend/Calendar/EditEvent/RepeatBox.svelte
@@ -90,7 +90,6 @@
 
   $: master = $event.parentEvent ?? event;
   $: frequency = $master.recurrenceRule?.frequency ?? Frequency.Weekly;
-  $: console.log("frequency", frequency, "master freq", $master.recurrenceRule?.frequency);
   $: interval = $master.recurrenceRule?.interval ?? 1;
   // end // let count = Number.isFinite(event.recurrenceRule?.count) ? event.recurrenceRule.count : 1;
   $: weekdays = $master.recurrenceRule?.weekdays?.slice() ?? [$event.startTime.getDay()];
@@ -172,11 +171,9 @@
   }
 
   function onWeekChanged(item: RadioOption) {
-    console.log("on week changed", item, "before", week, "set to", item.value);
     let newWeek = item.value;
     master.startEditing();
     master.newRecurrenceRule(frequency, interval, newWeek, weekdays);
-    console.log("week is now", master.recurrenceRule.week, master.recurrenceRule.frequency);
   }
 
   function onWeekdayChanged(weekday: number) {
@@ -185,20 +182,17 @@
     } else {
       weekdays.push(weekday);
     }
-    console.log("weekdays changed", weekday, weekdays);
     master.startEditing();
     master.newRecurrenceRule(frequency, interval, week, weekdays);
   }
 
   function onIntervalChanged(newValue: string) {
-    console.log("new interval", newValue, typeof newValue);
     interval = Number(newValue);
     master.startEditing();
     master.newRecurrenceRule(frequency, interval, week, weekdays);
   }
 
   async function onFrequencyChanged(newValue: string) {
-    console.log("frequency changed cur", frequency, "to", newValue);
     frequency = newValue as Frequency;
     assert(frequency, "Need frequency");
     if (frequency == Frequency.None) {

--- a/app/frontend/Calendar/EditEvent/TimeBox.svelte
+++ b/app/frontend/Calendar/EditEvent/TimeBox.svelte
@@ -120,7 +120,6 @@
   export let event: Event;
 
   $: showTimezone = !isMyTimezone($event.timezone);
-  $: console.log("show timezonee", showTimezone, "event timezone", $event.timezone, "is my", isMyTimezone($event.timezone), "my timezone", myTimezone());
   $: $event.endTime, checkEndTime();
   $: isMultipleDays = $event.startTime && $event.endTime &&
     // all day events have the non-inclusive next day as end

--- a/app/logic/Calendar/Event.ts
+++ b/app/logic/Calendar/Event.ts
@@ -1,6 +1,6 @@
 import type { Calendar } from "./Calendar";
 import type { Participant } from "./Participant";
-import { RecurrenceRule } from "./RecurrenceRule";
+import { RecurrenceRule, type RecurrenceInit, Frequency } from "./RecurrenceRule";
 import OutgoingInvitation from "./Invitation/OutgoingInvitation";
 import { InvitationResponse, type InvitationResponseInMessage } from "./Invitation/InvitationStatus";
 import type { MailAccount } from "../Mail/MailAccount";
@@ -310,6 +310,21 @@ export class Event extends Observable {
       this.clearExceptions();
     }
     this.generateRecurringInstances();
+  }
+
+  newRecurrenceRule(frequency: Frequency): void {
+    let init: RecurrenceInit = {
+      masterDuration: this.duration,
+      seriesStartTime: this.startTime,
+      frequency,
+      interval: 1
+    };
+    if (frequency == Frequency.Weekly) {
+      init.weekdays = [this.startTime.getDay()];
+    } else if (frequency == Frequency.Monthly || frequency == Frequency.Yearly) {
+      init.week = 0;
+    }
+    this.recurrenceRule = new RecurrenceRule(init);
   }
 
   /** Create a new instance of the same event.

--- a/app/logic/Calendar/Event.ts
+++ b/app/logic/Calendar/Event.ts
@@ -323,11 +323,11 @@ export class Event extends Observable {
       interval,
     };
     if (frequency == Frequency.Weekly) {
-      init.weekdays = weekdays ?? [this.startTime.getDay()];
+      init.weekdays = weekdays ?? [this.startTime.getDay()]; // e.g. Monday and Thursday
     } else if (frequency == Frequency.Monthly || frequency == Frequency.Yearly) {
       init.week = week;
       if (week) {
-        init.weekdays = [this.startTime.getDay()];
+        init.weekdays = [this.startTime.getDay()]; // e.g. 3rd Wednesday of month
       }
     }
     this.recurrenceRule = new RecurrenceRule(init);

--- a/app/logic/Calendar/Event.ts
+++ b/app/logic/Calendar/Event.ts
@@ -323,6 +323,9 @@ export class Event extends Observable {
       init.weekdays = weekdays ?? [this.startTime.getDay()];
     } else if (frequency == Frequency.Monthly || frequency == Frequency.Yearly) {
       init.week = week;
+      if (week) {
+        init.weekdays = weekdays ?? [this.startTime.getDay()]; // TODO Workaround @see RecurrenceRule.fillOccurrences()
+      }
     }
     this.recurrenceRule = new RecurrenceRule(init);
   }

--- a/app/logic/Calendar/Event.ts
+++ b/app/logic/Calendar/Event.ts
@@ -131,6 +131,7 @@ export class Event extends Observable {
   recurrenceCase = RecurrenceCase.Normal;
   /** Describes the recurrence pattern.
    * Only for RecurrenceCase == Master */
+  @notifyChangedProperty
   protected _recurrenceRule: RecurrenceRule | null = null;
   /** Links back to the recurring master.
    * Only for RecurrenceCase == Instance or Exception */
@@ -312,17 +313,17 @@ export class Event extends Observable {
     this.generateRecurringInstances();
   }
 
-  newRecurrenceRule(frequency: Frequency): void {
+  newRecurrenceRule(frequency: Frequency, interval = 1, weekdays?: number[], week?: number): void {
     let init: RecurrenceInit = {
       masterDuration: this.duration,
       seriesStartTime: this.startTime,
       frequency,
-      interval: 1
+      interval,
     };
     if (frequency == Frequency.Weekly) {
-      init.weekdays = [this.startTime.getDay()];
+      init.weekdays = weekdays ?? [this.startTime.getDay()];
     } else if (frequency == Frequency.Monthly || frequency == Frequency.Yearly) {
-      init.week = 0;
+      init.week = week ?? 0;
     }
     this.recurrenceRule = new RecurrenceRule(init);
   }

--- a/app/logic/Calendar/Event.ts
+++ b/app/logic/Calendar/Event.ts
@@ -291,12 +291,15 @@ export class Event extends Observable {
    * Removes a recurrence pattern and all instances and exceptions.
    */
   protected clearRecurrenceRule() {
-    if (this._recurrenceRule) {
-      // this.clearExceptions(); in finishEditing()
-      this._recurrenceRule = null; // notifies
-      this.recurrenceCase = RecurrenceCase.Normal;
-      this.instances.replaceAll([this]);
+    if (!this._recurrenceRule) {
+      return;
     }
+    // clearExceptions() in finishEditing()
+    this._muteObservers = true;
+    this.recurrenceCase = RecurrenceCase.Normal;
+    this._muteObservers = false;
+    this._recurrenceRule = null; // notifies
+    this.instances.replaceAll([this]);
   }
   /**
    * Updates a recurrence pattern.
@@ -304,10 +307,10 @@ export class Event extends Observable {
    */
   protected setRecurrenceRule(rule: RecurrenceRule) {
     assert(this.recurrenceCase == RecurrenceCase.Normal || this.recurrenceCase == RecurrenceCase.Master, "Instances can't themselves recur");
-    this._recurrenceRule = rule; // notifies
     this._muteObservers = true;
     this.recurrenceCase = RecurrenceCase.Master;
     this._muteObservers = false;
+    this._recurrenceRule = rule; // notifies
     // clearExceptions() as necessary in finishEditing()
     this.generateRecurringInstances();
   }

--- a/app/logic/Calendar/Event.ts
+++ b/app/logic/Calendar/Event.ts
@@ -451,6 +451,12 @@ export class Event extends Observable {
   finishEditing() {
     this.unedited = null;
   }
+  cancelEditing() {
+    if (this.unedited) {
+      this.copyFrom(this.unedited);
+    }
+    this.finishEditing();
+  }
 
   createMeeting() {
     this.outgoingInvitation.createOrganizer();

--- a/app/logic/Calendar/Event.ts
+++ b/app/logic/Calendar/Event.ts
@@ -566,12 +566,14 @@ export class Event extends Observable {
     assert(this.calendar.storage, "To save an event, the calendar needs to be saved first");
     this.calUID ??= crypto.randomUUID();
     await this.calendar.storage.saveEvent(this);
+
     if (this.recurrenceCase == RecurrenceCase.Master) {
       this.generateRecurringInstances();
     } else if (this.recurrenceCase == RecurrenceCase.Instance) {
       this.recurrenceCase = RecurrenceCase.Exception;
       this.parentEvent.instances.remove(this);
       this.parentEvent.exceptions.add(this);
+      await this.parentEvent.save();
     }
   }
 

--- a/app/logic/Calendar/Event.ts
+++ b/app/logic/Calendar/Event.ts
@@ -327,7 +327,7 @@ export class Event extends Observable {
     } else if (frequency == Frequency.Monthly || frequency == Frequency.Yearly) {
       init.week = week;
       if (week) {
-        init.weekdays = weekdays ?? [this.startTime.getDay()]; // TODO Workaround @see RecurrenceRule.fillOccurrences()
+        init.weekdays = [this.startTime.getDay()];
       }
     }
     this.recurrenceRule = new RecurrenceRule(init);

--- a/app/logic/Calendar/RecurrenceRule.ts
+++ b/app/logic/Calendar/RecurrenceRule.ts
@@ -277,7 +277,7 @@ export class RecurrenceRule implements Readonly<RecurrenceInit> {
         };
         break;
       case Frequency.Monthly:
-        if (!this.weekdays) {
+        if (!this.weekdays) { // TODO Why weekdays?
           this.month += this.interval;
         } else {
           this.day++;
@@ -288,7 +288,7 @@ export class RecurrenceRule implements Readonly<RecurrenceInit> {
         }
         break;
       case Frequency.Yearly:
-        if (!this.weekdays) {
+        if (!this.weekdays) { // TODO Why weekdays?
           this.year += this.interval;
         } else {
           this.day++;

--- a/app/logic/Calendar/RecurrenceRule.ts
+++ b/app/logic/Calendar/RecurrenceRule.ts
@@ -237,7 +237,8 @@ export class RecurrenceRule implements Readonly<RecurrenceInit> {
     if (this.occurrences.length < this.count && this.occurrences.at(-1)! < seriesEndTime) {
       this.fillOccurrences(this.count, seriesEndTime);
     }
-    return this.occurrences.filter(date => date >= seriesStartTime && date <= seriesEndTime);
+    return this.occurrences;
+    //return this.occurrences.filter(date => date >= seriesStartTime && date <= seriesEndTime);
   }
 
   getOccurrenceByIndex(index: number): Date | void {

--- a/app/logic/Calendar/RecurrenceRule.ts
+++ b/app/logic/Calendar/RecurrenceRule.ts
@@ -203,6 +203,9 @@ export class RecurrenceRule implements Readonly<RecurrenceInit> {
    * this still (intentionally) returns false.
    */
   timesMatch(rule: RecurrenceRule) {
+    if (!rule) {
+      return false;
+    }
     // Must be fast, because it's used by `event.hasChanged()`
     const allWeekdays = [0, 1, 2, 3, 4, 5, 6];
     let thisWeekdays = this.weekdays || allWeekdays;

--- a/app/logic/Calendar/RecurrenceRule.ts
+++ b/app/logic/Calendar/RecurrenceRule.ts
@@ -277,7 +277,7 @@ export class RecurrenceRule implements Readonly<RecurrenceInit> {
         };
         break;
       case Frequency.Monthly:
-        if (!this.weekdays) { // TODO Why weekdays?
+        if (!this.week) {
           this.month += this.interval;
         } else {
           this.day++;
@@ -288,7 +288,7 @@ export class RecurrenceRule implements Readonly<RecurrenceInit> {
         }
         break;
       case Frequency.Yearly:
-        if (!this.weekdays) { // TODO Why weekdays?
+        if (!this.week) {
           this.year += this.interval;
         } else {
           this.day++;


### PR DESCRIPTION
The old code was saving the changes in local variables in the UI, and then pushed it to the event on save. There are at least 2 problems with that:
1. It's against our general idea to a) apply changes directly on the object and b) that changes show up immediately in the rest of the app, whenever possible
2. More importantly, the `let foo =` in RepeatBox.svelte meant that the calendar edit dialog in the sidebar would not refresh and show the values of the previously selected event. This is because `let foo =` is run only when the component is instantiated. Later changes to the properties do *not* re-run that code, and therefore, the variables were not updated to the new data. To fix that, we need to use `$:`, which re-runs the line whenever one of the values changes (as far as Svelte knows, i.e. properties and local vars with assignment, i.e. anywhere on the left side of `=`,  including `foo` in `foo.bar = ...`, and observables with `$`).

However, once I changed to `$:`, the values could not be updated properly by simply writing to them using `bind:value={...}`. Probably, because they were re-calculated from the `event.recurrenceRule` before the latter could be changed.

So, instead of using `bind:`, this is now using `onFooChanged()` user input handlers, which is uglier and more code, and I'm not happy with it, but at least creates a well-defined code path.

This also immediately creates a new `RecurrenceRule` when the user makes changes, and applies it on the event, which means that the change shows in the user's calendar immediately. When he clicks [Revert], we use `unedited` on the master as well to restore the original state.

(Unfortunately, this "immediately see in your calendar" doesn't work for new events yet, simply because they are not yet added to the calendar. This should be fixable.)

This also moves some logic from the UI into the `Event` implementation.