### PR TITLE
Turn on strictFunctionTypes TypeScript type checking #841

### DIFF
--- a/app/frontend/Files/drag.ts
+++ b/app/frontend/Files/drag.ts
@@ -38,9 +38,9 @@ export async function onDropFile(event: DragEvent, folder: Directory) {
     assert(messages.every(msg => fileIDs.includes(msg.id)), gt`Drag&drop failed: Selected file IDs don't match the drag data`);
   }
   if (event.ctrlKey || event.metaKey) {
-    await folder.copyFilesHere(new ArrayColl(messages));
+    await folder.copyFilesHere(new ArrayColl(messages as File[]));
   } else {
-    await folder.moveFilesHere(new ArrayColl(messages));
+    await folder.moveFilesHere(new ArrayColl(messages as File[]));
   }
 }
 

--- a/app/logic/Chat/SQL/SQLChatMessage.ts
+++ b/app/logic/Chat/SQL/SQLChatMessage.ts
@@ -150,7 +150,7 @@ export class SQLChatMessage {
       FROM message
       WHERE chatID = ${chat.dbID}
       `) as any;
-    let newMsgs = new ArrayColl<Message>();
+    let newMsgs = new ArrayColl<ChatMessage>();
     for (let row of rows) {
       try {
         let msg = chat.messages.find(msg => msg.dbID == row.id);

--- a/app/logic/Mail/ActiveSync/ActiveSyncAccount.ts
+++ b/app/logic/Mail/ActiveSync/ActiveSyncAccount.ts
@@ -448,7 +448,7 @@ export class ActiveSyncAccount extends MailAccount {
             break;
           case FolderType.Calendar:
           case FolderType.UserCalendar:
-            let calendar = appGlobal.calendars.find((calendar: ActiveSyncCalendar) => calendar.mainAccount == this && (calendar.url == url.toString() || calendar.serverID == change.ServerId)) as ActiveSyncCalendar | null;
+            let calendar = appGlobal.calendars.filterOnce((calendar): calendar is ActiveSyncCalendar => calendar.mainAccount == this).find(calendar => (calendar.url == url.toString() || calendar.serverID == change.ServerId));
             console.log("found the ActS cal again", calendar?.name);
             if (calendar) {
               calendar.name = change.DisplayName;
@@ -470,7 +470,7 @@ export class ActiveSyncAccount extends MailAccount {
             break;
           case FolderType.Contacts:
           case FolderType.UserContacts:
-            let addressbook = appGlobal.addressbooks.find((addressbook: ActiveSyncAddressbook) => addressbook.mainAccount == this && (addressbook.url == url.toString() || addressbook.serverID == change.ServerId)) as ActiveSyncAddressbook | null;
+            let addressbook = appGlobal.addressbooks.filterOnce((addressbook): addressbook is ActiveSyncAddressbook => addressbook.mainAccount == this).find(addressbook => (addressbook.url == url.toString() || addressbook.serverID == change.ServerId));
             console.log("found the ActS AB again", addressbook?.name);
             if (addressbook) {
               addressbook.name = change.DisplayName;
@@ -505,12 +505,12 @@ export class ActiveSyncAccount extends MailAccount {
           }
           let url = new URL(this.url);
           url.searchParams.set("serverID", deletion.ServerId);
-          let addressbook = appGlobal.addressbooks.find((addressbook: ActiveSyncAddressbook) => addressbook.mainAccount == this && (addressbook.url == url.toString() || addressbook.serverID == deletion.ServerId)) as ActiveSyncAddressbook | undefined;
+          let addressbook = appGlobal.addressbooks.filterOnce((addressbook): addressbook is ActiveSyncAddressbook => addressbook.mainAccount == this).find(addressbook => (addressbook.url == url.toString() || addressbook.serverID == deletion.ServerId));
           if (addressbook) {
             this.removePingable(addressbook);
             addressbook.deleteIt();
           }
-          let calendar = appGlobal.calendars.find((calendar: ActiveSyncCalendar) => calendar.mainAccount == this && (calendar.url == url.toString() || calendar.serverID == deletion.ServerId)) as ActiveSyncCalendar | undefined;
+          let calendar = appGlobal.calendars.filterOnce((calendar): calendar is ActiveSyncCalendar => calendar.mainAccount == this).find(calendar => (calendar.url == url.toString() || calendar.serverID == deletion.ServerId));
           if (calendar) {
             this.removePingable(calendar);
             calendar.deleteIt();

--- a/app/logic/Mail/ActiveSync/ActiveSyncEMail.ts
+++ b/app/logic/Mail/ActiveSync/ActiveSyncEMail.ts
@@ -224,9 +224,9 @@ export class ActiveSyncEMail extends EMail {
 }
 
 function setPersons(targetList: ArrayColl<PersonUID>, addresses: string): void {
-  let list = parseAddressList(addresses);
+  let list = parseAddressList(addresses) as ParsedMailbox[];
   if (!list) {
     return;
   }
-  targetList.replaceAll(list.map((mailbox: ParsedMailbox) => findOrCreatePersonUID(mailbox.address, mailbox.name)));
+  targetList.replaceAll(list.map(mailbox => findOrCreatePersonUID(mailbox.address, mailbox.name)));
 }

--- a/app/logic/Mail/EWS/EWSAccount.ts
+++ b/app/logic/Mail/EWS/EWSAccount.ts
@@ -470,12 +470,12 @@ export class EWSAccount extends MailAccount {
           await mailFolder.updateChangedMessages();
           continue;
         }
-        let addressbook = appGlobal.addressbooks.find((addressbook: EWSAddressbook) => addressbook.mainAccount == this && addressbook.folderID == folderID) as EWSAddressbook | null;
+        let addressbook = appGlobal.addressbooks.filterOnce((addressbook): addressbook is EWSAddressbook => addressbook.mainAccount == this).find(addressbook => addressbook.folderID == folderID);
         if (addressbook) {
           await addressbook.listContacts();
           continue;
         }
-        let calendar = appGlobal.calendars.find((calendar: EWSCalendar) => calendar.mainAccount == this && calendar.folderID == folderID) as EWSCalendar | null;
+        let calendar = appGlobal.calendars.filterOnce((calendar): calendar is EWSCalendar => calendar.mainAccount == this).find(calendar => calendar.folderID == folderID);
         if (calendar) {
           await calendar.listEvents();
           continue;

--- a/app/logic/Mail/EWS/EWSFolder.ts
+++ b/app/logic/Mail/EWS/EWSFolder.ts
@@ -356,7 +356,7 @@ export class EWSFolder extends Folder {
     if (!id) {
       return undefined;
     }
-    return this.messages.find((m: EWSEMail) => m.itemID == id) as EWSEMail | undefined;
+    return this.messages.find((m): m is EWSEMail => (m as EWSEMail).itemID == id);
   }
 
   async moveMessagesHere(messages: Collection<EMail>) {

--- a/app/logic/Mail/Folder.ts
+++ b/app/logic/Mail/Folder.ts
@@ -183,7 +183,7 @@ export class Folder extends Observable implements TreeItem<Folder> {
     assert(folder != this, "Cannot move a folder into itself. Neither physics nor logic allow that. We would run into a circle and run and run and run...");
     assert(this.subFolders.contains(folder), "This folder is *already* a subfolder of the target folder");
     let disableSubfolders = this.disableSubfolders();
-    assert(!disableSubfolders, disableSubfolders ?? "This folder cannot have subfolders");
+    assert(!disableSubfolders, disableSubfolders || "This folder cannot have subfolders");
     // TODO Check sub sub folders
     if (folder.parent) {
       folder.parent.subFolders.remove(folder);
@@ -197,7 +197,7 @@ export class Folder extends Observable implements TreeItem<Folder> {
   /** @see MailAccount.createToplevelFolder() */
   async createSubFolder(name: string): Promise<Folder> {
     let disableSubfolders = this.disableSubfolders();
-    assert(!disableSubfolders, disableSubfolders ?? "This folder cannot have subfolders");
+    assert(!disableSubfolders, disableSubfolders || "This folder cannot have subfolders");
     let folder = this.account.newFolder();
     folder.name = name;
     folder.parent = this;
@@ -207,7 +207,7 @@ export class Folder extends Observable implements TreeItem<Folder> {
 
   async rename(newName: string): Promise<void> {
     let disabled = this.disableRename();
-    assert(!disabled, disabled);
+    assert(!disabled, disabled || "Cannot rename");
     this.name = newName;
   }
 
@@ -218,7 +218,7 @@ export class Folder extends Observable implements TreeItem<Folder> {
   /** Warning: Also deletes all messages in the folder, also on the server */
   async deleteIt(): Promise<void> {
     let disableDelete = this.disableDelete();
-    assert(!disableDelete, disableDelete ?? "Cannot delete");
+    assert(!disableDelete, disableDelete || "Cannot delete");
     await this.deleteItLocally();
     await this.deleteItOnServer();
   }

--- a/app/logic/Mail/Graph/GraphAccount.ts
+++ b/app/logic/Mail/Graph/GraphAccount.ts
@@ -82,7 +82,7 @@ export class GraphAccount extends MailAccount {
     await calendar.listEvents();
     */
 
-    let chatAccount = appGlobal.chatAccounts.find((calendar: GraphChatAccount) => calendar.protocol == "chat-graph" && calendar.url == this.url && calendar.username == this.username) as GraphChatAccount | undefined;
+    let chatAccount = appGlobal.chatAccounts.find((calendar): calendar is GraphChatAccount => calendar.protocol == "chat-graph" && calendar.url == this.url && calendar.username == this.username);
     if (!chatAccount) {
       chatAccount = newChatAccountForProtocol("chat-graph") as GraphChatAccount;
       chatAccount.name = this.name;

--- a/app/logic/Mail/OWA/OWAAccount.ts
+++ b/app/logic/Mail/OWA/OWAAccount.ts
@@ -384,12 +384,12 @@ export class OWAAccount extends MailAccount {
 
   protected handleHierarchyNotification(notification: any) {
     try {
-      let addressbook = appGlobal.addressbooks.find((addressbook: OWAAddressbook) => addressbook.mainAccount == this && addressbook.folderID == notification.folderId) as OWAAddressbook | null;
+      let addressbook = appGlobal.addressbooks.filterOnce((addressbook): addressbook is OWAAddressbook => addressbook.mainAccount == this).find(addressbook => addressbook.folderID == notification.folderId);
       if (addressbook) {
         addressbook.listContacts().catch(this.errorCallback);
         return;
       }
-      let calendar = appGlobal.calendars.find((calendar: OWACalendar) => calendar.mainAccount == this && calendar.folderID == notification.folderId) as OWACalendar | null;
+      let calendar = appGlobal.calendars.filterOnce((calendar): calendar is OWACalendar => calendar.mainAccount == this).find(calendar => calendar.folderID == notification.folderId);
       if (calendar) {
         calendar.listEvents().catch(this.errorCallback);
         return;

--- a/app/logic/Mail/OWA/OWAFolder.ts
+++ b/app/logic/Mail/OWA/OWAFolder.ts
@@ -188,7 +188,7 @@ export class OWAFolder extends Folder {
     if (!id) {
       return undefined;
     }
-    return this.messages.find((m: OWAEMail) => m.itemID == id) as OWAEMail | undefined;
+    return this.messages.find((m): m is OWAEMail => (m as OWAEMail).itemID == id);
   }
 
   async moveMessagesHere(messages: Collection<EMail>) {

--- a/app/logic/Mail/Store/EMailCollection.ts
+++ b/app/logic/Mail/Store/EMailCollection.ts
@@ -5,10 +5,10 @@ import type { Folder } from '../Folder';
 
 export class EMailCollection<T extends EMail> extends SortedCollection<T> {
   folder: Folder;
-  sortFunc: (a: T, b: T) => number;
+  sortFunc: (a: EMail, b: EMail) => number;
 
   constructor(folder: Folder) {
-    let sortFunc = (a: T, b: T) => compareValues(b.sent, a.sent); // inverted = newest first
+    let sortFunc = (a: EMail, b: EMail) => compareValues(b.sent, a.sent); // inverted = newest first
     /* Normally, a `SortedCollection` is simply a sorted /copy/ of the source collection.
      * Here, we don't use a source collection, but add the items directly to the
      * `SortedCollection`, using `.add()` and `.remove()`. The `SortedCollection`

--- a/app/logic/Mail/Virtual/SavedSearchFolder.ts
+++ b/app/logic/Mail/Virtual/SavedSearchFolder.ts
@@ -70,7 +70,7 @@ export class SavedSearchFolder extends Folder {
 
   async deleteIt() {
     let disableDelete = this.disableDelete();
-    assert(!disableDelete, disableDelete ?? "Cannot delete");
+    assert(!disableDelete, disableDelete || "Cannot delete");
     savedSearchFolders.remove(this);
     saveSavedSearches();
   }

--- a/app/logic/Meet/LiveKit/LiveKitConf.ts
+++ b/app/logic/Meet/LiveKit/LiveKitConf.ts
@@ -192,7 +192,7 @@ export class LiveKitConf extends VideoConfMeeting {
     this.state = MeetingState.Ongoing;
 
     this.room.localParticipant.registerRpcMethod("handUp", async (data: RpcInvocationData) => {
-      let remoteParticipant = this.participants.find((p: LiveKitRemoteParticipant) => p.rp.identity == data.callerIdentity);
+      let remoteParticipant = this.participants.find((p): p is LiveKitRemoteParticipant => (p as LiveKitRemoteParticipant).rp.identity == data.callerIdentity);
       assert(remoteParticipant, "LiveKit: Remote participant not found");
       let up = sanitize.translate(data.payload, { "up": true, "down": false });
       console.log(remoteParticipant.name, "has put hand", up ? "up" : "down");

--- a/app/logic/Meet/Matrix/MatrixVideoConf.ts
+++ b/app/logic/Meet/Matrix/MatrixVideoConf.ts
@@ -4,7 +4,7 @@ import { MeetingParticipant } from "../Participant";
 import { LocalMediaDeviceStreams } from "../LocalMediaDeviceStreams";
 import { Chat } from "../../Chat/Chat";
 import { assert } from "../../util/util";
-import type { MatrixCall, MatrixClient } from "matrix-js-sdk";
+import { CallEvent, type EmittedEvents, type MatrixCall, type MatrixClient } from "matrix-js-sdk";
 import { CallErrorCode, createNewMatrixCall } from "matrix-js-sdk/lib/webrtc/call";
 
 export class MatrixVideoConf extends VideoConfMeeting {
@@ -28,13 +28,13 @@ export class MatrixVideoConf extends VideoConfMeeting {
     this.mediaDeviceStreams = new LocalMediaDeviceStreams();
     this.client = client;
     this._call = call;
-    this._call.on("error", ex => this.errorCallback(ex));
-    this._call.on("hangup", () => this.endCallback());
+    this._call.on(CallEvent.Error, ex => this.errorCallback(ex));
+    this._call.on(CallEvent.Hangup, () => this.endCallback());
   }
 
   async start() {
     await super.start();
-    this._call.on("feeds_changed", (feeds) => {
+    this._call.on(CallEvent.FeedsChanged, (feeds) => {
       for (let feed of feeds) {
         if (feed.isLocal()) {
           let self = new VideoStream(feed.stream);
@@ -93,7 +93,7 @@ export class MatrixVideoConf extends VideoConfMeeting {
    * This `listenForCalls()` function should normally be called only once in the lifetime of the app.
    */
   static listenForCalls(client: MatrixClient, incomingCallCallback: (MatrixVideoConf) => Promise<void>) {
-    client.on("Call.incoming", (call: MatrixCall) => {
+    client.on("Call.incoming" as EmittedEvents, (call: MatrixCall) => {
       console.log("Incoming call", call.roomId, call);
       let conf = new MatrixVideoConf(client, call);
       incomingCallCallback(conf);

--- a/app/tsconfig.json
+++ b/app/tsconfig.json
@@ -11,6 +11,7 @@
      * Extra type checking that's not turned on by default.
      */
     "noImplicitThis": true,
+    "strictFunctionTypes": true,
     /**
      * Typecheck JS in `.svelte` and `.js` files by default.
      * Disable checkJs if you'd like to use dynamic types in JS.


### PR DESCRIPTION
Note: needs a patch to `svelte-collections` for proper type checking of `ArrayColl.find` and `Collection.filterOnce`.