### PR TITLE
Fix bugs handling remainder of series #725 #729

### DIFF
--- a/app/frontend/Calendar/EditEvent/DialogHeader.svelte
+++ b/app/frontend/Calendar/EditEvent/DialogHeader.svelte
@@ -239,8 +239,14 @@
     master.startEditing();
     master.copyEditableFieldsFrom(event);
     master.calUID = null;
+    if (event.parentEvent.recurrenceRule) {
+      let { frequency, interval, week, weekdays } = event.parentEvent.recurrenceRule;
+      master.newRecurrenceRule(frequency, interval, week, weekdays);
+    }
     await saveEvent(master);
     master.finishEditing();
+    event.parentEvent.cancelEditing();
+    event.cancelEditing();
     await event.truncateRecurrence();
     onClose();
   }
@@ -272,6 +278,8 @@
   }
 
   async function onDeleteRemainder() {
+    event.parentEvent.cancelEditing();
+    event.cancelEditing();
     await event.truncateRecurrence();
     $selectedEvent = null;
     onClose();

--- a/app/logic/Calendar/Event.ts
+++ b/app/logic/Calendar/Event.ts
@@ -526,16 +526,17 @@ export class Event extends Observable {
     // Normally the parent of an instance would always have a
     // recurrence rule, but this might get removed during saving,
     // and would cause Svelte to crash if we didn't handle it.
-    let rule = this.parentEvent?.recurrenceRule;
+    let master = this.parentEvent?.unedited ?? this.parentEvent;
+    let rule = master?.recurrenceRule;
     if (!rule) {
       return "none";
     }
-    if (rule.countIs(this.parentEvent.exclusions.length + 1)) {
+    if (rule.countIs(master.exclusions.length + 1)) {
       return "only";
     }
     // Not supporting "last" any more; fortunately nobody needs it
     // (it's prohibitively expensive to compute these days)
-    return this.isNew ? this == this.parentEvent.instances.first ? "first" : "middle" : "exception";
+    return this.isNew ? this.recurrenceStartTime.getDate() == master.instances.first.recurrenceStartTime.getDate() ? "first" : "middle" : "exception";
   }
 
   /**


### PR DESCRIPTION
Prior to #725, a recurring master's rule didn't get updated until you clicked save. This meant that `onChangeRemainder` would automatically pick up the new rule as it saved the new series, while `Event.seriesStatus` and `Event.truncateRecurrence` were both relying on the master's rule being unedited. `onChangeRemainder` now has to clone the rule, if it wasn't turned off, `Event.seriesStatus` has to now check the unedited state, while for `Event.truncateRecurrence` I just cancel editing to simplify matters. Furthermore, `Event.seriesStatus` suffered the double whammy of an unedited instance not being able to find itself in its master's instance list, presumably due to the recent more dynamic instance generation changes.