### PR TITLE
EWS, OWA: Actually use local weekdays varible in `saveRule` #841

### DIFF
--- a/app/logic/Calendar/EWS/EWSEvent.ts
+++ b/app/logic/Calendar/EWS/EWSEvent.ts
@@ -267,7 +267,7 @@ export class EWSEvent extends Event {
     }
     if (/^Relative|^Weekly/.test(recurrenceType)) {
       let weekdays = rule.weekdays || [rule.seriesStartTime.getDay()];
-      pattern.t$DaysOfWeek = rule.weekdays.map(day => Weekday[day]).join(" ");
+      pattern.t$DaysOfWeek = weekdays.map(day => Weekday[day]).join(" ");
     }
     if (rule.frequency == Frequency.Weekly) {
       pattern.t$FirstDayOfWeek = Weekday[rule.first];

--- a/app/logic/Calendar/OWA/OWAEvent.ts
+++ b/app/logic/Calendar/OWA/OWAEvent.ts
@@ -316,7 +316,7 @@ export class OWAEvent extends Event {
     }
     if (/^Relative|^Weekly/.test(recurrenceType)) {
       let weekdays = rule.weekdays || [rule.seriesStartTime.getDay()];
-      recurrence.RecurrencePattern.DaysOfWeek = rule.weekdays.map(day => Weekday[day]).join(" ");
+      recurrence.RecurrencePattern.DaysOfWeek = weekdays.map(day => Weekday[day]).join(" ");
     }
     if (rule.frequency == Frequency.Weekly) {
       recurrence.RecurrencePattern.FirstDayOfWeek = Weekday[rule.first];


### PR DESCRIPTION
Found by `tsc --noUnusedLocals`.