### PR TITLE
Allow manual setup of OWA accounts with full page login again

### DIFF
--- a/app/frontend/Settings/Mail/Manual/ManualConfigURL.svelte
+++ b/app/frontend/Settings/Mail/Manual/ManualConfigURL.svelte
@@ -49,6 +49,9 @@
 <script lang="ts">
   import type { MailAccount } from "../../../../logic/Mail/MailAccount";
   import { AuthMethod } from "../../../../logic/Abstract/Account";
+  import { OAuth2URLs } from "../../../../logic/Auth/OAuth2URLs";
+  import { OAuth2 } from "../../../../logic/Auth/OAuth2";
+  import { OWAAuth } from "../../../../logic/Auth/OWAAuth";
   import { TLSSocketType } from "../../../../logic/Abstract/TCPAccount";
   import ProtocolSelector from "./ProtocolSelector.svelte";
   import PasswordChange from "../../Shared/PasswordChange.svelte";
@@ -134,6 +137,15 @@
     if (config.authMethod == AuthMethod.Unknown) {
       authError = new Error("Please enter the authentication method");
       throw authError;
+    } else if (config.authMethod == AuthMethod.OAuth2) {
+      if (config.protocol == "owa") {
+        config.oAuth2 = new OWAAuth(config);
+      } else {
+        let oAuth = OAuth2URLs.find(o => o.hostnames.some(h => h == config.hostname));
+        if (oAuth) {
+          config.oAuth2 = new OAuth2(config, oAuth.tokenURL, oAuth.authURL, oAuth.authDoneURL, oAuth.scope, oAuth.clientID, oAuth.clientSecret, oAuth.doPKCE);
+        }
+      }
     } else {
       authError = null;
     }

--- a/app/frontend/Setup/Mail/SetupMail.svelte
+++ b/app/frontend/Setup/Mail/SetupMail.svelte
@@ -184,7 +184,11 @@
       }
       fillConfig(config, emailAddress, password);
       errorMessage = null;
-      step = Step.CheckConfig;
+      if (config.oAuth2) {
+        step = Step.Login;
+      } else {
+        step = Step.CheckConfig;
+      }
     } else if (step == Step.CheckConfig) {
       step = Step.FinalizeConfig;
     } else if (step == Step.FinalizeConfig) {


### PR DESCRIPTION
PR #815 changed the way OWA full page login works, which broke manual setup.

Manual setup also didn't work properly with EWS accounts, and this also improves that.

The changes in `ManualConfigURL` were ported from `ManualConfigHostServer`, while the change in `SetupMail` was ported from line 173 as I assume manual setup has no instructions.