### PR TITLE
OWA: Stop using sessiondata.ashx

### DIFF
--- a/app/logic/Auth/OWAAuth.ts
+++ b/app/logic/Auth/OWAAuth.ts
@@ -4,6 +4,7 @@ import type { OAuth2 } from "./OAuth2";
 import { OAuth2LoginNeeded } from "./OAuth2Error";
 import { OAuth2Tab } from "./UI/OAuth2Tab";
 import type { OWAAccount } from "../Mail/OWA/OWAAccount";
+import { owaFindFoldersRequest } from "../Mail/OWA/Request/OWAFolderRequests";
 import { appGlobal } from "../app";
 import { assert, NotReached, type URLString } from "../util/util";
 
@@ -65,7 +66,7 @@ export class OWAAuth extends WebBasedAuth {
 
   // Called from `startLogin()` during account setup
   async getAccessTokenFromAuthCode(authCode: string): Promise<string> {
-    await appGlobal.remoteApp.OWA.fetchSessionData(this.account.partition, this.account.url, false);
+    await this.account.callOWA(owaFindFoldersRequest(), true);
     return "";
   }
 
@@ -77,7 +78,7 @@ export class OWAAuth extends WebBasedAuth {
   // Called from `OAuth2Embed.urlChanged()` and `OAuth2Tab.urlChanged()`
   async isAuthDoneURL(url: URLString): Promise<boolean> {
     try {
-      await appGlobal.remoteApp.OWA.fetchSessionData(this.account.partition, this.account.url, false);
+      await this.account.callOWA(owaFindFoldersRequest(), true);
       this.isLoggedIn = true;
     } catch (ex) {
       this.isLoggedIn = false;

--- a/app/logic/Auth/OWAAuth.ts
+++ b/app/logic/Auth/OWAAuth.ts
@@ -66,7 +66,9 @@ export class OWAAuth extends WebBasedAuth {
 
   // Called from `startLogin()` during account setup
   async getAccessTokenFromAuthCode(authCode: string): Promise<string> {
-    await this.account.callOWA(owaFindFoldersRequest(), true);
+    if (!await this.account.testLoggedIn()) {
+      throw new OAuth2LoginNeeded();
+    }
     return "";
   }
 
@@ -77,13 +79,7 @@ export class OWAAuth extends WebBasedAuth {
 
   // Called from `OAuth2Embed.urlChanged()` and `OAuth2Tab.urlChanged()`
   async isAuthDoneURL(url: URLString): Promise<boolean> {
-    try {
-      await this.account.callOWA(owaFindFoldersRequest(), true);
-      this.isLoggedIn = true;
-    } catch (ex) {
-      this.isLoggedIn = false;
-    }
-    return this.isLoggedIn;
+    return this.isLoggedIn = await this.account.testLoggedIn();
   }
 
   // Called from `OAuth2Embed.success()` and `OAuth2Tab.success()`

--- a/app/logic/Mail/OWA/OWAAccount.ts
+++ b/app/logic/Mail/OWA/OWAAccount.ts
@@ -75,7 +75,7 @@ export class OWAAccount extends MailAccount {
     assert(!this.hasLoggedIn, "Only for use during login");
     let url = this.url + 'service.svc';
     let options = { headers: { Action: "FindFolder" } };
-    let bodyJSON = Object.assign({}, owaFindFoldersRequest());
+    let bodyJSON = Object.assign({}, owaFindFoldersRequest(false)); // Remove class before JPC, not needed for JSON
     let  response = await appGlobal.remoteApp.OWA.fetchJSON(this.partition, url, options, bodyJSON);
     if ([401, 440].includes(response.status)) {
       return false;

--- a/app/logic/Mail/OWA/OWAAccount.ts
+++ b/app/logic/Mail/OWA/OWAAccount.ts
@@ -111,8 +111,11 @@ export class OWAAccount extends MailAccount {
       if (response.status == 401 || responseURL.origin == formURL.origin && responseURL.pathname == formURL.pathname && responseURL.searchParams.get("reason") == "2") {
         throw new LoginError(null, gt`Password incorrect`);
       }
-      if (!response.ok || !await this.testLoggedIn()) {
+      if (!response.ok) {
         throw new Error(`HTTP ${response.status} ${response.statusText}`);
+      }
+      if (!await this.testLoggedIn()) {
+        throw new LoginError(`Login check failed`);
       }
     }
   }

--- a/app/logic/Mail/OWA/Request/OWAFolderRequests.ts
+++ b/app/logic/Mail/OWA/Request/OWAFolderRequests.ts
@@ -165,6 +165,32 @@ export function owaMoveOrCopyMsgsIntoFolderRequest(action: "Move" | "Copy", fold
   });
 }
 
+export function owaFindFoldersRequest(deep?: true): OWARequest {
+  return new OWARequest("FindFolder", {
+    __type: "FindFolderRequest:#Exchange",
+    FolderShape: {
+      BaseShape: "Default",
+      AdditionalProperties: [{
+        __type: "PropertyUri:#Exchange",
+          FieldURI: "folder:FolderClass",
+      }, {
+        __type: "PropertyUri:#Exchange",
+          FieldURI: "folder:ParentFolderId",
+      }, {
+        __type: "PropertyUri:#Exchange",
+          FieldURI: "folder:DistinguishedFolderId",
+      }],
+    },
+    Paging: null,
+    ParentFolderIds: [{
+      __type: "DistinguishedFolderId:#Exchange",
+      Id: "msgfolderroot",
+    }],
+    ReturnParentFolder: true,
+    Traversal: deep ? "Deep" : "Shallow",
+  });
+}
+
 export function owaMoveEntireFolderRequest(sourceFolderID: string, newParentFolderId: string): OWARequest {
   return new OWARequest("MoveFolder", {
     __type: "MoveFolderRequest:#Exchange",

--- a/backend/owa.ts
+++ b/backend/owa.ts
@@ -4,105 +4,6 @@ import { Readable } from 'stream';
 const kCanaryName = "X-OWA-CANARY";
 const kHotmailServer = "outlook.live.com";
 
-export async function fetchSessionData(partition: string, url: string, interactive?: boolean, autoFillLoginPage?: string) {
-  let session = Session.fromPartition(partition);
-  let response = await session.fetch(url + 'sessiondata.ashx', { method: 'POST' });
-  if ([401, 440].includes(response.status) && interactive) {
-    return await new Promise(resolve => {
-      let urlObj = new URL(url);
-      // We want to skip the landing page for personal Microsoft accounts.
-      let isHotmail = urlObj.hostname == kHotmailServer;
-      if (isHotmail) {
-        url = url + "?nlp=1";
-      }
-      let popup = new BrowserWindow({
-        //parent: mainWindow,
-        //modal: true,
-        center: true,
-        autoHideMenuBar: true,
-        webPreferences: {
-          session,
-          // Security
-          sandbox: true,
-          disableHtmlFullscreenWindowResize: true,
-          webgl: false,
-          autoplayPolicy: "user-gesture-required",
-        },
-      });
-      let finished = false;
-      let finish = function(data) {
-        if (finished) {
-          return;
-        }
-        finished = true;
-        session.cookies.removeListener('changed', onCookie);
-        resolve(data);
-        if (!popup.isDestroyed()) {
-          popup.destroy();
-        }
-      };
-      let checkLoginFinished = async function() {
-        try {
-          url = urlObj.href;
-          response = await session.fetch(url + 'sessiondata.ashx', { method: 'POST' });
-          let json = await response.json();
-          if (isHotmail) {
-            json.owaURL = url;
-          }
-          finish(json);
-        } catch (ex) {
-        }
-      }
-      let onCookie = async function (_event, cookie, _cause, removed) {
-        try {
-          if (removed) {
-            return;
-          }
-          // For Hotmail, check the path to the CANARY cookie.
-          if (cookie.domain == kHotmailServer &&
-            cookie.name == kCanaryName &&
-            cookie.path?.startsWith("/owa/")) {
-            // Hotmail also sets cookies for /owa/0/, /mail/0/, /calendar/0/ etc.,
-            // but we can use only the /owa/0/ cookie.
-            // We also need to use that URL for the service request.
-            // This needs to happen before CheckLoginFinished().
-            urlObj.hostname = cookie.domain;
-            urlObj.pathname = cookie.path;
-            isHotmail = true;
-          }
-          // If we receive the canary cookie, check whether we're logged in
-          if (cookie.name == kCanaryName &&
-            cookie.domain == urlObj.hostname) {
-            await checkLoginFinished();
-          }
-        } catch (ex) {
-          console.error(ex);
-        }
-      };
-      let checkLoaded = async function(_event) {
-        let cookies = await Session.fromPartition(partition).cookies.get({ name: kCanaryName });
-        if (cookies[0]?.value) {
-          await checkLoginFinished();
-        } else if (autoFillLoginPage) {
-          try {
-            await popup.webContents.executeJavaScript(autoFillLoginPage);
-          } catch (ex) {
-            console.error(ex);
-          }
-        }
-      };
-      session.cookies.on('changed', onCookie);
-      popup.on('closed', function() { finish(null); });
-      popup.webContents.on('did-stop-loading', checkLoaded);
-      popup.loadURL(url);
-    });
-  }
-  if (!response.ok) {
-    throw new Error(`HTTP ${response.status} ${response.statusText}`);
-  }
-  return await response.json();
-}
-
 export async function fetchJSON(partition: string, url: string, options: any, bodyJSON: any) {
   let result = {
     ok: false,
@@ -281,7 +182,7 @@ class EventDecoder {
         this.event.id = value;
         break;
       case 'retry':
-        if (!Number.isInteger(value)) {
+        if (Number.isInteger(value)) {
           this.event.retry = Number(value);
         }
         break;


### PR DESCRIPTION
As requested in PR #815.

Note that `callOWA` uses `fetchJSON` which checks for the `X-OWA-CANARY` cookie before hitting the network.