### PR TITLE
Optimise recurrence rule editing #842

### DIFF
--- a/app/frontend/Calendar/EditEvent/EditEvent.svelte
+++ b/app/frontend/Calendar/EditEvent/EditEvent.svelte
@@ -88,7 +88,7 @@
 
   export let event: Event;
 
-  $: showRepeat = !!event.recurrenceRule || event.parentEvent && event.isNew;
+  $: showRepeat = !!$event.recurrenceRule || event.parentEvent && event.isNew;
   $: showReminder = !!$event.alarm;
   $: showParticipants = $event.participants.hasItems;
   $: showLocation = !!$event.location;

--- a/app/frontend/Calendar/EditEvent/RepeatBox.svelte
+++ b/app/frontend/Calendar/EditEvent/RepeatBox.svelte
@@ -109,7 +109,8 @@
 
   $: $event.startTime, $event.duration, updateDateUI();
   function updateDateUI() {
-    // This should close the repeat box, but this update might run first.
+    // Setting the frequency to None should close the repeat box,
+    // but Svelte might decide to run this function again first.
     if (frequency == Frequency.None) {
       return;
     }

--- a/app/frontend/Calendar/EditEvent/RepeatBox.svelte
+++ b/app/frontend/Calendar/EditEvent/RepeatBox.svelte
@@ -109,6 +109,11 @@
 
   $: $event.startTime, $event.duration, updateDateUI();
   function updateDateUI() {
+    // This should close the repeat box, but this update might run first.
+    if (frequency == Frequency.None) {
+      return;
+    }
+
     master.startEditing();
     master.startTime = event.startTime;
     master.duration = event.duration;

--- a/app/logic/Calendar/Event.ts
+++ b/app/logic/Calendar/Event.ts
@@ -334,7 +334,10 @@ export class Event extends Observable {
         init.weekdays = [this.startTime.getDay()]; // e.g. 3rd Wednesday of month
       }
     }
-    this.recurrenceRule = new RecurrenceRule(init);
+    let recurrenceRule = new RecurrenceRule(init);
+    if (!recurrenceRule.timesMatch(this.recurrenceRule)) {
+      this.recurrenceRule = recurrenceRule;
+    }
   }
 
   /** Create a new instance of the same event.
@@ -442,8 +445,11 @@ export class Event extends Observable {
       return;
     }
     this.timezone ||= myTimezone();
-    this.unedited = this.calendar.newEvent();
+    // Use a raw event to avoid automatic instance generation.
+    this.unedited = new Event();
     this.unedited.copyFrom(this);
+    // Instead, just shallow clone our instances (needed for `seriesStatus`)
+    this.unedited.instances.replaceAll(this.instances);
   }
   finishEditing() {
     if (this.unedited?.recurrenceCase == RecurrenceCase.Master) {


### PR DESCRIPTION
- Changing the frequency to None wasn't collapsing the repeat box
- Even when it does, sometimes `updateDateUI` runs first; in this case we don't want the update, as the rule would be invalid
- Even when `updateDateUI` is supposed to run, the rule may already be valid, so don't update it, as that will regenerate the instances
- When first editing the event, don't bother generating the instances on the unedited copy, instead just shallow clone them