### PR TITLE
Turn on noImplicitThis TypeScript type checking #841

### DIFF
--- a/app/tsconfig.json
+++ b/app/tsconfig.json
@@ -8,6 +8,10 @@
     "module": "ESNext",
     "resolveJsonModule": true,
     /**
+     * Extra type checking that's not turned on by default.
+     */
+    "noImplicitThis": true,
+    /**
      * Typecheck JS in `.svelte` and `.js` files by default.
      * Disable checkJs if you'd like to use dynamic types in JS.
      * Note that setting allowJs false does not prevent the use

--- a/lib/jpc/obj.js
+++ b/lib/jpc/obj.js
@@ -219,7 +219,7 @@ export default class BaseProtocol {
 
   makeIterator(symbolName) {
     let self = this;
-    return async function* () {
+    return /** @this {RemoteClass} */ async function* () {
       let remote = await self.mapIncomingObjects(await self.callRemote("iter", {
         obj: this._jpc_id,
         symbol: symbolName,
@@ -235,7 +235,7 @@ export default class BaseProtocol {
 
   makeFunction(functionName) {
     let self = this;
-    return async function (...args) {
+    return /** @this {RemoteClass} */ async function (...args) {
       // this == stub object
       return await self.mapIncomingObjects(await self.callRemote("func", {
         obj: this._jpc_id,
@@ -247,7 +247,7 @@ export default class BaseProtocol {
 
   makeGetter(propName) {
     let self = this;
-    return async function () {
+    return /** @this {RemoteClass} */ async function () {
       // this == stub object
       return await self.mapIncomingObjects(await self.callRemote("get", {
         obj: this._jpc_id,
@@ -258,7 +258,7 @@ export default class BaseProtocol {
 
   makeSetter(propName) {
     let self = this;
-    return async function (val) {
+    return /** @this {RemoteClass} */ async function (val) {
       // this == stub object
       return self.callRemote("set", {
         obj: this._jpc_id,


### PR DESCRIPTION
The type annotations in JPC tell TypeScript what type of object the function will actually be run against, so that it can type check uses of `this`.