### PR TITLE
Remove duplicated allDay check #846

### DIFF
--- a/app/frontend/Calendar/DayView/EventsBlockCell.svelte
+++ b/app/frontend/Calendar/DayView/EventsBlockCell.svelte
@@ -27,7 +27,7 @@
   function setEnd() {
     end = new Date(start);
     end.setHours(end.getHours() + intervalInHours);
-    displayEvents = events.filterObservable(ev => ev.startTime < end && ev.endTime > start && !ev.allDay);
+    displayEvents = events.filterObservable(ev => ev.startTime < end && ev.endTime > start);
   }
 
   function addEvent() {


### PR DESCRIPTION
PR #846 added filtering to DayView and WeekView to reduce the number of subscriptions to individual events.

As part of this filtering, WeekView further filters on `allDay` (for the existing `allDayEvents` variable) and `!allDay` for the new `visibleEvents` variable.

These new filtered events then get passed down through `TimeDayRow` into `EventsBlockCell`, which no longer has to filter on `!allDay` itself.