### PR TITLE
New master event API for changing recurrence rule length #750

### DIFF
--- a/app/logic/Calendar/RecurrenceRule.ts
+++ b/app/logic/Calendar/RecurrenceRule.ts
@@ -246,7 +246,7 @@ export class RecurrenceRule implements Readonly<RecurrenceInit> {
     //return this.occurrences.filter(date => date >= seriesStartTime && date <= seriesEndTime);
   }
 
-  getOccurrenceByIndex(index: number): Date | void {
+  getOccurrenceByIndex(index: number): Date | undefined {
     if (!this.occurrences[index] && index < this.count) {
       this.fillOccurrences(index + 1);
     }


### PR DESCRIPTION
Please note that the count is exclusive but the end time is inclusive, so to delete the remainder of series you either need to set the count to the index of the instance or the end time to the recurrence start time of the previous instance.