### PR TITLE
Shoehorn OWA login into OAuth2 logic #809

### DIFF
--- a/app/frontend/Setup/Shared/OAuth2Login.svelte
+++ b/app/frontend/Setup/Shared/OAuth2Login.svelte
@@ -2,22 +2,24 @@
   <hbox class="header">
     <hbox class="emailAddress font-small">{$account.emailAddress}</hbox>
     <hbox flex />
-    <hbox class="buttons">
-      {#if oAuth2Running != OAuth2UIMethod.Embed}
-        <Button label={$t`Login inline *=> within the same application window`}
-          onClick={() => run(loginEmbed)}
+    {#if account.oAuth2 instanceof OAuth2}
+      <hbox class="buttons">
+        {#if oAuth2Running != OAuth2UIMethod.Embed}
+          <Button label={$t`Login inline *=> within the same application window`}
+            onClick={() => run(loginEmbed)}
+            errorCallback={showError}
+            />
+        {/if}
+        <Button label={$t`Login in browser`}
+          onClick={() => run(loginBrowser)}
           errorCallback={showError}
           />
-      {/if}
-      <Button label={$t`Login in browser`}
-        onClick={() => run(loginBrowser)}
-        errorCallback={showError}
-        />
-      <Button label={showConfirmCopied ? $t`URL copied` : $t`Copy URL`}
-        onClick={() => run(loginCopyURL)}
-        errorCallback={showError}
-        />
-    </hbox>
+        <Button label={showConfirmCopied ? $t`URL copied` : $t`Copy URL`}
+          onClick={() => run(loginCopyURL)}
+          errorCallback={showError}
+          />
+      </hbox>
+    {/if}
   </hbox>
   {#if oAuth2Running == OAuth2UIMethod.Embed && embed}
     <vbox class="browser">
@@ -40,8 +42,9 @@
 
 <script lang="ts">
   import type { MailAccount } from "../../../logic/Mail/MailAccount";
+  import { OAuth2 } from "../../../logic/Auth/OAuth2";
   import { OAuth2UIMethod } from "../../../logic/Auth/UI/OAuth2UIMethod";
-  import { OAuth2UI } from "../../../logic/Auth/UI/OAuth2UI";
+  import type { OAuth2UI } from "../../../logic/Auth/UI/OAuth2UI";
   import { OAuth2Embed } from "../../../logic/Auth/UI/OAuth2Embed";
   import { OAuth2SystemBrowser } from "../../../logic/Auth/UI/OAuth2SystemBrowser";
   import { OAuth2Localhost } from "../../../logic/Auth/UI/OAuth2Localhost";

--- a/app/frontend/Shared/Auth/OAuth2EmbeddedBrowser.svelte
+++ b/app/frontend/Shared/Auth/OAuth2EmbeddedBrowser.svelte
@@ -1,6 +1,7 @@
 <Browser
   title={$t`Authentication`}
   url={startURL}
+  autofill={owaAutoFillLoginPage(dialog.oAuth2.account.username, dialog.oAuth2.account.password)}
   on:page-change={onPageChange}
   on:close={onClose}
   sessionID={dialog.oAuth2.account?.webSessionID}
@@ -15,6 +16,7 @@
   import type { OAuth2Tab } from "../../../logic/Auth/UI/OAuth2Tab";
   import { OAuth2Embed } from "../../../logic/Auth/UI/OAuth2Embed";
   import Browser from "../Browser.svelte";
+  import { owaAutoFillLoginPage } from "../../../logic/Mail/OWA/Login/OWALoginAutoFill";
   import { UserCancelled, UserError, type URLString, sleep } from "../../../logic/util/util";
   import { onMount } from "svelte";
   import { t } from "../../../l10n/l10n";
@@ -26,7 +28,7 @@
 
   async function onPageChange(event: CustomEvent<URLString>) {
     let url = event.detail;
-    dialog.urlChanged(url);
+    await dialog.urlChanged(url);
   }
 
   function onClose() {

--- a/app/frontend/Shared/Browser.svelte
+++ b/app/frontend/Shared/Browser.svelte
@@ -43,6 +43,7 @@
   /** The cookie storage. For `<webview partition="persist:...">` */
   export let sessionID: string;
   export let withURLbar = true;
+  export let autofill: string;
 
   $: partition = sessionID ? "persist:" + sessionID : undefined;
 
@@ -68,6 +69,9 @@
     });
     webviewE.addEventListener("did-stop-loading", () => {
       isLoading = false;
+      if (autofill) {
+        webviewE.executeJavaScript(autofill);
+      }
     });
   }
 

--- a/app/logic/Auth/OAuth2.ts
+++ b/app/logic/Auth/OAuth2.ts
@@ -41,15 +41,15 @@ export class OAuth2 extends Observable {
   @notifyChangedProperty
   accessToken?: string;
   @notifyChangedProperty
-  protected refreshToken?: string;
+  refreshToken?: string;
   @notifyChangedProperty
   idToken: string;
   verificationToken: string; /** `state` URL param of authURL/doneURL */
   uiMethod: OAuth2UIMethod = OAuth2UIMethod.Window;
-  protected ui: OAuth2UI | null = null;
+  ui: OAuth2UI | null = null;
 
   expiresAt: Date | null = null;
-  protected expiryTimout: NodeJS.Timeout;
+  expiryTimout: NodeJS.Timeout;
   refreshErrorCallback = (ex: Error) => console.error(ex);
   idTokenCallback: (idToken: string, oAuth2: OAuth2) => void;
 
@@ -196,7 +196,7 @@ export class OAuth2 extends Observable {
    * @returns accessToken
    * @throws OAuth2Error
    */
-  protected async getAccessTokenFromParams(params: any, additionalHeaders?: any, tokenURL: string = this.tokenURL): Promise<string> {
+  async getAccessTokenFromParams(params: any, additionalHeaders?: any, tokenURL: string = this.tokenURL): Promise<string> {
     params.scope = this.scope;
     params.client_id = this.clientID;
     if (this.clientSecret) {
@@ -274,7 +274,7 @@ export class OAuth2 extends Observable {
   }
 
   /** Helper for auth Done URL */
-  isAuthDoneURL(url: URLString): boolean {
+  async isAuthDoneURL(url: URLString): Promise<boolean> {
     let urlParams = Object.fromEntries(new URL(url).searchParams);
     console.log("OAuth2 page change to", url, "doneURL is", this.authDoneURL, "matches", this.authDoneURL == url,
       "is auth done", url.startsWith(this.authDoneURL) && this.verificationToken && urlParams.state == this.verificationToken);
@@ -357,17 +357,17 @@ export class OAuth2 extends Observable {
   /**
    * @returns refreshToken (or null, if not available)
    */
-  protected async getRefreshTokenFromStorage(): Promise<string | null> {
+  async getRefreshTokenFromStorage(): Promise<string | null> {
     return await getPassword(this.storageKey);
   }
-  protected async deleteRefreshTokenFromStorage(): Promise<void> {
+  async deleteRefreshTokenFromStorage(): Promise<void> {
     await deletePassword(this.storageKey);
   }
-  protected async storeRefreshToken(refreshToken: string): Promise<void> {
+  async storeRefreshToken(refreshToken: string): Promise<void> {
     assert(refreshToken, "Nothing to store");
     await setPassword(this.storageKey, refreshToken);
   }
-  protected get storageKey(): string {
+  get storageKey(): string {
     let host = new URL(this.tokenURL).host.replaceAll(".", "-");
     let username = this.account.username.replace(/@/, "-").replaceAll(".", "-");
     return `oauth2.refreshToken.${host}.${username}`;

--- a/app/logic/Auth/OWAAuth.ts
+++ b/app/logic/Auth/OWAAuth.ts
@@ -1,0 +1,114 @@
+import type { OAuth2UIMethod } from "./UI/OAuth2UIMethod";
+import type { OAuth2 } from "./OAuth2";
+import { OAuth2LoginNeeded } from "./OAuth2Error";
+import { OAuth2Tab } from "./UI/OAuth2Tab";
+import type { OWAAccount} from "../Mail/OWA/OWAAccount";
+import { appGlobal } from "../app";
+import { Observable } from "../util/Observable";
+import { assert, type URLString } from "../util/util";
+
+/// Class to perform fake OAuth2 to log into OWA web interface via browser
+export class OWAAuth extends Observable implements OAuth2 {
+  ui: OAuth2Tab | null = null;
+  isLoggedIn = false;
+
+  constructor(public account: OWAAccount) {
+    super();
+  }
+
+  // Called from `TBProfile.readMailAccount()`
+  setTokenURLPasswordAuth(url: string | null | undefined) {
+  }
+
+  // Called from `OWAAccount.loginCommon()`
+  async login(interactive: boolean): Promise<string> {
+    assert(this.account, "Need to set account first");
+    if (this.isLoggedIn) {
+      return;
+    }
+    if (!interactive) {
+      throw new OAuth2LoginNeeded();
+    }
+    return this.loginWithUI();
+  }
+
+  // Called from above to match behaviour of OAuth2 class
+  async loginWithUI(): Promise<string> {
+    this.ui = new OAuth2Tab(this);
+    await this.ui.login();
+    this.ui = null;
+    return "";
+  }
+
+  // Called from `prepareLogin()` during account setup
+  // ui is probably not actually set at this point, but whatever
+  abort() {
+    this.ui?.abort();
+  }
+
+  // Called from `OWAAccount.logout()`
+  async logout() {
+    this.isLoggedIn = false;
+    return appGlobal.remoteApp.OWA.clearStorageData(this.account.partition);
+  }
+
+  // Called from `startLogin()` during account setup
+  async getAccessTokenFromAuthCode(authCode: string): Promise<string> {
+    await appGlobal.remoteApp.OWA.fetchSessionData(this.account.partition, this.account.url, false);
+    return "";
+  }
+
+  // Called from `OAuth2Embed.login()` and `OAuth2Tab.login()`
+  async getAuthURL(): Promise<URLString> {
+    return this.account.url;
+  }
+
+  // Called from `OAuth2Embed.urlChanged()` and `OAuth2Tab.urlChanged()`
+  async isAuthDoneURL(url: URLString): Promise<boolean> {
+    try {
+      await appGlobal.remoteApp.OWA.fetchSessionData(this.account.partition, this.account.url, false);
+      this.isLoggedIn = true;
+    } catch (ex) {
+      this.isLoggedIn = false;
+    }
+    return this.isLoggedIn;
+  }
+
+  // Called from `OAuth2Embed.success()` and `OAuth2Tab.success()`
+  getAuthCodeFromDoneURL(url: URLString): string {
+    return "";
+  }
+
+  // Called from `MailAccount.toConfigJSON()`
+  toConfigJSON() {
+  }
+
+  // Unused stuff but needed to fake out TypeScript for implements OAuth2
+  // Can't actually derive from OAuth2 because all its assertions would fail
+  // Note: This requires all of OAuth2's members to be public
+  tokenURL: URLString;
+  authURL: URLString;
+  authDoneURL: URLString;
+  scope: string;
+  clientID: string;
+  clientSecret: string | null;
+  doPKCE: boolean;
+  idToken: string;
+  verificationToken: string;
+  uiMethod: OAuth2UIMethod;
+  expiresAt: Date | null;
+  expiryTimout: NodeJS.Timeout; // sic
+  refreshErrorCallback: (ex : Error) => void;
+  idTokenCallback: (idToken: string, oAuth2: OAuth2) => void;
+  authorizationHeader: string;
+  loginWithPassword: (username: string, password: string) => Promise<string>;
+  reset: () => Promise<void>;
+  getAccessTokenFromRefreshToken: (refreshToken: string) => Promise<string>;
+  getAccessTokenFromParams: (params: any, additionaHeaders?: any, tokenURL?: string) => Promise<string>;
+  refreshInSeconds: (seconds: number) => void;
+  stop: () => void;
+  getRefreshTokenFromStorage: () => Promise<string | null>;
+  deleteRefreshTokenFromStorage: () => Promise<void>;
+  storeRefreshToken: (refreshToken: string) => Promise<void>;
+  storageKey: string;
+}

--- a/app/logic/Auth/UI/OAuth2Embed.ts
+++ b/app/logic/Auth/UI/OAuth2Embed.ts
@@ -26,8 +26,8 @@ export class OAuth2Embed extends OAuth2UI {
       this.failFunc = reject;
     });
   }
-  urlChanged(url: URLString) {
-    if (this.oAuth2.isAuthDoneURL(url)) {
+  async urlChanged(url: URLString) {
+    if (await this.oAuth2.isAuthDoneURL(url)) {
       this.success(url);
     }
   }

--- a/app/logic/Auth/UI/OAuth2Tab.ts
+++ b/app/logic/Auth/UI/OAuth2Tab.ts
@@ -29,9 +29,9 @@ export class OAuth2Tab extends OAuth2UI {
       this.failFunc = reject;
     });
   }
-  urlChanged(url: URLString) {
+  async urlChanged(url: URLString) {
     // console.log("OAuth2 page change to", url);
-    if (this.oAuth2.isAuthDoneURL(url)) {
+    if (await this.oAuth2.isAuthDoneURL(url)) {
       this.success(url);
     }
   }

--- a/app/logic/Auth/UI/OAuth2UI.ts
+++ b/app/logic/Auth/UI/OAuth2UI.ts
@@ -1,4 +1,4 @@
-import { OAuth2 } from "../OAuth2";
+import type { OAuth2 } from "../OAuth2";
 import { assert, AbstractFunction } from "../../util/util";
 import { Observable } from "../../util/Observable";
 
@@ -17,7 +17,7 @@ export class OAuth2UI extends Observable {
 
   constructor(oAuth2: OAuth2) {
     super();
-    assert(oAuth2 instanceof OAuth2, "Need OAuth2 object");
+    assert(oAuth2, "Need OAuth2 object");
     this.oAuth2 = oAuth2;
   }
 

--- a/app/logic/Auth/UI/OAuth2Window.ts
+++ b/app/logic/Auth/UI/OAuth2Window.ts
@@ -22,9 +22,9 @@ export class OAuth2Window extends OAuth2UI {
     return await new Promise((resolve, reject) => {
       let ipcRenderer = (window as any).electron.ipcRenderer; // TODO use JPC, or remove window
       let weClosed = false;
-      let onNavigation = (event, url: URLString) => {
+      let onNavigation = async (event, url: URLString) => {
         try {
-          if (this.oAuth2.isAuthDoneURL(url)) {
+          if (await this.oAuth2.isAuthDoneURL(url)) {
             ipcRenderer.removeListener('oauth2-navigate', onNavigation);
             ipcRenderer.removeListener('oauth2-close', onClose);
             weClosed = true;

--- a/app/logic/Mail/AutoConfig/readConfig.ts
+++ b/app/logic/Mail/AutoConfig/readConfig.ts
@@ -14,6 +14,8 @@ import { newFileSharingAccountForProtocol } from "../../Files/AccountsList/FileS
 import { newChatAccountForProtocol } from "../../Chat/AccountsList/ChatAccounts";
 import { newMeetAccountForProtocol } from "../../Meet/AccountsList/MeetAccounts";
 import { SetupInfo } from "./SetupInfo";
+import { OWAAccount } from "../OWA/OWAAccount";
+import { OWAAuth } from "../../Auth/OWAAuth";
 import { OAuth2 } from "../../Auth/OAuth2";
 import { OAuth2URLs } from "../../Auth/OAuth2URLs";
 import JXON from "../../../../lib/util/JXON";
@@ -164,6 +166,9 @@ function readServer(xml: any, displayName: string, fullXML: any, source: ConfigS
 }
 
 function getOAuth2Config(account: Account, autoConfigXML: any): OAuth2 {
+  if (account instanceof OWAAccount) {
+    return new OWAAuth(account);
+  }
   let oAuth2: OAuth2;
   // try built-in
   let hostname = account instanceof TCPAccount ? account.hostname : account.url ? new URL(account.url).hostname : null;

--- a/app/logic/Mail/Import/Thunderbird/TBProfile.ts
+++ b/app/logic/Mail/Import/Thunderbird/TBProfile.ts
@@ -13,6 +13,7 @@ import { newAccountForProtocol } from "../../AccountsList/MailAccounts";
 import { kStandardPorts } from "../../AutoConfig/configInfo";
 import { OAuth2URLs } from "../../../Auth/OAuth2URLs";
 import { OAuth2 } from "../../../Auth/OAuth2";
+import { OWAAuth } from "../../../Auth/OWAAuth";
 import { appGlobal } from "../../../app";
 import { sanitize } from "../../../../../lib/util/sanitizeDatatypes";
 import { arrayRemove, assert, NotReached } from "../../../util/util";
@@ -105,7 +106,7 @@ export class ThunderbirdProfile {
         }
         let url = OAuth2URLs.find(url => url.hostnames.includes(hostname));
         assert(url, `${acc.name}: Need OAuth2 config for host ${hostname}`);
-        acc.oAuth2 = new OAuth2(
+        acc.oAuth2 = acc instanceof OWAAccount ? new OWAAuth(acc) : new OAuth2(
           acc as any as Account,
           url.tokenURL,
           url.authURL,


### PR DESCRIPTION
I may have misunderstood and this is actually option 6 of #809 rather than option 7. Anyway:
- Disable OAuth2 browser choice for OWA login
- Add OWA autofill to in-app OAuth2 browser
- Unprotected all OAuth2 methods because TypeScript won't duck type otherwise
- Make `isAuthDoneURL` async so that OWA can check by running a request
- Force OWA accounts to have the magic `OWAAuth` object instead of a regular `OAuth2` object
- Switch OWA accounts to use `persist:` rather than `persist:login:`

Unfortunately the code in `OWAAuth` and `OAuth2` is so different that I can't really use inheritance. If you prefer I could make a base interface for all of the calls that the various UI object classes make back to the `OAuth2` object.