### PR TITLE
Remove duplicate call to getOrCreateIDForLocalObject #841

### DIFF
--- a/lib/jpc/obj.js
+++ b/lib/jpc/obj.js
@@ -471,7 +471,6 @@ export default class BaseProtocol {
     } else if (Array.isArray(value)) {
       return value.map(el => this.mapOutgoingObjects(el));
     } else if (typeof (value) == "function") {
-      let id = this.getOrCreateIDForLocalObject(value);
       return {
         idSender: this.getOrCreateIDForLocalObject(value),
         className: "Function",


### PR DESCRIPTION
Found by `tsc --noUnusedLocals`.