### PR TITLE
Properly handle acceptance of occurrence of series

### DIFF
--- a/app/logic/Calendar/Event.ts
+++ b/app/logic/Calendar/Event.ts
@@ -565,7 +565,7 @@ export class Event extends Observable {
       this.recurrenceCase = RecurrenceCase.Exception;
       this.parentEvent.instances.remove(this);
       this.parentEvent.exceptions.add(this);
-      await this.parentEvent.save();
+      this.calendar.events.add(this);
     }
   }
 

--- a/app/logic/Calendar/Invitation/IncomingInvitation.ts
+++ b/app/logic/Calendar/Invitation/IncomingInvitation.ts
@@ -1,5 +1,6 @@
 import type { Calendar } from "../Calendar";
-import type { Event } from "../Event";
+import { RecurrenceCase, type Event } from "../Event";
+import { Participant } from "../Participant";
 import { InvitationMessage, InvitationResponse, type InvitationResponseInMessage } from "../Invitation/InvitationStatus";
 import type { EMail } from "../../Mail/EMail";
 import { AbstractFunction, NotReached, assert } from "../../util/util";
@@ -62,6 +63,9 @@ export class IncomingInvitation {
     assert(this.invitationMessage == InvitationMessage.ParticipantReply, "Not a reply");
     let event = this.calEvent();
     assert(event, "Cannot process invitation update: The event was not found in your calendar");
+    if (event.recurrenceCase == RecurrenceCase.Instance) {
+      event.participants.replaceAll(event.participants.contents.map(participant => new Participant(participant.emailAddress, participant.name, participant.response)));
+    }
     let invitee = this.event.participants.find(participant => participant.response != InvitationResponse.Organizer);
     let participant = event.participants.find(participant => participant.emailAddress == invitee.emailAddress);
     let timestamp = this.event.lastUpdateTime;

--- a/app/logic/Calendar/Invitation/IncomingInvitation.ts
+++ b/app/logic/Calendar/Invitation/IncomingInvitation.ts
@@ -64,7 +64,7 @@ export class IncomingInvitation {
     let event = this.calEvent();
     assert(event, "Cannot process invitation update: The event was not found in your calendar");
     if (event.recurrenceCase == RecurrenceCase.Instance) {
-      event.participants.replaceAll(event.participants.contents.map(participant => new Participant(participant.emailAddress, participant.name, participant.response)));
+      event.participants.replaceAll(event.participants.contents.map(p => new Participant(p.emailAddress, p.name, p.response)));
     }
     let invitee = this.event.participants.find(participant => participant.response != InvitationResponse.Organizer);
     let participant = event.participants.find(participant => participant.emailAddress == invitee.emailAddress);

--- a/app/logic/Calendar/Invitation/IncomingInvitation.ts
+++ b/app/logic/Calendar/Invitation/IncomingInvitation.ts
@@ -64,7 +64,8 @@ export class IncomingInvitation {
     let event = this.calEvent();
     assert(event, "Cannot process invitation update: The event was not found in your calendar");
     if (event.recurrenceCase == RecurrenceCase.Instance) {
-      event.participants.replaceAll(event.participants.contents.map(p => new Participant(p.emailAddress, p.name, p.response)));
+      event.participants.replaceAll(event.participants.contents.map(p =>
+        new Participant(p.emailAddress, p.name, p.response)));
     }
     let invitee = this.event.participants.find(participant => participant.response != InvitationResponse.Organizer);
     let participant = event.participants.find(participant => participant.emailAddress == invitee.emailAddress);


### PR DESCRIPTION
When you invite a participant to a recurring meeting but they have a custom response to a single occurrence, this does not currently get processed properly. There are two problems:
1. The instance turns into an exception, but this means it needs to be added explicitly to its parent calendar's event list.
2. The instance has a shallow copy of the list of participants, which allows it to show the correct master response (if the participant previously replied to the entire series), but we need to deep clone the list before modifying it. (This is not normally a problem because we don't normally modify participants in-place.)

I don't know why `saveLocally` was saving the parent event; creating an exception has no effect on the parent.