### PR TITLE
Android: Parula brand in the Java code and file path

### DIFF
--- a/mobile/backend/backend.ts
+++ b/mobile/backend/backend.ts
@@ -438,7 +438,7 @@ function directory(type: string): string {
 }
 
 // workaround: @capacitor/app App.getInfo().id has some code not getting bundled
-const appID = "com.beonex.parula";
+const appID = "im.mustang.capa";
 let configDir: string;
 /**
  * Get the user config directory on disk.

--- a/mobile/backend/backend.ts
+++ b/mobile/backend/backend.ts
@@ -437,6 +437,7 @@ function directory(type: string): string {
   return os.homedir();
 }
 
+const appID = "im.mustang.capa";
 let configDir: string;
 /**
  * Get the user config directory on disk.
@@ -456,7 +457,7 @@ function getConfigDir(): string {
   }
   let homeDir: string = os.homedir();
   if (os.platform() == "android") {
-    configDir = path.join(homeDir, "data", "im.mustang.capa", "config");
+    configDir = path.join(homeDir, "data", appID, "config");
   } else {
     configDir = homeDir;
   }
@@ -485,7 +486,7 @@ function getFilesDir(): string {
   }
   let homeDir: string = os.homedir();
   if (os.platform() == "android") {
-    filesDir = path.join(homeDir, "data", "im.mustang.capa", "config");
+    filesDir = path.join(homeDir, "data", appID, "config");
   } else {
     filesDir = homeDir;
   }

--- a/mobile/backend/backend.ts
+++ b/mobile/backend/backend.ts
@@ -437,7 +437,8 @@ function directory(type: string): string {
   return os.homedir();
 }
 
-const appID = "im.mustang.capa";
+// workaround: @capacitor/app App.getInfo().id has some code not getting bundled
+const appID = "com.beonex.parula";
 let configDir: string;
 /**
  * Get the user config directory on disk.

--- a/mobile/hooks/android/update-project.ts
+++ b/mobile/hooks/android/update-project.ts
@@ -1,18 +1,27 @@
 import path from "node:path";
-import packageJSON from "../../package.json";
-import config from "../../capacitor.config";
-import { readFile, writeFile } from "node:fs/promises";
+import packageJSON from "../../package.json" with { type: "json" };
+import config from "../../capacitor.config.ts";
+import { cp, mkdir, readFile, rm, writeFile } from "node:fs/promises";
+import { createReadStream, existsSync } from "node:fs";
+import zlib from "node:zlib";
+import { extract } from "tar";
 
 const __dirname = import.meta.dirname;
+const appId = config.appId;
+const appName = config.appName;
+const version = packageJSON.version;
 
+/**
+ *  These settings and files need to be update for the Android Project
+ *  based on which are based on the Capacitor CLI.
+ *
+ *  @url https://github.com/ionic-team/capacitor/blob/03e92c42d8f1460559dc933c1f79d88be8b9e2bc/cli/src/android/common.ts#L52-L106
+ */
+
+// Update build.gradle
 async function updateProjectSettings() {
   if (process.env.CAPACITOR_PLATFORM_NAME != "android") return;
 
-  const appId = config.appId;
-  const appName = config.appName;
-  const version = packageJSON.version;
-
-  // Update build.gradle
   let androidProjectFile = path.join(__dirname, "../../android/app/build.gradle");
   let gradleContent = await readFile(androidProjectFile, { encoding: 'utf-8' });
   gradleContent = gradleContent.replace(/applicationId "[^"]+"/, `applicationId "${appId}"`);
@@ -22,9 +31,59 @@ async function updateProjectSettings() {
   await writeFile(androidProjectFile, gradleContent);
 }
 
+// Update the package in the MainActivity java file
+async function updateMainActivityPackage() {
+
+  let domainPath = appId?.split('.').join('/');
+  let mainDir = "android/app/src/main";
+
+  // Make the package source path to the new plugin Java file
+  let newJavaPath = path.resolve(mainDir, `java/${domainPath}`);
+
+  if (!existsSync(newJavaPath)) {
+    await mkdir(newJavaPath,  { recursive: true });
+  }
+
+  let cliPackage = import.meta.resolve("@capacitor/cli").split(":")[1];
+  let templatePath = path.join(cliPackage, "../../assets");
+  let templateZip = path.resolve(templatePath, "android-template.tar.gz");
+  let templateDir = path.join(templatePath, "android-template");
+  let mainActivityFile = path.resolve(templateDir, "app/src/main/java/com/getcapacitor/myapp/MainActivity.java");
+
+  if (!existsSync(templateDir)) {
+    await mkdir(templateDir);
+  }
+  await decompress(templateZip, templateDir);
+
+  let activityPath = path.resolve(newJavaPath, 'MainActivity.java');
+  await rm(path.join(mainDir, "java"), { recursive: true });
+  await cp(mainActivityFile, activityPath, { recursive: true });
+
+  let activityContent = await readFile(activityPath, { encoding: 'utf-8' });
+
+  activityContent = activityContent.replace(/package ([^;]*)/, `package ${appId}`);
+  await writeFile(activityPath, activityContent, { encoding: 'utf-8' });
+}
+
+async function decompress(source: string, destination: string) {
+  return await new Promise((res) => {
+    createReadStream(source)
+      .pipe(zlib.createGunzip())
+      .pipe(extract({ cwd: destination }))
+      .on('finish', () => {
+        res(null);
+      });
+  });
+}
+
 async function main() {
+  if (process.env.CAPACITOR_PLATFORM_NAME != "android") return;
+
   try {
-    await updateProjectSettings();
+    await Promise.all([
+      updateProjectSettings(),
+      updateMainActivityPackage(),
+    ]);
   } catch (ex) {
     console.error(ex);
   }

--- a/mobile/hooks/common/parula-brand.sh
+++ b/mobile/hooks/common/parula-brand.sh
@@ -13,3 +13,8 @@ perl -p -i \
   -e "s|im.mustang.capa|com.beonex.parula|;" \
   -e "s|"Mustang"|"Parula"|;" \
   ./capacitor.config.ts
+
+# Relace all appID in /mobile/backend
+perl -p -i \
+  -e "s|im.mustang.capa|com.beonex.parula|;" \
+  ./backend/backend.ts

--- a/mobile/package.json
+++ b/mobile/package.json
@@ -29,6 +29,7 @@
   "devDependencies": {
     "@capacitor/cli": "^7.0.0",
     "@tsconfig/node22": "^22.0.2",
+    "tar": "^7.4.3",
     "typescript": "^5.9.2",
     "vite": "^5.4.2"
   },

--- a/mobile/package.json
+++ b/mobile/package.json
@@ -28,6 +28,7 @@
   },
   "devDependencies": {
     "@capacitor/cli": "^7.0.0",
+    "@tsconfig/node22": "^22.0.2",
     "typescript": "^5.9.2",
     "vite": "^5.4.2",
     "vite-node": "^3.2.4"

--- a/mobile/package.json
+++ b/mobile/package.json
@@ -14,7 +14,7 @@
     "build:android:aab": "export MOBILE_ARCH=android-arm64; npm run build && cap sync android && cd android && ./gradlew --configuration-cache :app:bundleRelease",
     "preview": "vite preview",
     "setup:ios": "cd ios && ./setup-ios.sh",
-    "capacitor:update:before": "vite-node ./hooks/android/update-project.ts"
+    "capacitor:update:before": "node --experimental-strip-types ./hooks/android/update-project.ts"
   },
   "dependencies": {
     "@capacitor/android": "^7.0.0",
@@ -30,8 +30,7 @@
     "@capacitor/cli": "^7.0.0",
     "@tsconfig/node22": "^22.0.2",
     "typescript": "^5.9.2",
-    "vite": "^5.4.2",
-    "vite-node": "^3.2.4"
+    "vite": "^5.4.2"
   },
   "repository": {
     "type": "git",

--- a/mobile/tsconfig.json
+++ b/mobile/tsconfig.json
@@ -1,0 +1,3 @@
+{
+  "extends": "@tsconfig/node22/tsconfig.json"
+}

--- a/mobile/tsconfig.json
+++ b/mobile/tsconfig.json
@@ -1,3 +1,8 @@
 {
-  "extends": "@tsconfig/node22/tsconfig.json"
+  "extends": "@tsconfig/node22/tsconfig.json",
+  "compilerOptions": {
+    "allowImportingTsExtensions": true,
+    "emitDeclarationOnly": true,
+    "declaration": true
+  }
 }


### PR DESCRIPTION
- There were still some traces of the "im.mustang.capa" in the Java code which caused the app to crash
- The file path also needed to be changed also
- `App.getInfo().id` is the preferred way to get appID but some of the code was not getting bundled which caused more errors
- We now run the update-project.ts script with node.js instead of vite-node