### PR TITLE
Pre-filter event collections in the day and month views #842

### DIFF
--- a/app/frontend/Calendar/DayView/EventsBlockCell.svelte
+++ b/app/frontend/Calendar/DayView/EventsBlockCell.svelte
@@ -1,9 +1,7 @@
 <vbox flex class="events" on:dblclick={addEvent}>
   {#if $displayEvents && !$displayEvents.isEmpty}
     {#each $displayEvents.each as event (event.id)}
-      {#if event.startTime && event.endTime}
-        <EventBlock {event} {start} {end} conflicts={displayEvents} />
-      {/if}
+      <EventBlock {event} {start} {end} conflicts={displayEvents} />
     {/each}
   {/if}
 </vbox>

--- a/app/frontend/Calendar/DayView/EventsBlockCell.svelte
+++ b/app/frontend/Calendar/DayView/EventsBlockCell.svelte
@@ -28,7 +28,7 @@
   function setEnd() {
     end = new Date(start);
     end.setHours(end.getHours() + intervalInHours);
-    displayEvents = events.filterObservable(ev => ev.startTime < end && ev.endTime > start && !ev.allDay);
+    displayEvents = events.filterObservable(ev => ev.startTime < end && ev.endTime > start);
   }
 
   function addEvent() {

--- a/app/frontend/Calendar/DayView/EventsBlockCell.svelte
+++ b/app/frontend/Calendar/DayView/EventsBlockCell.svelte
@@ -26,7 +26,7 @@
   function setEnd() {
     end = new Date(start);
     end.setHours(end.getHours() + intervalInHours);
-    displayEvents = events.filterObservable(ev => ev.startTime < end && ev.endTime > start);
+    displayEvents = events.filterObservable(ev => ev.startTime < end && ev.endTime > start && !ev.allDay);
   }
 
   function addEvent() {

--- a/app/frontend/Calendar/DayView/TimeDayRow.svelte
+++ b/app/frontend/Calendar/DayView/TimeDayRow.svelte
@@ -17,10 +17,7 @@
     startTimes = [];
     for (let day of days) {
       let startTime = new Date(day);
-      startTime.setHours(time.getHours());
-      startTime.setMinutes(0);
-      startTime.setSeconds(0);
-      startTime.setMilliseconds(0);
+      startTime.setHours(time.getHours(), 0, 0, 0);
       startTimes.push(startTime);
     }
   }

--- a/app/frontend/Calendar/DayView/WeekView.svelte
+++ b/app/frontend/Calendar/DayView/WeekView.svelte
@@ -72,9 +72,7 @@
   $: start, setStartTimes();
   function setStartTimes() {
     let startTime = new Date(start);
-    startTime.setMinutes(0);
-    startTime.setSeconds(0);
-    startTime.setMilliseconds(0);
+    startTime.setMinutes(0, 0, 0);
     startTimes = [];
     for (let i = startHour; i < endHour; i += intervalHour) {
       startTime.setHours(i);
@@ -91,10 +89,7 @@
     if (showDays > 3) {
       startTime.setDate(startTime.getDate() - 1);
     }
-    startTime.setHours(startHour);
-    startTime.setMinutes(0);
-    startTime.setSeconds(0);
-    startTime.setMilliseconds(0);
+    startTime.setHours(startHour, 0, 0, 0);
     let filterStart = new Date(startTime);
     days = [];
     for (let i = 0; i < showDays; i++) {

--- a/app/frontend/Calendar/DayView/WeekView.svelte
+++ b/app/frontend/Calendar/DayView/WeekView.svelte
@@ -26,7 +26,7 @@
         {/each}
         {#each startTimes as start}
           <TimeLabel time={start} />
-          <TimeDayRow {days} time={start} {events} />
+          <TimeDayRow {days} time={start} events={visibleEvents} />
         {/each}
       </grid>
     </Scroll>
@@ -83,28 +83,24 @@
   }
 
   let days: Date[] = [];
+  let visibleEvents: Collection<Event>;
+  let allDayEvents: Collection<Event>;
   $: start, setDays();
   function setDays() {
     let startTime = new Date(start);
     if (showDays > 3) {
       startTime.setDate(startTime.getDate() - 1);
     }
-    startTime.setHours(startHour);
-    startTime.setMinutes(0);
-    startTime.setSeconds(0);
-    startTime.setMilliseconds(0);
+    let filterStart = startTime.setHours(startHour, 0, 0, 0);
     days = [];
     for (let i = 0; i < showDays; i++) {
       days.push(new Date(startTime));
-      startTime.setDate(startTime.getDate() + 1)
+      startTime.setDate(startTime.getDate() + 1);
     }
-  }
-
-  let allDayEvents: Collection<Event>;
-  $: start, $events, setAllDayEvents();
-  function setAllDayEvents() {
-    let end = new Date(start.getTime() + showDays * k1DayMS);
-    allDayEvents = events.filterObservable(ev => ev.allDay && ev.startTime < end && start < ev.endTime);
+    let filterEnd = startTime.getTime();
+    let filtered = events.filterObservable(ev => ev.startTime && ev.startTime < filterEnd && filterStart < ev.endTime);
+    visibleEvents = filtered.filterObservable(ev => !ev.allDay);
+    allDayEvents = filtered.filterObservable(ev => ev.allDay);
   }
 
   function goToToday() {

--- a/app/frontend/Calendar/DayView/WeekView.svelte
+++ b/app/frontend/Calendar/DayView/WeekView.svelte
@@ -91,13 +91,17 @@
     if (showDays > 3) {
       startTime.setDate(startTime.getDate() - 1);
     }
-    let filterStart = startTime.setHours(startHour, 0, 0, 0);
+    startTime.setHours(startHour);
+    startTime.setMinutes(0);
+    startTime.setSeconds(0);
+    startTime.setMilliseconds(0);
+    let filterStart = new Date(startTime);
     days = [];
     for (let i = 0; i < showDays; i++) {
       days.push(new Date(startTime));
       startTime.setDate(startTime.getDate() + 1);
     }
-    let filterEnd = startTime.getTime();
+    let filterEnd = startTime;
     let filtered = events.filterObservable(ev => ev.startTime && ev.startTime < filterEnd && filterStart < ev.endTime);
     visibleEvents = filtered.filterObservable(ev => !ev.allDay);
     allDayEvents = filtered.filterObservable(ev => ev.allDay);

--- a/app/frontend/Calendar/MonthView/MonthView.svelte
+++ b/app/frontend/Calendar/MonthView/MonthView.svelte
@@ -18,7 +18,7 @@
         class:selected={day.getTime() == $selectedDate?.getTime()}
         >
         <DayLabel {day} />
-        <EventsLineCell start={day} {events} intervalInHours={24}
+        <EventsLineCell start={day} events={filteredEvents} intervalInHours={24}
           withMonthOnFirst={true} withMonthOnMonday={true} />
       </vbox>
     {/each}
@@ -42,6 +42,7 @@
 
   let days: Date[] = [];
   let weekDays: Date[] = [];
+  let filteredEvents: Collection<Event>;
   $: start, setDays();
   function setDays() {
     weekDays = getWeekDays(start);
@@ -52,11 +53,14 @@
       }
     }
     let startTime = weekDays[0]; // Always start with Monday
+    let filterStart = startTime.getTime();
     days = [];
     for (let i = 0; i < showDays; i++) {
       days.push(new Date(startTime));
       startTime.setDate(startTime.getDate() + 1)
     }
+    let filterEnd = startTime.getTime();
+    filteredEvents = events.filterObservable(ev => ev.startTime && ev.startTime < filterEnd && filterStart < ev.endTime);
   }
 
   function onScrollWheel(event: WheelEvent) {

--- a/app/frontend/Calendar/MonthView/MonthView.svelte
+++ b/app/frontend/Calendar/MonthView/MonthView.svelte
@@ -53,13 +53,13 @@
       }
     }
     let startTime = weekDays[0]; // Always start with Monday
-    let filterStart = startTime.getTime();
+    let filterStart = new Date(startTime);
     days = [];
     for (let i = 0; i < showDays; i++) {
       days.push(new Date(startTime));
       startTime.setDate(startTime.getDate() + 1)
     }
-    let filterEnd = startTime.getTime();
+    let filterEnd = startTime;
     filteredEvents = events.filterObservable(ev => ev.startTime && ev.startTime < filterEnd && filterStart < ev.endTime);
   }
 


### PR DESCRIPTION
As mentioned in #842, if I have 11870 events (recurring instances) then that results in 2991240 subscriptions by `filterObservable` and the Calendar first time open is three seconds; with these extra filters, this reduces to 110972 subscriptions and the Calendar first time open time reduces to under half a second.