### PR TITLE
Android build: Move env from workflow to scripts

### DIFF
--- a/.github/workflows/installer-android.yml
+++ b/.github/workflows/installer-android.yml
@@ -37,10 +37,6 @@ jobs:
     - run: cd mobile; yarn install
     - run: cd mobile/backend; yarn install
     - run: cd mobile; yarn build
-      env:
-        ANDROID_LIBNODE: "https://github.com/mustang-im/nodejs-mobile/releases/download/v22.9.0/nodejs-mobile-v22.9.0-android.zip"
-        ANDROID_SDK: --sdk35
-        MOBILE_ARCH: 'android-arm64'
 
     - run: |
         mkdir -p ${{ github.workspace }}//private_keys/

--- a/mobile/backend/prebuild.sh
+++ b/mobile/backend/prebuild.sh
@@ -1,7 +1,11 @@
 #!/usr/bin/env bash
 
 export ANDROID_LIBNODE="https://github.com/mustang-im/nodejs-mobile/releases/download/v22.9.0/nodejs-mobile-v22.9.0-android.zip"
+export ANDROID_SDK="--sdk35"
 
 cd node_modules;
 (cd better-sqlite3 && npx prebuild-for-nodejs-mobile $MOBILE_ARCH $ANDROID_SDK) &&
 (cd bufferutil && npx prebuild-for-nodejs-mobile $MOBILE_ARCH $ANDROID_SDK)
+
+unset ANDROID_LIBNODE
+unset ANDROID_SDK

--- a/mobile/docs/build.md
+++ b/mobile/docs/build.md
@@ -8,12 +8,11 @@
 3. `cd backend; yarn install`
 4. `cd mobile; yarn install`
 5. `cd mobile/backend; yarn install`
-6. `export MOBILE_ARCH=android-arm64`
-7. `cd mobile; yarn build`
-8. `cd mobile; npx cap sync android`
-9. `npx cap open android` in `/mobile`
-10. Wait for the project to be fully loaded and Gradle Sync to finish running
-11. Go to `Build > Generate Signed App Bundle or APK` and follow the steps
+6. `cd mobile; yarn build`
+7. `cd mobile; npx cap sync android`
+8. `npx cap open android` in `/mobile`
+9. Wait for the project to be fully loaded and Gradle Sync to finish running
+10. Go to `Build > Generate Signed App Bundle or APK` and follow the steps
 
 ### Building with CI
 
@@ -42,7 +41,6 @@ fails when there's no tag for the commit which fails when you manually trigger i
 4. `cd backend; yarn install`
 5. `cd mobile; yarn install`
 6. `cd mobile/backend; yarn install`
-7. `export MOBILE_ARCH=android-arm64`
-8. `cd mobile; yarn build`
-9. Set the envs `KEYSTORE_PATH`, `KEYSTORE_PASS`, `KEYSTORE_ALIAS`, `KEYSTORE_ALIAS_PASS`
-10. `cd mobile; yarn build:android`
+7. `cd mobile; yarn build`
+8. Set the envs `KEYSTORE_PATH`, `KEYSTORE_PASS`, `KEYSTORE_ALIAS`, `KEYSTORE_ALIAS_PASS`
+9. `cd mobile; yarn build:android`

--- a/mobile/package.json
+++ b/mobile/package.json
@@ -9,8 +9,8 @@
     "start:ios": "cap run ios",
     "build": "./hooks/common/build.sh",
     "build:android": "npm run build:android:apk && npm run build:android:aab",
-    "build:android:apk": "cap sync android && cd android && ./gradlew --configuration-cache assembleRelease",
-    "build:android:aab": "cap sync android && cd android && ./gradlew --configuration-cache :app:bundleRelease",
+    "build:android:apk": "export MOBILE_ARCH=android-arm64; npm run build && cap sync android && cd android && ./gradlew --configuration-cache assembleRelease",
+    "build:android:aab": "export MOBILE_ARCH=android-arm64; npm run build && cap sync android && cd android && ./gradlew --configuration-cache :app:bundleRelease",
     "preview": "vite preview",
     "setup:ios": "cd ios && ./setup-ios.sh",
     "capacitor:update:before": "vite-node ./hooks/android/update-project.ts"


### PR DESCRIPTION
- Many of the env variables were set in the CI script so when you did a local build those env variables were not set
- Moved all the env variables to be included in the npm and sh scripts