### PR TITLE
`fullDate` and `dateDetails` should be typed as `Intl.DateTimeFormatOptions` #841

### DIFF
--- a/app/frontend/Util/date.ts
+++ b/app/frontend/Util/date.ts
@@ -13,7 +13,7 @@ export function getDateTimeString(date: Date): string {
   if (!date) {
     return "";
   }
-  let dateDetails = null;
+  let dateDetails: Intl.DateTimeOptions;
   let today = new Date();
   if (date.getDate() == today.getDate() && today.getTime() - date.getTime() < k1DayMS) { // today
     dateDetails = { hour: "numeric", minute: "numeric" };
@@ -37,11 +37,11 @@ export function getDateTimeString(date: Date): string {
 * Each in locale
 * See also <https://momentjs.com> for relative time
 */
-export function getDateString(date: Date, fullDate = { year: "numeric", month: "2-digit", day: "2-digit" }): string {
+export function getDateString(date: Date, fullDate: Intl.DateTimeOptions = { year: "numeric", month: "2-digit", day: "2-digit" }): string {
   if (!date) {
     return "";
   }
-  let dateDetails = null;
+  let dateDetails: Intl.DateTimeOptions;
   let today = new Date();
   if (date.getDate() == today.getDate() && today.getTime() - date.getTime() < k1DayMS) { // today
     return gt`Today`;


### PR DESCRIPTION
Found by `tsc --strictNullChecks` (11 error messages in total).