### PR TITLE
Android: APK and AAB naming

### DIFF
--- a/mobile/android/app/build.gradle
+++ b/mobile/android/app/build.gradle
@@ -45,8 +45,8 @@ android {
             def ext = output.outputFile.name.endsWith('.apk') ? '.apk' : '.aab'
             if (buildType == 'release') {
                 outputFileName = "${appName}-${version}${ext}"
-            } else if (buildType == 'debug') {
-                outputFileName = "${appName}-${version}-debug${ext}"
+            }
+        }
 
         tasks.named("sign${variant.name.capitalize()}Bundle", FinalizeBundleTask) {
             if (variant.name == "release") {


### PR DESCRIPTION
- Don't rename APK Debug filename
- Rename AAB release file