### PR TITLE
Remove some unused imports #841

### DIFF
--- a/app/logic/Auth/OWAAuth.ts
+++ b/app/logic/Auth/OWAAuth.ts
@@ -1,10 +1,7 @@
 import { WebBasedAuth } from "./WebBasedAuth";
-import type { OAuth2UIMethod } from "./UI/OAuth2UIMethod";
-import type { OAuth2 } from "./OAuth2";
 import { OAuth2LoginNeeded } from "./OAuth2Error";
 import { OAuth2Tab } from "./UI/OAuth2Tab";
 import type { OWAAccount } from "../Mail/OWA/OWAAccount";
-import { owaFindFoldersRequest } from "../Mail/OWA/Request/OWAFolderRequests";
 import { appGlobal } from "../app";
 import { assert, NotReached, type URLString } from "../util/util";
 

--- a/app/logic/Calendar/EWS/EWSEvent.ts
+++ b/app/logic/Calendar/EWS/EWSEvent.ts
@@ -10,7 +10,7 @@ import { EWSDeleteItemRequest } from "../../Mail/EWS/Request/EWSDeleteItemReques
 import { EWSUpdateItemRequest } from "../../Mail/EWS/Request/EWSUpdateItemRequest";
 import { k1MinuteMS } from "../../../frontend/Util/date";
 import { sanitize } from "../../../../lib/util/sanitizeDatatypes";
-import { assert, ensureArray, NotReached } from "../../util/util";
+import { assert, ensureArray } from "../../util/util";
 import type { ArrayColl } from "svelte-collections";
 
 const ResponseTypes: Record<InvitationResponseInMessage, string> = {

--- a/app/logic/Mail/ActiveSync/ActiveSyncAccount.ts
+++ b/app/logic/Mail/ActiveSync/ActiveSyncAccount.ts
@@ -18,7 +18,7 @@ import { ensureLicensed } from "../../util/LicenseClient";
 import { appGlobal } from "../../app";
 import { Throttle } from "../../util/Throttle";
 import { Semaphore } from "../../util/Semaphore";
-import { ensureArray, assert, NotSupported, sleep } from "../../util/util";
+import { ensureArray, assert, NotSupported } from "../../util/util";
 import { sanitize } from "../../../../lib/util/sanitizeDatatypes";
 import { ArrayColl } from "svelte-collections";
 import { gt } from "../../../l10n/l10n";

--- a/app/logic/Mail/ActiveSync/ActiveSyncFolder.ts
+++ b/app/logic/Mail/ActiveSync/ActiveSyncFolder.ts
@@ -4,7 +4,7 @@ import type { ActiveSyncAccount, ActiveSyncPingable } from "./ActiveSyncAccount"
 import { ActiveSyncError } from "./ActiveSyncError";
 import { CreateMIME } from "../SMTP/CreateMIME";
 import type { EMailCollection } from "../Store/EMailCollection";
-import { ensureArray, assert, NotImplemented, NotSupported } from "../../util/util";
+import { ensureArray, NotImplemented, NotSupported } from "../../util/util";
 import { sanitize } from "../../../../lib/util/sanitizeDatatypes";
 import { ArrayColl, type Collection } from "svelte-collections";
 import { gt } from "../../../l10n/l10n";

--- a/app/logic/Mail/EWS/EWSFolder.ts
+++ b/app/logic/Mail/EWS/EWSFolder.ts
@@ -5,7 +5,7 @@ import type { EWSAccount } from "./EWSAccount";
 import { EWSCreateItemRequest } from "./Request/EWSCreateItemRequest";
 import { CreateMIME } from "../SMTP/CreateMIME";
 import { sanitize } from "../../../../lib/util/sanitizeDatatypes";
-import { base64ToArrayBuffer, blobToBase64, ensureArray, assert } from "../../util/util";
+import { base64ToArrayBuffer, blobToBase64, ensureArray } from "../../util/util";
 import { ArrayColl, Collection } from "svelte-collections";
 
 export const kMaxCount = 50;

--- a/app/logic/Mail/Folder.ts
+++ b/app/logic/Mail/Folder.ts
@@ -5,7 +5,7 @@ import { EMailCollection } from "./Store/EMailCollection";
 import { Observable, notifyChangedProperty } from "../util/Observable";
 import { ArrayColl, Collection } from 'svelte-collections';
 import { Lock } from "../util/Lock";
-import { assert, AbstractFunction, NotImplemented } from "../util/util";
+import { assert, AbstractFunction } from "../util/util";
 import { gt } from "../../l10n/l10n";
 
 export class Folder extends Observable implements TreeItem<Folder> {

--- a/app/logic/Mail/OWA/OWAAccount.ts
+++ b/app/logic/Mail/OWA/OWAAccount.ts
@@ -16,8 +16,6 @@ import { OWASubscribeToNotificationRequest } from "./Request/OWASubscribeToNotif
 import { owaCreateNewTopLevelFolderRequest, owaFindFoldersRequest } from "./Request/OWAFolderRequests";
 import { OWALoginBackground } from "./Login/OWALoginBackground";
 import type { PersonUID } from "../../Abstract/PersonUID";
-import type { OAuth2 } from "../../Auth/OAuth2";
-import { OAuth2UIMethod } from "../../Auth/UI/OAuth2UIMethod";
 import { OWAAuth } from "../../Auth/OWAAuth";
 import { ContentDisposition } from "../../Abstract/Attachment";
 import { LoginError } from "../../Abstract/Account";

--- a/app/logic/Mail/OWA/OWAFolder.ts
+++ b/app/logic/Mail/OWA/OWAFolder.ts
@@ -11,7 +11,7 @@ import {
   owaMoveOrCopyMsgsIntoFolderRequest, owaRenameFolderRequest
 } from "./Request/OWAFolderRequests";
 import { CreateMIME } from "../SMTP/CreateMIME";
-import { base64ToArrayBuffer, blobToBase64, assert } from "../../util/util";
+import { base64ToArrayBuffer, blobToBase64 } from "../../util/util";
 import { sanitize } from "../../../../lib/util/sanitizeDatatypes";
 import { ArrayColl, Collection } from "svelte-collections";
 import { gt } from "../../../l10n/l10n";

--- a/app/logic/Mail/SQL/Account/SQLAccount.ts
+++ b/app/logic/Mail/SQL/Account/SQLAccount.ts
@@ -1,5 +1,4 @@
 import type { Account } from "../../../Abstract/Account";
-import { MailAccount } from "../../MailAccount";
 import { getDatabase } from "./SQLDatabase";
 import { passwordDecrypt, passwordEncrypt } from "../../../Auth/passwordEncrypt";
 import { sanitize } from "../../../../../lib/util/sanitizeDatatypes";

--- a/app/logic/util/Semaphore.ts
+++ b/app/logic/util/Semaphore.ts
@@ -1,4 +1,4 @@
-import { arrayRemove, assert } from "./util";
+import { arrayRemove } from "./util";
 
 /**
  * Allows a function to ensure that it will never run in parallel


### PR DESCRIPTION
Found by `tsc --noUnusedLocals`.

Note: There are more unused imports than those listed here, but some are e.g. for unfinished or commented out code.