### PR TITLE
Fix getOccurrenceByDate might return the wrong occurence #725

### DIFF
--- a/app/logic/Calendar/Event.ts
+++ b/app/logic/Calendar/Event.ts
@@ -498,7 +498,7 @@ export class Event extends Observable {
     let index = this.recurrenceRule.getIndexOfOccurrence(recurrenceStartTime);
     assert(index != -1, "occurrence date not in recurrence");
     this.generateRecurringInstances(recurrenceStartTime);
-    return this.instances.last;
+    return this.instances.find(event => event.recurrenceStartTime.getTime() == recurrenceStartTime.getTime());
   }
 
   protected makeExclusionLocally(recurrenceStartTime: Date) {


### PR DESCRIPTION
#725 changed `RecurrenceRule.getOccurrencesByDate` to return all of the cached occurrences, not just filtered down to the desired date.

Unfortunately `Event.getOccurenceByDate` (added in #663) was relying on `generateRecurrences` to only generate the exact number of occurrences.

(Because #663 removed the 1-1 correspondence between recurrence rule occurrences and instances, I don't have any better way of finding the right instance.)