### PR TITLE
Invitation: Outgoing: Use isInvitee

### DIFF
--- a/app/logic/Calendar/Invitation/OutgoingInvitation.ts
+++ b/app/logic/Calendar/Invitation/OutgoingInvitation.ts
@@ -30,12 +30,12 @@ export class OutgoingInvitation {
   }
 
   async sendInvitationsTo(participants: Collection<Participant>) {
-    let sendTo = participants.filterOnce(participant => participant.response != InvitationResponse.Organizer);
+    for (let participant of participants) {
+      participant.response ||= InvitationResponse.NoResponseReceived;
+    }
+    let sendTo = participants.filterOnce(participant => participant.isInvitee);
     if (sendTo.isEmpty) {
       return;
-    }
-    for (let participant of sendTo) {
-      participant.response ||= InvitationResponse.NoResponseReceived;
     }
     await this.send("REQUEST", sendTo);
   }


### PR DESCRIPTION
This is a followup of #801 and it eaf6fe3bd9

* Use `isInvitee` also for `sendInvitationsTo()`, like we do in `sendCancellationsTo()`