### PR TITLE
MailSetup: Assign emailAddress and password from Manual Config #309

### DIFF
--- a/app/frontend/Setup/Mail/SetupMail.svelte
+++ b/app/frontend/Setup/Mail/SetupMail.svelte
@@ -182,7 +182,6 @@
       if (!await manualConfigEl.onContinue()) {
         return;
       }
-      fillConfig(config, emailAddress, password);
       errorMessage = null;
       step = Step.CheckConfig;
     } else if (step == Step.CheckConfig) {

--- a/app/logic/Mail/AutoConfig/checkConfig.ts
+++ b/app/logic/Mail/AutoConfig/checkConfig.ts
@@ -2,7 +2,9 @@ import type { MailAccount } from "../MailAccount";
 import { fillConfig } from "./saveConfig";
 
 export async function checkConfig(config: MailAccount, emailAddress: string, password: string): Promise<void> {
-  fillConfig(config, emailAddress, password);
+  if (config.source != "manual") {
+    fillConfig(config, emailAddress, password);
+  }
   console.log("Checking new mail account", config);
   try {
     await config.verifyLogin();
@@ -16,7 +18,7 @@ export async function checkConfig(config: MailAccount, emailAddress: string, pas
       await config.outgoing.verifyLogin();
     } catch (ex) {
       if (config.isLoggedIn) {
-        await config.logout();        
+        await config.logout();
       }
       config.outgoing.fatalError = ex;
       throw ex;

--- a/app/logic/Mail/AutoConfig/saveConfig.ts
+++ b/app/logic/Mail/AutoConfig/saveConfig.ts
@@ -15,7 +15,9 @@ export async function saveAndInitConfig(config: MailAccount, emailAddress: strin
 }
 
 export async function saveConfig(config: MailAccount, emailAddress: string, password: string): Promise<void> {
-  fillConfig(config, emailAddress, password);
+  if (config.source != "manual") {
+    fillConfig(config, emailAddress, password);
+  }
 
   let identity = new MailIdentity(config);
   identity.realname = config.realname;


### PR DESCRIPTION
- In SetupMail we were using `emailAddress` and `password` instead of `config.emailAddress` and `config.password` and `<CheckConfig />` uses `emailAddress` and `password`

https://github.com/mustang-im/mustang/blob/ba202c17bee1c70ac0c3dd4f5835416aea9b14f8/app/frontend/Setup/Mail/SetupMail.svelte#L22

- So I just set it to that `emailAddress` to `config.emailAddress` since everywhere else seems to be using that.