### PR TITLE
ActiveSync v14.0: Don't include FirstDayOfWeek field #645

### DIFF
--- a/app/logic/Calendar/ActiveSync/ActiveSyncEvent.ts
+++ b/app/logic/Calendar/ActiveSync/ActiveSyncEvent.ts
@@ -127,7 +127,7 @@ export class ActiveSyncEvent extends Event {
         MonthOfYear: this.recurrenceRule.frequency == Frequency.Yearly ? String(this.recurrenceRule.seriesStartTime.getMonth() + 1) : [],
         Until: toCompact(this.recurrenceRule.seriesEndTime) || [],
         DayOfMonth: [Frequency.Monthly, Frequency.Yearly].includes(this.recurrenceRule.frequency) && !this.recurrenceRule.week ? String(this.recurrenceRule.seriesStartTime.getDate()) : [],
-        FirstDayOfWeek: this.recurrenceRule.frequency == Frequency.Weekly && this.calendar.account.protocolVersion != "14.0" ? String(this.recurrenceRule.first) : [],
+        FirstDayOfWeek: this.calendar.account.protocolVersion == "14.0" ? [] : this.recurrenceRule.frequency == Frequency.Weekly ? String(this.recurrenceRule.first) : [],
       } : [],
       Subject: this.title,
       Body: this.rawHTMLDangerous ? { Type: "2", Data: this.rawHTMLDangerous } : { Type: "1", Data: [this.descriptionText ?? ""] },


### PR DESCRIPTION
- On ActiveSync v14.0 the `FirstDayOfWeek` field is not supported, therefore, it causes an `Malformed` request when creating a recurring event
- see https://learn.microsoft.com/en-us/openspecs/exchange_server_protocols/ms-ascal/438e1602-1042-4d6d-bed9-77e2b0855da9