### PR TITLE
Prevent slow functions from being reentered

### DIFF
--- a/app/logic/util/RunOnce.ts
+++ b/app/logic/util/RunOnce.ts
@@ -1,0 +1,26 @@
+/**
+ * Wrapper around a slow async function to prevent it from being re-entered.
+ * Call maybeRun() to attempt to invoke the async function.
+ * Unlike Semaphore, attempting re-entrancy does nothing.
+ * XXX need better name
+ */
+export class RunOnce {
+  func: () => void;
+  running: boolean = false;
+
+  constructor(func) {
+    this.func = func;
+  }
+
+  async maybeRun() {
+    if (this.running) {
+      return;
+    }
+    try {
+      this.running = true;
+      await this.func();
+    } finally {
+      this.running = false;
+    }
+  }
+}


### PR DESCRIPTION
In particular, `listContacts` and `listEvents` are relatively slow on OWA, so we don't want to accidentally run them when they're already running.