### PR TITLE
Setup: Autoconfig for CalDAV, CardDAV, WebDAV

### DIFF
--- a/app/frontend/Setup/Mail/DisplayConfig.svelte
+++ b/app/frontend/Setup/Mail/DisplayConfig.svelte
@@ -1,8 +1,10 @@
 <grid class="result">
   <DisplayConfigServer {config} />
-  {#if config.outgoing}
-    <DisplayConfigServer config={config.outgoing} />
-  {/if}
+  {#each childServices as childService}
+    {#if childService}
+      <DisplayConfigServer config={childService} />
+    {/if}
+  {/each}
 </grid>
 
 <script lang="ts">
@@ -11,6 +13,10 @@
 
   /** in */
   export let config: MailAccount;
+
+  $: childServices = [ config.outgoing,
+    config.setup?.calendar, config.setup?.addressbook,
+    config.setup?.fileShare, config.setup?.meet ];
 </script>
 
 <style>

--- a/app/frontend/Setup/Mail/Instructions.svelte
+++ b/app/frontend/Setup/Mail/Instructions.svelte
@@ -3,11 +3,11 @@
   subtitle={$t`${config.name} requires you to do some manual steps for initial set up`} />
 
 <ol class="instructions">
-  {#each config.setupInstructions as step}
+  {#each config.setup.instructions as step}
     <li>
       {#if step.url}
         <a href={step.url} target="_blank">
-          <Button label="Go to setup" classes="filled" />
+          <Button label={$t`Go to ${config.name} *=> Go to Google`} classes="filled" />
         </a>
       {:else if step.enterPassword}
         {step.instruction || $t`Password`}
@@ -24,10 +24,10 @@
 
 <script lang="ts">
   import type { MailAccount } from "../../../logic/Mail/MailAccount";
-  import { t } from "../../../l10n/l10n";
   import Header from "../Shared/Header.svelte";
   import Button from "../../Shared/Button.svelte";
   import Password from "../Shared/Password.svelte";
+  import { t } from "../../../l10n/l10n";
 
   export let config: MailAccount;
   export let password: string; /** in/out */

--- a/app/frontend/Setup/Mail/SetupMail.svelte
+++ b/app/frontend/Setup/Mail/SetupMail.svelte
@@ -168,7 +168,7 @@
     } else if (step == Step.FoundConfig) {
       fillConfig(config, emailAddress, password);
       errorMessage = null;
-      if (config.setupInstructions) {
+      if (config.setup?.instructions) {
         step = Step.Instructions;
       } else if (config.oAuth2) {
         step = Step.Login;

--- a/app/logic/Abstract/TCPAccount.ts
+++ b/app/logic/Abstract/TCPAccount.ts
@@ -10,6 +10,13 @@ export class TCPAccount extends Account {
   @notifyChangedProperty
   tls = TLSSocketType.Unknown;
 
+  getHostname(): string | null {
+    return this.hostname;
+  }
+  getTLS(): TLSSocketType {
+    return this.tls;
+  }
+
   fromConfigJSON(json: any) {
     super.fromConfigJSON(json);
     this.hostname = sanitize.hostname(json.hostname, null);

--- a/app/logic/Files/WebDAV/WebDAVAccount.ts
+++ b/app/logic/Files/WebDAV/WebDAVAccount.ts
@@ -2,7 +2,7 @@ import { FileSharingAccount } from "../FileSharingAccount";
 import { WebDAVDirectory } from "./WebDAVDirectory";
 import { AuthMethod } from "../../Abstract/Account";
 import { ArrayColl } from "svelte-collections";
-import { NotReached, assert } from "../../util/util";
+import { NotImplemented, NotReached, assert } from "../../util/util";
 import { gt } from "../../../l10n/l10n";
 import { appGlobal } from "../../app";
 import type { DAVClient } from "tsdav";
@@ -80,5 +80,9 @@ export class WebDAVAccount extends FileSharingAccount {
     }
 
     await this.save();
+  }
+
+  async save() {
+    throw new NotImplemented(); // TODO DB for files
   }
 }

--- a/app/logic/Mail/AccountsList/MailAccounts.ts
+++ b/app/logic/Mail/AccountsList/MailAccounts.ts
@@ -90,5 +90,5 @@ export function listMailProtocols(): string[] {
 }
 
 export function labelForMailProtocol(protocol: string): string {
-  return kProtocolLabel[protocol];
+  return kProtocolLabel[protocol] ?? protocol.toUpperCase();
 }

--- a/app/logic/Mail/AutoConfig/SetupInfo.ts
+++ b/app/logic/Mail/AutoConfig/SetupInfo.ts
@@ -1,0 +1,24 @@
+import type { Calendar } from "../../Calendar/Calendar";
+import type { Addressbook } from "../../Contacts/Addressbook";
+import type { FileSharingAccount } from "../../Files/FileSharingAccount";
+import type { ChatAccount } from "../../Chat/ChatAccount";
+import type { MeetAccount } from "../../Meet/MeetAccount";
+import type { URLString } from "../../util/util";
+
+/** Only for setup. Additional info about an account or related accounts. */
+export class SetupInfo {
+  calendar: Calendar;
+  addressbook: Addressbook;
+  fileShare: FileSharingAccount;
+  chat: ChatAccount;
+  meet: MeetAccount;
+  /** We know a config, but the user needs to do some manual steps for this ISP */
+  instructions: SetupInstruction[] | null = null;
+}
+
+export class SetupInstruction {
+  instruction: string | null;
+  url: URLString | null;
+  enterPassword: boolean = false;
+  enterUsername: boolean = false;
+}

--- a/app/logic/Mail/AutoConfig/configInfo.ts
+++ b/app/logic/Mail/AutoConfig/configInfo.ts
@@ -1,12 +1,8 @@
-import type { MailAccount } from "../MailAccount";
-import { TLSSocketType } from "../../Abstract/TCPAccount";
+import { TCPAccount, TLSSocketType } from "../../Abstract/TCPAccount";
+import type { Account } from "../../Abstract/Account";
 import type { URLString } from "../../util/util";
 
-export function hasEncryption(tls: TLSSocketType): boolean {
-  return tls == TLSSocketType.TLS || tls == TLSSocketType.STARTTLS;
-}
-
-export function isStandardPort(config: MailAccount) {
+export function isStandardPort(config: TCPAccount) {
   return !!kStandardPorts.find(p =>
     config.protocol == p.protocol && config.tls == p.tls && config.port == p.port);
 }
@@ -42,5 +38,44 @@ export function getStandardURL(protocol: string, domain: string): URLString {
     return `https://graph.microsoft.com`;
   } else {
     return "";
+  }
+}
+
+export function hasEncryption(tls: TLSSocketType): boolean {
+  return tls == TLSSocketType.TLS || tls == TLSSocketType.STARTTLS;
+}
+
+export function getHostname(account: Account): string | null {
+  if (account instanceof TCPAccount) {
+    return account.hostname;
+  }
+  if (!account.url) {
+    return null;
+  }
+  try {
+    return new URL(account.url).hostname;
+  } catch (ex) {
+    return null;
+  }
+}
+
+export function getTLS(account: Account): TLSSocketType {
+  if (account instanceof TCPAccount) {
+    return account.tls;
+  }
+  if (!account.url) {
+    return TLSSocketType.Unknown;
+  }
+  try {
+    let url = new URL(account.url);
+    if (url.protocol == "https:") {
+      return TLSSocketType.TLS;
+    } else if (url.protocol == "http:") {
+      return TLSSocketType.Plain;
+    } else {
+      return TLSSocketType.Unknown;
+    }
+  } catch (ex) {
+    return null;
   }
 }

--- a/app/logic/Mail/AutoConfig/localConfig.ts
+++ b/app/logic/Mail/AutoConfig/localConfig.ts
@@ -1,5 +1,6 @@
-import type { MailAccount, SetupInstruction } from "../MailAccount";
+import type { MailAccount } from "../MailAccount";
 import { readConfigFromXML } from "./readConfig";
+import { SetupInfo } from "./SetupInfo";
 import type { ArrayColl } from "svelte-collections";
 import { assert } from "../../util/util";
 
@@ -8,7 +9,8 @@ export function localConfig(domain: string): ArrayColl<MailAccount> {
   assert(local, "No local config found (expected)");
   let configs = readConfigFromXML(local.xml, domain, "local");
   for (let config of configs) {
-    config.setupInstructions = local.instructions;
+    config.setup ??= new SetupInfo();
+    config.setup.instructions = local.instructions;
   }
   return configs;
 }

--- a/app/logic/Mail/AutoConfig/readConfig.ts
+++ b/app/logic/Mail/AutoConfig/readConfig.ts
@@ -1,12 +1,24 @@
-import type { MailAccount, ConfigSource } from "../MailAccount";
-import { AuthMethod } from "../../Abstract/Account";
-import { TLSSocketType } from "../../Abstract/TCPAccount";
+import { MailAccount, type ConfigSource } from "../MailAccount";
+import { Account, AuthMethod } from "../../Abstract/Account";
+import { TCPAccount, TLSSocketType } from "../../Abstract/TCPAccount";
 import type { SMTPAccount } from "../SMTP/SMTPAccount";
+import type { Calendar } from "../../Calendar/Calendar";
+import type { Addressbook } from "../../Contacts/Addressbook";
+import type { FileSharingAccount } from "../../Files/FileSharingAccount";
+import type { ChatAccount } from "../../Chat/ChatAccount";
+import type { MeetAccount } from "../../Meet/MeetAccount";
 import { newAccountForProtocol } from "../AccountsList/MailAccounts";
+import { newCalendarForProtocol } from "../../Calendar/AccountsList/Calendars";
+import { newAddressbookForProtocol } from "../../Contacts/AccountsList/Addressbooks";
+import { newFileSharingAccountForProtocol } from "../../Files/AccountsList/FileSharingAccounts";
+import { newChatAccountForProtocol } from "../../Chat/AccountsList/ChatAccounts";
+import { newMeetAccountForProtocol } from "../../Meet/AccountsList/MeetAccounts";
+import { SetupInfo } from "./SetupInfo";
 import { OAuth2 } from "../../Auth/OAuth2";
 import { OAuth2URLs } from "../../Auth/OAuth2URLs";
 import JXON from "../../../../lib/util/JXON";
 import { sanitize } from "../../../../lib/util/sanitizeDatatypes";
+import { logError } from "../../../frontend/Util/error";
 import { ensureArray, assert } from "../../util/util";
 import { ArrayColl } from "svelte-collections";
 
@@ -31,7 +43,7 @@ export function readConfigFromXML(autoconfigXMLStr: string, forDomain: string | 
   // Incoming server
   for (let iX of ensureArray(xml.$incomingServer)) {
     try {
-      configs.push(readServer(iX, displayName, fullXML, source));
+      configs.push(readServer(iX, displayName, fullXML, source, newAccountForProtocol) as MailAccount);
     } catch (ex) {
       firstError = ex;
     }
@@ -42,16 +54,9 @@ export function readConfigFromXML(autoconfigXMLStr: string, forDomain: string | 
   firstError = null;
 
   // Outgoing server
-  for (let oX of ensureArray(xml.$outgoingServer)) {
-    try {
-      outgoingConfigs.push(readServer(oX, displayName, fullXML, source));
-    } catch (ex) {
-      firstError = ex;
-    }
-  }
-  let imapConfigs = configs.filter(config => config.protocol == "imap" || config.protocol == "pop3");
+  let imapConfigs = configs.filterOnce(config => config.protocol == "imap" || config.protocol == "pop3");
   if (imapConfigs.hasItems) {
-    let outgoing = outgoingConfigs.first;
+    let outgoing = readFirstServer(xml.$outgoingServer, displayName, fullXML, source, newAccountForProtocol) as MailAccount;
     if (!outgoing) {
       throw firstError ?? new Error(`No working <outgoingServer> in autoconfig XML for ${forDomain} found`);
     }
@@ -62,14 +67,29 @@ export function readConfigFromXML(autoconfigXMLStr: string, forDomain: string | 
     }
   }
 
+  let calendar = readFirstServer(fullXML.$calendar, displayName, fullXML, source, newCalendarForProtocol) as Calendar;
+  let addressbook = readFirstServer(fullXML.$addressbook, displayName, fullXML, source, newAddressbookForProtocol) as Addressbook;
+  let fileShare = readFirstServer(fullXML.$fileShare, displayName, fullXML, source, newFileSharingAccountForProtocol) as any as FileSharingAccount;
+  let chat = readFirstServer(fullXML.$chatServer, displayName, fullXML, source, newChatAccountForProtocol) as any as ChatAccount;
+  let meet = readFirstServer(fullXML.$videoConference, displayName, fullXML, source, newMeetAccountForProtocol) as any as MeetAccount;
+  for (let config of configs) {
+    break; // TODO Fix calendarURL in CalDAV / CardDAV, and implement DB to save WebDAV accounts
+    let setup = config.setup ??= new SetupInfo();
+    setup.calendar = calendar;
+    setup.addressbook = addressbook;
+    setup.fileShare = fileShare;
+    setup.chat = chat;
+    setup.meet = meet;
+  }
+
   return configs;
 }
 
 /**
  * @param {JXON} xml <incomingServer> or <outgoingServer>
  */
-function readServer(xml: any, displayName: string, fullXML: any, source: ConfigSource): MailAccount {
-  let protocol = sanitize.enum(xml["@type"], ["pop3", "imap", "jmap", "smtp", "ews", "owa", "activesync", "graph", "exchange"], null);
+function readServer(xml: any, displayName: string, fullXML: any, source: ConfigSource, newAccount: (protocol: string) => Account): Account {
+  let protocol = sanitize.enum(xml["@type"], ["pop3", "imap", "jmap", "smtp", "ews", "owa", "activesync", "graph", "exchange", "caldav", "carddav", "webdav"], null);
   assert(protocol, `Need type for <incomingServer> in autoconfig XML for ${displayName}`);
 
   if (protocol == "exchange") { // Backwards compat
@@ -83,41 +103,40 @@ function readServer(xml: any, displayName: string, fullXML: any, source: ConfigS
     assert(xml.url, "Need URL for Exchange servers");
   }
 
-  let account = newAccountForProtocol(protocol);
+  let account = newAccount(protocol);
 
   account.name = displayName;
   account.url = sanitize.url(xml.url, null);
-  if (account.url) {
-    let url = new URL(account.url);
-    account.hostname = url.hostname;
-    account.port = url.port
-      ? sanitize.portTCP(url.port)
-      : url.protocol == "https:" ? 443 : url.protocol == "http:" ? 80 : null;
-    assert(account.port, "Need port number or known protocol in URL");
-  } else {
-    account.hostname = sanitize.hostname(xml.hostname);
-    account.port = sanitize.portTCP(xml.port);
-  }
   account.username = sanitize.string(xml.username); // may be a %VARIABLE%
   if (xml.password) {
     account.password = sanitize.string(xml.password);
   }
 
-  if (account.url) {
-    account.tls = account.url.startsWith("https:") ? TLSSocketType.TLS : account.url.startsWith("http:") ? TLSSocketType.Plain : null;
-  } else {
-    // Take first supported
-    account.tls = ensureArray(xml.$socketType).map(socketType => sanitize.translate(socketType, {
-      plain: TLSSocketType.Plain,
-      SSL: TLSSocketType.TLS,
-      STARTTLS: TLSSocketType.STARTTLS
-    }, null)).find(v => v !== null);
+  if (account instanceof TCPAccount) {
+    if (account.url) {
+      let url = new URL(account.url);
+      account.hostname = url.hostname;
+      account.port = url.port
+        ? sanitize.portTCP(url.port)
+        : url.protocol == "https:" ? 443 : url.protocol == "http:" ? 80 : null;
+      assert(account.port, "Need port number or known protocol in URL");
+      account.tls = account.url.startsWith("https:") ? TLSSocketType.TLS : account.url.startsWith("http:") ? TLSSocketType.Plain : null;
+    } else {
+      account.hostname = sanitize.hostname(xml.hostname);
+      account.port = sanitize.portTCP(xml.port);
+      // Take first supported
+      account.tls = ensureArray(xml.$socketType).map(socketType => sanitize.translate(socketType, {
+        plain: TLSSocketType.Plain,
+        SSL: TLSSocketType.TLS,
+        STARTTLS: TLSSocketType.STARTTLS
+      }, null)).find(v => v !== null);
+    }
+    assert(account.tls, "No supported <socketType> in autoconfig");
   }
-  assert(account.tls, "No supported <socketType> in autoconfig");
 
   let authMethods = ensureArray(xml.$authentication).map(auth => sanitize.translate(auth, {
     "password-cleartext": AuthMethod.Password,
-    "http-basic": AuthMethod.Password,
+    "basic": AuthMethod.Password,
     "OAuth2": AuthMethod.OAuth2,
     "password-encrypted": AuthMethod.CRAMMD5,
     "GSSAPI": AuthMethod.GSSAPI,
@@ -138,14 +157,17 @@ function readServer(xml: any, displayName: string, fullXML: any, source: ConfigS
   }
   assert(account.authMethod, `No supported <authentication> method in autoconfig XML for ${displayName}\n\nGot authentication methods ${JSON.stringify(xml.$authentication, null, 2)}`);
 
-  account.source = source;
+  if (account instanceof MailAccount) {
+    account.source = source;
+  }
   return account;
 }
 
-function getOAuth2Config(account: MailAccount, autoConfigXML: any): OAuth2 {
+function getOAuth2Config(account: Account, autoConfigXML: any): OAuth2 {
   let oAuth2: OAuth2;
   // try built-in
-  let builtin = OAuth2URLs.find(a => a.hostnames.includes(account.hostname));
+  let hostname = account instanceof TCPAccount ? account.hostname : account.url ? new URL(account.url).hostname : null;
+  let builtin = OAuth2URLs.find(a => a.hostnames.includes(hostname));
   if (builtin) {
     oAuth2 = new OAuth2(account, builtin.tokenURL, builtin.authURL, builtin.authDoneURL, builtin.scope, builtin.clientID, builtin.clientSecret, builtin.doPKCE);
     oAuth2.setTokenURLPasswordAuth(builtin.tokenURLPasswordAuth);
@@ -168,4 +190,14 @@ function getOAuth2Config(account: MailAccount, autoConfigXML: any): OAuth2 {
   }
   assert(oAuth2, "No suitable OAuth2 config found, neither in AutoConfig XML, nor built-in");
   return oAuth2;
+}
+
+function readFirstServer(serversX: any, displayName: string, fullXML: any, source: ConfigSource, newAccount: (protocol: string) => Account): Account {
+  for (let accX of ensureArray(serversX)) {
+    try {
+      return readServer(accX, displayName, fullXML, source, newAccount);
+    } catch (ex) {
+      logError(ex);
+    }
+  }
 }

--- a/app/logic/Mail/MailAccount.ts
+++ b/app/logic/Mail/MailAccount.ts
@@ -6,9 +6,10 @@ import type { SMTPAccount } from "./SMTP/SMTPAccount";
 import { ContactEntry } from "../Abstract/Person";
 import { FilterRuleAction } from "./FilterRules/FilterRuleAction";
 import { OAuth2 } from "../Auth/OAuth2";
+import type { SetupInfo } from "./AutoConfig/SetupInfo";
 import { appGlobal } from "../app";
 import { sanitize } from "../../../lib/util/sanitizeDatatypes";
-import { AbstractFunction, type URLString } from "../util/util";
+import { AbstractFunction } from "../util/util";
 import { notifyChangedProperty } from "../util/Observable";
 import { Collection, ArrayColl } from 'svelte-collections';
 
@@ -33,8 +34,7 @@ export class MailAccount extends TCPAccount {
   readonly identities = new ArrayColl<MailIdentity>();
   @notifyChangedProperty
   readonly filterRuleActions = new ArrayColl<FilterRuleAction>();
-  /** Only for setup. We know a config, but the user needs to do some manual steps for this ISP */
-  setupInstructions: SetupInstruction[] | null = null;
+  setup: SetupInfo;
 
   readonly rootFolders: Collection<Folder> = new ArrayColl<Folder>();
 
@@ -239,11 +239,4 @@ export enum DeleteStrategy {
   DeleteImmediately = 1,
   Flag = 1,
   MoveToTrash = 3,
-}
-
-export class SetupInstruction {
-  instruction: string | null;
-  url: URLString | null;
-  enterPassword: boolean = false;
-  enterUsername: boolean = false;
 }

--- a/app/logic/util/collections.ts
+++ b/app/logic/util/collections.ts
@@ -16,7 +16,6 @@ export function filterUnique<T>(source: Collection<T>, compareFunc: (a: T, b: T)
       unique.add(newItem);
     }
   }
-  return unique;
 }
 
 export function getNext<T>(list: ArrayColl<T>, curObject: T): T | null {

--- a/app/logic/util/collections.ts
+++ b/app/logic/util/collections.ts
@@ -16,6 +16,7 @@ export function filterUnique<T>(source: Collection<T>, compareFunc: (a: T, b: T)
       unique.add(newItem);
     }
   }
+  return unique;
 }
 
 export function getNext<T>(list: ArrayColl<T>, curObject: T): T | null {


### PR DESCRIPTION
* AutoConfig: Read CalDAV, CardDAV, WebDAV into from the autoconfig XML file
* Setup UI: Show the found config, to allow the user to verify the hostnames
* Setup logic: Create the calendar, addressbook and file share accounts, together with the email account
* Disabled for now, until #778 lands