### PR TITLE
Don't change the organiser's response type

### DIFF
--- a/app/logic/Calendar/ActiveSync/ActiveSyncEvent.ts
+++ b/app/logic/Calendar/ActiveSync/ActiveSyncEvent.ts
@@ -76,16 +76,15 @@ export class ActiveSyncEvent extends Event {
       for (let attendee of attendees) {
         attendee.Email = sanitize.emailAddress(attendee.Email);
       }
-      let status = this.isCancelled ? InvitationResponse.Decline : InvitationResponse.Organizer;
       let organizerEmail = sanitize.emailAddress(wbxmljs.OrganizerEmail);
       let organizer = attendees.find(attendee => attendee.Email == organizerEmail);
       if (organizer) {
-        organizer.AttendeeStatus = status;
+        organizer.AttendeeStatus = InvitationResponse.Organizer;
       } else {
         attendees.unshift({
           Email: organizerEmail,
           Name: sanitize.label(wbxmljs.OrganizerName),
-          AttendeeStatus: status
+          AttendeeStatus: InvitationResponse.Organizer,
         });
       }
     }

--- a/app/logic/Calendar/EWS/EWSEvent.ts
+++ b/app/logic/Calendar/EWS/EWSEvent.ts
@@ -103,7 +103,7 @@ export class EWSEvent extends Event {
     let participants: Participant[] = [];
     if (xmljs.Organizer && (xmljs.RequiredAttendees?.Attendee || xmljs.OptionalAttendees?.Attendee)) {
       organizer = sanitize.emailAddress(xmljs.Organizer.Mailbox.EmailAddress);
-      xmljs.Organizer.ResponseType = this.isCancelled ? "Decline" : "Organizer";
+      xmljs.Organizer.ResponseType = "Organizer";
       addParticipants(xmljs.Organizer, participants);
     }
     if (xmljs.RequiredAttendees?.Attendee) {

--- a/app/logic/Calendar/Invitation/IncomingInvitation.ts
+++ b/app/logic/Calendar/Invitation/IncomingInvitation.ts
@@ -38,10 +38,6 @@ export class IncomingInvitation {
       return;
     }
     event.isCancelled = true;
-    let organizer = event.participants.find(participant => participant.response == InvitationResponse.Organizer);
-    if (organizer) {
-      organizer.response = InvitationResponse.Decline;
-    }
     event.lastUpdateTime = this.event.lastUpdateTime;
     await event.save();
   }

--- a/app/logic/Calendar/OWA/OWAEvent.ts
+++ b/app/logic/Calendar/OWA/OWAEvent.ts
@@ -101,7 +101,7 @@ export class OWAEvent extends Event {
     let participants: Participant[] = [];
     if (json.Organizer && (json.RequiredAttendees || json.OptionalAttendees)) {
       organizer = sanitize.emailAddress(json.Organizer.Mailbox.EmailAddress);
-      json.Organizer.ResponseType = this.isCancelled ? "Decline" : "Organizer";
+      json.Organizer.ResponseType = "Organizer";
       addParticipants([json.Organizer], participants);
     }
     if (json.RequiredAttendees) {


### PR DESCRIPTION
Everything has switched to `isCancelled` so we don't need this any more. Plus, it means we don't generate malformed CalDAV events.