### PR TITLE
Don't send invitations/cancellations to empty participant list

### DIFF
--- a/app/logic/Calendar/Invitation/OutgoingInvitation.ts
+++ b/app/logic/Calendar/Invitation/OutgoingInvitation.ts
@@ -31,15 +31,19 @@ export class OutgoingInvitation {
 
   async sendInvitationsTo(participants: Collection<Participant>) {
     let sendTo = participants.filterOnce(participant => participant.response != InvitationResponse.Organizer);
-    for (let participant of sendTo) {
-      participant.response ||= InvitationResponse.NoResponseReceived;
+    if (sendTo.hasItems) {
+      for (let participant of sendTo) {
+        participant.response ||= InvitationResponse.NoResponseReceived;
+      }
+      await this.send("REQUEST", sendTo);
     }
-    await this.send("REQUEST", sendTo);
   }
 
   async sendCancellationsTo(participants: Collection<Participant>) {
-    let sendTo = participants.filterOnce(participant => participant.response > InvitationResponse.Organizer);
-    await this.send("CANCEL", sendTo);
+    let sendTo = participants.filterOnce(participant => [InvitationResponse.Accept, InvitationResponse.Decline, InvitationResponse.NoResponseReceived].includes(participant.response));
+    if (sendTo.hasItems) {
+      await this.send("CANCEL", sendTo);
+    }
   }
 
   async sendInvitations() {

--- a/app/logic/Calendar/Invitation/OutgoingInvitation.ts
+++ b/app/logic/Calendar/Invitation/OutgoingInvitation.ts
@@ -31,12 +31,13 @@ export class OutgoingInvitation {
 
   async sendInvitationsTo(participants: Collection<Participant>) {
     let sendTo = participants.filterOnce(participant => participant.response != InvitationResponse.Organizer);
-    if (sendTo.hasItems) {
-      for (let participant of sendTo) {
-        participant.response ||= InvitationResponse.NoResponseReceived;
-      }
-      await this.send("REQUEST", sendTo);
+    if (sendTo.isEmpty) {
+      return;
     }
+    for (let participant of sendTo) {
+      participant.response ||= InvitationResponse.NoResponseReceived;
+    }
+    await this.send("REQUEST", sendTo);
   }
 
   async sendCancellationsTo(participants: Collection<Participant>) {

--- a/app/logic/Calendar/Invitation/OutgoingInvitation.ts
+++ b/app/logic/Calendar/Invitation/OutgoingInvitation.ts
@@ -41,7 +41,9 @@ export class OutgoingInvitation {
   }
 
   async sendCancellationsTo(participants: Collection<Participant>) {
-    let sendTo = participants.filterOnce(participant => [InvitationResponse.Accept, InvitationResponse.Decline, InvitationResponse.NoResponseReceived].includes(participant.response));
+    const participantResponses = [ InvitationResponse.Accept, InvitationResponse.Decline,
+      InvitationResponse.Tentative, InvitationResponse.NoResponseReceived];
+    let sendTo = participants.filterOnce(participant => participantResponses.includes(participant.response));
     if (sendTo.isEmpty) {
       return;
     }

--- a/app/logic/Calendar/Invitation/OutgoingInvitation.ts
+++ b/app/logic/Calendar/Invitation/OutgoingInvitation.ts
@@ -42,9 +42,10 @@ export class OutgoingInvitation {
 
   async sendCancellationsTo(participants: Collection<Participant>) {
     let sendTo = participants.filterOnce(participant => [InvitationResponse.Accept, InvitationResponse.Decline, InvitationResponse.NoResponseReceived].includes(participant.response));
-    if (sendTo.hasItems) {
-      await this.send("CANCEL", sendTo);
+    if (sendTo.isEmpty) {
+      return;
     }
+    await this.send("CANCEL", sendTo);
   }
 
   async sendInvitations() {


### PR DESCRIPTION
I'm not exactly sure how I triggered this but I was editing a meeting and I got an error saying that my invitation message had no recipient.

Since i was there I thought there was no point sending a cancellation to a declined attendee.

(Strictly speaking this is a regression from eef7737 as the previous code sent separate messages for each participants therefore guaranteeing that if there were no relevant participants then no messages were sent.)