### PR TITLE
New recurrence rule APIs for finding nearby occurrences #750

### DIFF
--- a/app/logic/Calendar/RecurrenceRule.test.ts
+++ b/app/logic/Calendar/RecurrenceRule.test.ts
@@ -9,8 +9,11 @@ function check(calString: string, data: Partial<RecurrenceInit>, expected: [numb
     let ruleFromString = RecurrenceRule.fromCalString(36e5, data.seriesStartTime as Date, calString);
     expect(rule).toEqual(ruleFromString);
   }
-  expect(rule.getOccurrenceByIndex(1)).toEqual(new Date(...expected[1]));
-  expect(rule.getOccurrencesByDate(new Date(2010, 10, 10))).toEqual(expected.map(args => new Date(...args)));
+  let expectedDates = expected.map(args => new Date(...args));
+  expect(rule.getOccurrenceBefore(expectedDates[1])).toEqual(expectedDates[0]);
+  expect(rule.getOccurrenceByIndex(1)).toEqual(expectedDates[1]);
+  expect(rule.getOccurrenceAfter(expectedDates[1])).toEqual(expectedDates[2]);
+  expect(rule.getOccurrencesByDate(new Date(2010, 10, 10))).toEqual(expectedDates);
 }
 
 test("Daily with interval and end date", () => {

--- a/app/logic/Calendar/RecurrenceRule.ts
+++ b/app/logic/Calendar/RecurrenceRule.ts
@@ -235,13 +235,28 @@ export class RecurrenceRule implements Readonly<RecurrenceInit> {
     return this.occurrences[count - 1] != null && this.occurrences[count] == null;
   }
 
-  getOccurrencesByDate(seriesEndTime: Date, seriesStartTime: Date = this.seriesStartTime): Date[] {
-    if (this.seriesEndTime && this.seriesEndTime < seriesEndTime) {
-      seriesEndTime = this.seriesEndTime;
-    }
-    if (this.occurrences.length < this.count && this.occurrences.at(-1)! < seriesEndTime) {
-      this.fillOccurrences(this.count, seriesEndTime);
-    }
+  getOccurrenceAfter(date: Date): Date | undefined {
+    this.fillOccurrences(this.count, date);
+    return this.occurrences.find(occurrence => occurrence > date);
+  }
+
+  getOccurrenceBefore(date: Date): Date | undefined {
+    this.fillOccurrences(this.count, date);
+    return this.occurrences.findLast(occurrence => occurrence < date);
+  }
+
+  getOccurrenceNotAfter(date: Date): Date | undefined {
+    this.fillOccurrences(this.count, date);
+    return this.occurrences.findLast(occurrence => occurrence <= date);
+  }
+
+  getOccurrenceNotBefore(date: Date): Date | undefined {
+    this.fillOccurrences(this.count, date);
+    return this.occurrences.find(occurrence => occurrence >= date);
+  }
+
+  getOccurrencesByDate(seriesEndTime: Date/*, seriesStartTime: Date = this.seriesStartTime*/): Date[] {
+    this.fillOccurrences(this.count, seriesEndTime);
     return this.occurrences;
     //return this.occurrences.filter(date => date >= seriesStartTime && date <= seriesEndTime);
   }
@@ -257,14 +272,12 @@ export class RecurrenceRule implements Readonly<RecurrenceInit> {
     if (this.seriesEndTime && this.seriesEndTime < date) {
       return -1;
     }
-    if (this.occurrences.length < this.count && this.occurrences.at(-1)! < date) {
-      this.fillOccurrences(this.count, date);
-    }
+    this.fillOccurrences(this.count, date);
     return this.occurrences.findIndex(d => d.getTime() == date.getTime());
   }
 
-  fillOccurrences(count: number, seriesEndTime?: Date) {
-    while (this.occurrences.length < count) {
+  fillOccurrences(count: number, date?: Date) {
+    while (this.occurrences.length < count && (!date || this.occurrences.at(-1)! <= date)) {
       switch (this.frequency) {
       case Frequency.Daily:
         this.day += this.interval;
@@ -320,15 +333,16 @@ export class RecurrenceRule implements Readonly<RecurrenceInit> {
         occurrence.setDate(-6);
         this.day = occurrence.getDate();
       }
-      if (seriesEndTime && occurrence > seriesEndTime) {
-        break;
-      }
       if (this.weekdays && !this.weekdays.includes(occurrence.getDay())) {
         continue;
       }
       if ((this.frequency == Frequency.Yearly || this.frequency == Frequency.Monthly) && occurrence.getDate() != this.day) {
         // Ran out of days in the month, so rewind to the last day in the month.
         occurrence.setDate(0);
+      }
+      // Don't allow more occurrences than the series wants
+      if (this.seriesEndTime && occurrence > this.seriesEndTime) {
+        break;
       }
       this.occurrences.push(occurrence);
     }


### PR DESCRIPTION
The tests uncovered a bug in `fillOccurrences` so I tweaked it and made it easier to use. At that point, it made creating all of the variations trivial, as `fillOccurrences` now guarantees to fill to the next occurrence if there is one. (Note that this breaks `JSONEvent` even more than it is already.)