### PR TITLE
Password lost when changing account type in manual setup

### DIFF
--- a/app/logic/Mail/MailAccount.ts
+++ b/app/logic/Mail/MailAccount.ts
@@ -178,6 +178,7 @@ export class MailAccount extends TCPAccount {
     this.tls = other.tls;
     this.authMethod = other.authMethod;
     this.username = other.username;
+    this.password = other.password;
     this.emailAddress = other.emailAddress;
     this.realname = other.realname;
 


### PR DESCRIPTION
During setup, the password on the initial setup screen does not get copied to the manual setup UI. (Whether that is in itself a bug is outside the scope of this PR.)

However, the manual setup UI shows `••••••••` as a placeholder, making it look as if the password has in fact been copied.

I suggest that the placeholder only be set if there is in fact a password.

I've also suggested a different placeholder but if you don't like that idea then that's less important.