### PR TITLE
Settings: Debounce selectedCategory #777

### DIFF
--- a/app/frontend/Settings/Window/SettingsApp.svelte
+++ b/app/frontend/Settings/Window/SettingsApp.svelte
@@ -14,13 +14,14 @@
       </hbox>
     </hbox>
     <vbox flex class="right-page">
-      <MainContent category={$selectedCategory} />
+      <MainContent category={showCategory} />
     </vbox>
   </Scroll>
 </Splitter>
 
 <script lang="ts">
   import { settingsCategories } from "../SettingsCategories";
+  import type { SettingsCategory } from "./SettingsCategory";
   import { globalSearchTerm, openApp } from "../../AppsBar/selectedApp";
   import { selectedCategory } from "./selected";
   import { mailMustangApp } from "../../Mail/MailMustangApp";
@@ -29,10 +30,15 @@
   import Splitter from "../../Shared/Splitter.svelte";
   import Scroll from "../../Shared/Scroll.svelte";
   import RoundButton from "../../Shared/RoundButton.svelte";
+  import { useDebounce } from "@svelteuidev/composables";
   import CloseIcon from "lucide-svelte/icons/x";
   import { t } from "../../../l10n/l10n";
 
   let categories = settingsCategories;
+
+  let showCategory: SettingsCategory;
+  const selectCategoryDebounced = useDebounce(() => showCategory = $selectedCategory, 1);
+  $: $selectedCategory, selectCategoryDebounced();
 
   $: onSearch($globalSearchTerm)
   function onSearch(searchTerm: string) {


### PR DESCRIPTION
- When we mount components with `<svelte:components>` there seems to be some issues when the component passed is changed too quick because the component doesn't complete it's life cycle and may set any binded variables to `undefined`.
- Also there seems to be some in-between updates that aren't necessary so could skip those.
- I've debounced the `$selectedCategory` to fix _Settings: Mail: Password deleted when opening "Server" settings for any IMAP account_ and so far in my testing it seems to work
- We have to explicitly set the `delay` to `1ms` because it defaults to `100ms` which is too long and feels slow. `1ms` was enough for me. I think we just need to skip that in-between update.