### PR TITLE
Fix errors in 6ee24df

### DIFF
--- a/app/logic/Calendar/ActiveSync/ActiveSyncIncomingInvitation.ts
+++ b/app/logic/Calendar/ActiveSync/ActiveSyncIncomingInvitation.ts
@@ -1,6 +1,5 @@
 import { IncomingInvitation } from "../Invitation/IncomingInvitation";
 import { InvitationMessage, InvitationResponse, type InvitationResponseInMessage } from "../Invitation/InvitationStatus";
-import { ActiveSyncEvent } from "./ActiveSyncEvent";
 import type { ActiveSyncCalendar } from "./ActiveSyncCalendar";
 import type { ActiveSyncEMail } from "../../Mail/ActiveSync/ActiveSyncEMail";
 import { assert } from "../../util/util";
@@ -12,9 +11,8 @@ const ActiveSyncResponse: Record<InvitationResponseInMessage, number> = {
 };
 
 export class ActiveSyncIncomingInvitation extends IncomingInvitation {
-  declare calendar: ActiveSyncCalendar;
-  declare message: ActiveSyncEMail;
-  declare event: ActiveSyncEvent;
+  declare readonly calendar: ActiveSyncCalendar;
+  declare readonly message: ActiveSyncEMail;
 
   async respondToInvitation(response: InvitationResponseInMessage) {
     assert(this.invitationMessage == InvitationMessage.Invitation, "Only invitations can be responded to");
@@ -27,8 +25,7 @@ export class ActiveSyncIncomingInvitation extends IncomingInvitation {
     };
     await this.calendar.account.callEAS("MeetingResponse", request);
     this.event.myParticipation = response;
-    await this.event.respondToInvitation(response); // needs 16.x to do this automatically
-    await this.event.save();
+    await this.event.respondToInvitation(response, this.calendar.account); // needs 16.x to do this automatically
     await this.message.deleteMessageLocally(); // Exchange deletes the message from the inbox
     await this.calendar.listEvents(); // Exchange will have created a calendar item if there wasn't one already
   }

--- a/app/logic/Calendar/EWS/EWSIncomingInvitation.ts
+++ b/app/logic/Calendar/EWS/EWSIncomingInvitation.ts
@@ -1,6 +1,5 @@
 import { IncomingInvitation } from "../Invitation/IncomingInvitation";
 import { InvitationMessage, InvitationResponse, type InvitationResponseInMessage } from "../Invitation/InvitationStatus";
-import type { EWSEvent } from "./EWSEvent";
 import type { EWSCalendar } from "./EWSCalendar";
 import type { EWSEMail } from "../../Mail/EWS/EWSEMail";
 import EWSCreateItemRequest from "../../Mail/EWS/Request/EWSCreateItemRequest";
@@ -13,10 +12,8 @@ const ResponseTypes: Record<InvitationResponseInMessage, string> = {
 };
 
 export class EWSIncomingInvitation extends IncomingInvitation {
-  declare calendar: EWSCalendar;
-  declare message: EWSEMail;
-  declare event: EWSEvent;
-  myParticipation: InvitationResponse;
+  declare readonly calendar: EWSCalendar;
+  declare readonly message: EWSEMail;
 
   async respondToInvitation(response: InvitationResponseInMessage) {
     assert(this.invitationMessage == InvitationMessage.Invitation, "Only invitations can be responded to");

--- a/app/logic/Calendar/OWA/OWAIncomingInvitation.ts
+++ b/app/logic/Calendar/OWA/OWAIncomingInvitation.ts
@@ -1,7 +1,7 @@
 import { IncomingInvitation } from "../Invitation/IncomingInvitation";
 import { InvitationMessage, InvitationResponse, type InvitationResponseInMessage } from "../Invitation/InvitationStatus";
-import type { OWAEvent } from "./OWAEvent";
 import type { OWACalendar } from "./OWACalendar";
+import type { OWAEvent } from "./OWAEvent";
 import type { OWAEMail } from "../../Mail/OWA/OWAEMail";
 import OWACreateItemRequest from "../../Mail/OWA/Request/OWACreateItemRequest";
 import { assert } from "../../util/util";
@@ -14,14 +14,14 @@ const ResponseTypes: Record<InvitationResponseInMessage, string> = {
 };
 
 export class OWAIncomingInvitation extends IncomingInvitation {
-  declare calendar: OWACalendar;
-  declare message: OWAEMail;
-  declare event: OWAEvent;
+  declare readonly calendar: OWACalendar;
+  declare readonly message: OWAEMail;
   readonly itemID: string | void;
 
   constructor(calendar: OWACalendar, message: OWAEMail) {
     super(calendar, message);
-    this.itemID = this.event?.itemID;
+    let event = calendar.events.find(event => event.calUID == this.event.calUID);
+    this.itemID = event?.itemID;
   }
 
   async respondToInvitation(response: InvitationResponseInMessage) {


### PR DESCRIPTION
Although it fixed all but one of the TypeScript errors, it introduced new logic errors.
- `event` is the message's pseudo-event, so it's always an `Event` type (`OWAIncomingInvitation` wants the `calEvent`)
- `ActiveSyncIncomingInvitation` needs to specify the account when responding to the invitation
- `ActiveSyncIncomingInvitation` should not be trying to save the pseudo-event

I would be tempted to change `IncomingInvitation.prototype.calEvent()` from a getter back to a property like I did in #711, since it's used by its constructor and also `OWAIncomingInvitation`'s constructor and they're both recalculating it each time (the previous constructor didn't of course because it wasn't inheriting).