### PR TITLE
Create InvitationEvent subclass for events used for iMip

### DIFF
--- a/app/logic/Calendar/Event.ts
+++ b/app/logic/Calendar/Event.ts
@@ -2,6 +2,7 @@ import type { Calendar } from "./Calendar";
 import type { Participant } from "./Participant";
 import { RecurrenceRule, type RecurrenceInit, Frequency } from "./RecurrenceRule";
 import OutgoingInvitation from "./Invitation/OutgoingInvitation";
+import { InvitationEvent } from "./Invitation/InvitationEvent";
 import { InvitationResponse, type InvitationResponseInMessage } from "./Invitation/InvitationStatus";
 import type { MailAccount } from "../Mail/MailAccount";
 import type { MailIdentity } from "../Mail/MailIdentity";
@@ -696,7 +697,7 @@ export class Event extends Observable {
     email.from.name = myParticipant.name || email.from.name;
     email.to.add(organizer);
     email.iCalMethod = "REPLY";
-    email.event = new Event();
+    email.event = new InvitationEvent();
     email.event.copyFrom(this);
     // Only myself in reply: RFC 5546 3.2.3
     email.event.participants.replaceAll([myParticipant]);

--- a/app/logic/Calendar/ICal/ICalEMailProcessor.ts
+++ b/app/logic/Calendar/ICal/ICalEMailProcessor.ts
@@ -1,5 +1,5 @@
 import ICalParser from "./ICalParser";
-import { Event } from "../Event";
+import { InvitationEvent } from "../Invitation/InvitationEvent";
 import type { EMail } from "../../Mail/EMail";
 import { InvitationMessage } from "../Invitation/InvitationStatus";
 import { EMailProcessor, ProcessingStartOn } from "../../Mail/EMailProccessor";
@@ -15,7 +15,7 @@ export class ICalEMailProcessor extends EMailProcessor {
     let invitationStr = await invitationBlob.text();
     let ics = new ICalParser(invitationStr);
     email.invitationMessage = iTIPMethod(ics);
-    let event = new Event();
+    let event = new InvitationEvent();
     let isEvent = convertICalParserToEvent(ics, event);
     if (!isEvent) {
       return;

--- a/app/logic/Calendar/Invitation/InvitationEvent.ts
+++ b/app/logic/Calendar/Invitation/InvitationEvent.ts
@@ -1,0 +1,25 @@
+import { Event } from "../Event";
+
+export class InvitationEvent extends Event {
+  constructor() {
+    super();
+  }
+  async save(): Promise<never> {
+    throw new Error("InvitationEvent holds a temporary copy of event data for incoming and outgoing invitations only");
+  }
+  async saveLocally(): Promise<never> {
+    throw new Error("InvitationEvent holds a temporary copy of event data for incoming and outgoing invitations only");
+  }
+  async saveToServer(): Promise<never> {
+    throw new Error("InvitationEvent holds a temporary copy of event data for incoming and outgoing invitations only");
+  }
+  async deleteIt(): Promise<never> {
+    throw new Error("InvitationEvent holds a temporary copy of event data for incoming and outgoing invitations only");
+  }
+  async deleteLocally(): Promise<never> {
+    throw new Error("InvitationEvent holds a temporary copy of event data for incoming and outgoing invitations only");
+  }
+  async deleteFromServer(): Promise<never> {
+    throw new Error("InvitationEvent holds a temporary copy of event data for incoming and outgoing invitations only");
+  }
+}


### PR DESCRIPTION
As requested in #717.

(I guess the other approach would be to have the `Event` be a subclass of `InvitationEvent`, but that would mean moving the saving and deletion functions.)