### PR TITLE
EWS, OWA, ActiveSync: Accept an instance of a recurring meeting

### DIFF
--- a/app/logic/Calendar/ActiveSync/ActiveSyncEvent.ts
+++ b/app/logic/Calendar/ActiveSync/ActiveSyncEvent.ts
@@ -247,10 +247,16 @@ export class ActiveSyncEvent extends Event {
   async respondToInvitation(response: InvitationResponseInMessage): Promise<void> {
     assert(this.isIncomingMeeting, "Only invitations can be responded to");
     let request = {
-      Request: {
+      // TODO support ActiveSync 14.0
+      Request: this.serverID ? {
         UserResponse: ActiveSyncResponse[response],
         CollectionId: this.calendar.serverID,
         RequestId: this.serverID,
+      } : {
+        UserResponse: ActiveSyncResponse[response],
+        CollectionId: this.calendar.serverID,
+        RequestId: this.parentEvent.serverID,
+        InstanceId: this.recurrenceStartTime.toISOString(),
       },
     };
     await this.calendar.account.callEAS("MeetingResponse", request);

--- a/app/logic/Calendar/EWS/EWSEvent.ts
+++ b/app/logic/Calendar/EWS/EWSEvent.ts
@@ -404,7 +404,7 @@ export class EWSEvent extends Event {
     // Unfortunately this API won't take an OccurrenceItemId directly.
     if (!itemID) {
       // In case the invitation is for a single instance of a recurring meeting
-      assert(this.recurrenceCase == RecurrenceCase.Instance, "must be an instance");
+      assert(this.recurrenceCase == RecurrenceCase.Instance, "must be an instance, or have an itemID");
       let request = {
         m$GetItem: {
           m$ItemShape: {

--- a/app/logic/Calendar/EWS/EWSEvent.ts
+++ b/app/logic/Calendar/EWS/EWSEvent.ts
@@ -403,6 +403,7 @@ export class EWSEvent extends Event {
     let itemID = this.itemID;
     // Unfortunately this API won't take an OccurrenceItemId directly.
     if (!itemID) {
+      // In case the invitation is for a single instance of a recurring meeting
       assert(this.recurrenceCase == RecurrenceCase.Instance, "must be an instance");
       let request = {
         m$GetItem: {

--- a/app/logic/Calendar/OWA/OWAEvent.ts
+++ b/app/logic/Calendar/OWA/OWAEvent.ts
@@ -376,7 +376,7 @@ export class OWAEvent extends Event {
     // Unfortunately this API won't take an OccurrenceItemId directly.
     if (!itemID) {
       // In case the invitation is for a single instance of a recurring meeting
-      assert(this.recurrenceCase == RecurrenceCase.Instance, "must be an instance");
+      assert(this.recurrenceCase == RecurrenceCase.Instance, "must be an instance, or have an itemID");
       let request = owaGetOccurrenceIdRequest(this);
       let response = await this.calendar.account.callOWA(request);
       itemID = sanitize.nonemptystring(response.Items[0].ItemId.Id);

--- a/app/logic/Calendar/OWA/OWAEvent.ts
+++ b/app/logic/Calendar/OWA/OWAEvent.ts
@@ -1,4 +1,4 @@
-import { Event } from "../Event";
+import { Event, RecurrenceCase } from "../Event";
 import { Participant } from "../Participant";
 import { InvitationResponse, type InvitationResponseInMessage } from "../Invitation/InvitationStatus";
 import { Frequency, Weekday, RecurrenceRule } from "../RecurrenceRule";
@@ -12,7 +12,7 @@ import { OWAUpdateOffice365OccurrenceRequest } from "./Request/OWAUpdateOffice36
 import { OWACreateItemRequest } from "../../Mail/OWA/Request/OWACreateItemRequest";
 import { OWADeleteItemRequest } from "../../Mail/OWA/Request/OWADeleteItemRequest";
 import { OWAUpdateItemRequest } from "../../Mail/OWA/Request/OWAUpdateItemRequest";
-import { owaCreateExclusionRequest, owaCreateMultipleExclusionsRequest, owaGetEventUIDsRequest, owaOnlineMeetingDescriptionRequest, owaOnlineMeetingURLRequest, owaGetCalendarEventsRequest, owaGetEventsRequest } from "./Request/OWAEventRequests";
+import { owaCreateExclusionRequest, owaCreateMultipleExclusionsRequest, owaGetEventUIDsRequest, owaOnlineMeetingDescriptionRequest, owaOnlineMeetingURLRequest, owaGetCalendarEventsRequest, owaGetEventsRequest, owaGetOccurrenceIdRequest } from "./Request/OWAEventRequests";
 import { k1MinuteMS } from "../../../frontend/Util/date";
 import { ArrayColl } from "svelte-collections";
 import { sanitize } from "../../../../lib/util/sanitizeDatatypes";
@@ -372,14 +372,22 @@ export class OWAEvent extends Event {
 
   async respondToInvitation(response: InvitationResponseInMessage): Promise<void> {
     assert(this.isIncomingMeeting, "Only invitations can be responded to");
+    let itemID = this.itemID;
+    // Unfortunately this API won't take an OccurrenceItemId directly.
+    if (!itemID) {
+      assert(this.recurrenceCase == RecurrenceCase.Instance, "must be an instance");
+      let request = owaGetOccurrenceIdRequest(this);
+      let response = await this.calendar.account.callOWA(request);
+      itemID = sanitize.nonemptystring(response.Items[0].ItemId.Id);
+    }
     let request = new OWACreateItemRequest({MessageDisposition: "SendAndSaveCopy"});
     request.addField(ResponseTypes[response], "ReferenceItemId", {
       __type: "ItemId:#Exchange",
-      Id: this.itemID,
+      Id: itemID,
     });
     await this.calendar.account.callOWA(request);
     try {
-      await this.calendar.getEvents([this.itemID], new ArrayColl<OWAEvent>());
+      await this.calendar.getEvents([itemID], new ArrayColl<OWAEvent>(), this.parentEvent);
     } catch (ex) {
       if (ex.type == "ErrorItemNotFound") { // expected
         await this.deleteLocally(); // OWA deleted the event from the server

--- a/app/logic/Calendar/OWA/OWAEvent.ts
+++ b/app/logic/Calendar/OWA/OWAEvent.ts
@@ -375,6 +375,7 @@ export class OWAEvent extends Event {
     let itemID = this.itemID;
     // Unfortunately this API won't take an OccurrenceItemId directly.
     if (!itemID) {
+      // In case the invitation is for a single instance of a recurring meeting
       assert(this.recurrenceCase == RecurrenceCase.Instance, "must be an instance");
       let request = owaGetOccurrenceIdRequest(this);
       let response = await this.calendar.account.callOWA(request);

--- a/app/logic/Calendar/OWA/Request/OWAEventRequests.ts
+++ b/app/logic/Calendar/OWA/Request/OWAEventRequests.ts
@@ -1,6 +1,21 @@
 import { OWARequest } from "../../../Mail/OWA/Request/OWARequest";
 import type { OWAEvent } from "../OWAEvent";
 
+export function owaGetOccurrenceIdRequest(event: OWAEvent): OWARequest {
+  return new OWARequest("GetItem", {
+    __type: "GetItemRequest:#Exchange",
+    ItemShape: {
+      __type: "ItemResponseShape:#Exchange",
+      BaseShape: "IdOnly",
+    },
+    ItemIds: [{
+      __type: "OccurrenceItemId:#Exchange",
+      RecurringMasterId: event.parentEvent.itemID,
+      InstanceIndex: event.parentEvent.recurrenceRule.getIndexOfOccurrence(event.recurrenceStartTime) + 1,
+    }],
+  });
+}
+
 export function owaGetEventsRequest(eventIDs: string[]): OWARequest {
   return new OWARequest("GetItem", {
     __type: "GetItemRequest:#Exchange",


### PR DESCRIPTION
This used to fail because instances are locally generated and so don't have a server or item id.

I'm going to have to look up how to support this in ActiveSync 14.0 as that doesn't support the instance id.

When I tested, I couldn't get the user's calendar to show the new status, although Exchange had sent the email and the organiser's calendar showed their status, but maybe that was just me.