### PR TITLE
Android: Debugging

### DIFF
--- a/mobile/android/app/build.gradle
+++ b/mobile/android/app/build.gradle
@@ -34,6 +34,9 @@ android {
             minifyEnabled false
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
         }
+        debug {
+            debuggable true
+        }
     }
     def appName = "mustang"
     def version = android.defaultConfig.versionName

--- a/mobile/docs/debug.md
+++ b/mobile/docs/debug.md
@@ -1,0 +1,15 @@
+# Debugging
+
+## Android
+
+### Frontend
+
+1. Do the steps to build
+2. Replace the step for `yarn build:android` with `cd android && ./gradlew assembleDebug`
+3. Run the emulator
+4. Install the APK from `/android/app/build/outputs/apk/app-debug.apk`
+5. Run the app
+6. Open Chrome browser
+7. Go to `chrome://inspect/#devices`
+8. See your app under the `Remote Target`
+9. Click inspect


### PR DESCRIPTION
- We need to enable debuggable to true for the debug build for it to output logs and for the debug build to work
- This is still not done since I have have no idea how to debug without `adb` and `Android Studio`. There's only guides on how to use `Android Studio` or `adb` to debug