### PR TITLE
Only use `void` as a return type

### DIFF
--- a/app/logic/Calendar/ActiveSync/ActiveSyncCalendar.ts
+++ b/app/logic/Calendar/ActiveSync/ActiveSyncCalendar.ts
@@ -177,7 +177,7 @@ export class ActiveSyncCalendar extends Calendar implements ActiveSyncPingable {
     this.account.addPingable(this);
   }
 
-  getEventByServerID(id: string): ActiveSyncEvent | void {
+  getEventByServerID(id: string): ActiveSyncEvent | undefined {
     return this.events.find(p => p.serverID == id);
   }
 

--- a/app/logic/Calendar/CalDAV/CalDAVCalendar.ts
+++ b/app/logic/Calendar/CalDAV/CalDAVCalendar.ts
@@ -172,7 +172,7 @@ export class CalDAVCalendar extends Calendar {
     }
   }
 
-  getEventByURL(relativeURL: URLString): CalDAVEvent | void {
+  getEventByURL(relativeURL: URLString): CalDAVEvent | undefined {
     let url = new URL(relativeURL, this.calendarURL).href;
     return this.events.find(e => e.url == url);
   }

--- a/app/logic/Calendar/EWS/EWSCalendar.ts
+++ b/app/logic/Calendar/EWS/EWSCalendar.ts
@@ -132,7 +132,7 @@ export class EWSCalendar extends Calendar {
     return sanitize.string(syncState);
   }
 
-  getEventByItemID(id: string): EWSEvent | void {
+  getEventByItemID(id: string): EWSEvent | undefined {
     return this.events.find(p => p.itemID == id);
   }
 

--- a/app/logic/Calendar/OWA/OWACalendar.ts
+++ b/app/logic/Calendar/OWA/OWACalendar.ts
@@ -44,7 +44,7 @@ export class OWACalendar extends Calendar {
     }));
   }
 
-  protected getEventByItemID(id: string): OWAEvent | void {
+  protected getEventByItemID(id: string): OWAEvent | undefined {
     return this.events.find(p => p.itemID == id);
   }
 

--- a/app/logic/Calendar/OWA/OWAIncomingInvitation.ts
+++ b/app/logic/Calendar/OWA/OWAIncomingInvitation.ts
@@ -16,7 +16,7 @@ const ResponseTypes: Record<InvitationResponseInMessage, string> = {
 export class OWAIncomingInvitation extends IncomingInvitation {
   declare readonly calendar: OWACalendar;
   declare readonly message: OWAEMail;
-  readonly itemID: string | void;
+  readonly itemID: string | undefined;
 
   constructor(calendar: OWACalendar, message: OWAEMail) {
     super(calendar, message);

--- a/app/logic/Contacts/ActiveSync/ActiveSyncAddressbook.ts
+++ b/app/logic/Contacts/ActiveSync/ActiveSyncAddressbook.ts
@@ -127,7 +127,7 @@ export class ActiveSyncAddressbook extends Addressbook implements ActiveSyncPing
     this.account.addPingable(this);
   }
 
-  getPersonByServerID(id: string): ActiveSyncPerson | void {
+  getPersonByServerID(id: string): ActiveSyncPerson | undefined {
     return this.persons.find(p => p.serverID == id);
   }
 

--- a/app/logic/Contacts/CardDAV/CardDAVAddressbook.ts
+++ b/app/logic/Contacts/CardDAV/CardDAVAddressbook.ts
@@ -163,7 +163,7 @@ export class CardDAVAddressbook extends Addressbook {
     }
   }
 
-  getPersonByURL(relativeURL: URLString): CardDAVPerson | void {
+  getPersonByURL(relativeURL: URLString): CardDAVPerson | undefined {
     let url = new URL(relativeURL, this.addressbookURL).href;
     return this.persons.find(p => p.url == url);
   }

--- a/app/logic/Contacts/EWS/EWSAddressbook.ts
+++ b/app/logic/Contacts/EWS/EWSAddressbook.ts
@@ -184,7 +184,7 @@ export class EWSAddressbook extends Addressbook {
     }
   }
 
-  protected getPersonByItemID(id: string): EWSPerson | void {
+  protected getPersonByItemID(id: string): EWSPerson | undefined {
     return this.persons.find(p => p.itemID == id);
   }
 
@@ -231,7 +231,7 @@ export class EWSAddressbook extends Addressbook {
     }
   }
 
-  protected getGroupByItemID(id: string): EWSGroup | void {
+  protected getGroupByItemID(id: string): EWSGroup | undefined {
     return this.groups.find(p => p.itemID == id);
   }
 

--- a/app/logic/Contacts/OWA/OWAAddressbook.ts
+++ b/app/logic/Contacts/OWA/OWAAddressbook.ts
@@ -126,11 +126,11 @@ export class OWAAddressbook extends Addressbook {
     }
   }
 
-  getPersonByPersonaID(id: string): OWAPerson | void {
+  getPersonByPersonaID(id: string): OWAPerson | undefined {
     return this.persons.find(p => p.personaID == id);
   }
 
-  getGroupByPersonaID(id: string): OWAGroup | void {
+  getGroupByPersonaID(id: string): OWAGroup | undefined {
     return this.groups.find(p => p.personaID == id);
   }
 

--- a/app/logic/Mail/ActiveSync/ActiveSyncAccount.ts
+++ b/app/logic/Mail/ActiveSync/ActiveSyncAccount.ts
@@ -505,12 +505,12 @@ export class ActiveSyncAccount extends MailAccount {
           }
           let url = new URL(this.url);
           url.searchParams.set("serverID", deletion.ServerId);
-          let addressbook = appGlobal.addressbooks.find((addressbook: ActiveSyncAddressbook) => addressbook.mainAccount == this && (addressbook.url == url.toString() || addressbook.serverID == deletion.ServerId)) as ActiveSyncAddressbook | void;
+          let addressbook = appGlobal.addressbooks.find((addressbook: ActiveSyncAddressbook) => addressbook.mainAccount == this && (addressbook.url == url.toString() || addressbook.serverID == deletion.ServerId)) as ActiveSyncAddressbook | undefined;
           if (addressbook) {
             this.removePingable(addressbook);
             addressbook.deleteIt();
           }
-          let calendar = appGlobal.calendars.find((calendar: ActiveSyncCalendar) => calendar.mainAccount == this && (calendar.url == url.toString() || calendar.serverID == deletion.ServerId)) as ActiveSyncCalendar | void;
+          let calendar = appGlobal.calendars.find((calendar: ActiveSyncCalendar) => calendar.mainAccount == this && (calendar.url == url.toString() || calendar.serverID == deletion.ServerId)) as ActiveSyncCalendar | undefined;
           if (calendar) {
             this.removePingable(calendar);
             calendar.deleteIt();

--- a/app/logic/Mail/Graph/GraphAccount.ts
+++ b/app/logic/Mail/Graph/GraphAccount.ts
@@ -53,7 +53,7 @@ export class GraphAccount extends MailAccount {
     inbox.startPolling();
 
     /*
-    let addressbook = appGlobal.addressbooks.find((addressbook: GraphAddressbook) => addressbook.protocol == "addressbook-graph" && addressbook.url == this.url && addressbook.username == this.username) as GraphAddressbook | void;
+    let addressbook = appGlobal.addressbooks.find((addressbook: GraphAddressbook) => addressbook.protocol == "addressbook-graph" && addressbook.url == this.url && addressbook.username == this.username) as GraphAddressbook | undefined;
     if (!addressbook) {
       addressbook = newAddressbookForProtocol("addressbook-graph") as GraphAddressbook;
       addressbook.name = this.name;
@@ -67,7 +67,7 @@ export class GraphAccount extends MailAccount {
     addressbook.account = this;
     await addressbook.listContacts();
 
-    let calendar = appGlobal.calendars.find((calendar: GraphCalendar) => calendar.protocol == "calendar-graph" && calendar.url == this.url && calendar.username == this.username) as GraphCalendar | void;
+    let calendar = appGlobal.calendars.find((calendar: GraphCalendar) => calendar.protocol == "calendar-graph" && calendar.url == this.url && calendar.username == this.username) as GraphCalendar | undefined;
     if (!calendar) {
       calendar = newCalendarForProtocol("calendar-graph") as GraphCalendar;
       calendar.name = this.name;
@@ -82,7 +82,7 @@ export class GraphAccount extends MailAccount {
     await calendar.listEvents();
     */
 
-    let chatAccount = appGlobal.chatAccounts.find((calendar: GraphChatAccount) => calendar.protocol == "chat-graph" && calendar.url == this.url && calendar.username == this.username) as GraphChatAccount | void;
+    let chatAccount = appGlobal.chatAccounts.find((calendar: GraphChatAccount) => calendar.protocol == "chat-graph" && calendar.url == this.url && calendar.username == this.username) as GraphChatAccount | undefined;
     if (!chatAccount) {
       chatAccount = newChatAccountForProtocol("chat-graph") as GraphChatAccount;
       chatAccount.name = this.name;

--- a/app/logic/Mail/OWA/OWAAccount.ts
+++ b/app/logic/Mail/OWA/OWAAccount.ts
@@ -40,7 +40,7 @@ export class OWAAccount extends MailAccount {
    * But we have to special-case the root folder,
    * since Mustang doesn't use a dedicated root folder object.
    */
-  msgFolderRootID: string | void;
+  msgFolderRootID: string | undefined;
   @notifyChangedProperty
   hasLoggedIn = false;
   protected notifications: OWANotifications;


### PR DESCRIPTION
`void` has a special meaning as a return type, in that you're not expected to examine the return value at all. We should use `undefined` instead everywhere else, including where you do examine the return value because it's a union type.

Optional chaining works on a variable declared as `string | undefined` but not on one defined as `string | void`.