### PR TITLE
Android build: Remove configuration cache

### DIFF
--- a/mobile/package.json
+++ b/mobile/package.json
@@ -10,8 +10,8 @@
     "brand:parula": "./hooks/common/parula-brand.sh",
     "build": "./hooks/common/build.sh",
     "build:android": "npm run build:android:apk && npm run build:android:aab",
-    "build:android:apk": "export MOBILE_ARCH=android-arm64; npm run build && cap sync android && cd android && ./gradlew --configuration-cache assembleRelease",
-    "build:android:aab": "export MOBILE_ARCH=android-arm64; npm run build && cap sync android && cd android && ./gradlew --configuration-cache :app:bundleRelease",
+    "build:android:apk": "export MOBILE_ARCH=android-arm64; npm run build && cap sync android && cd android && ./gradlew assembleRelease",
+    "build:android:aab": "export MOBILE_ARCH=android-arm64; npm run build && cap sync android && cd android && ./gradlew :app:bundleRelease",
     "preview": "vite preview",
     "setup:ios": "cd ios && ./setup-ios.sh"
   },


### PR DESCRIPTION
- Configuration cache was originally used for speeding up local builds and CI builds
- On the CI builds the setup-gradle step was supposed to cache the config but it doesn't. It only caches Gradle assets.
- Now it's causing some errors and might cause more errors in the future:

```
FAILURE: Build failed with an exception.

 * What went wrong:
Configuration cache problems found in this build.

1 problem was found storing the configuration cache.
- Plugin 'kotlin-android': Unsupported provider is registered as a task completion listener in 'org.gradle.build.event.BuildEventsListenerRegistry'. Configuration Cache only supports providers returned from 'org.gradle.api.services.BuildServiceRegistry' as task completion listeners.
  See https://docs.gradle.org/9.0.0/userguide/configuration_cache_status.html#config_cache:not_yet_implemented:more_build_event_listeners
```
https://github.com/mustang-im/mustang/actions/runs/17291762622/job/49080549999#step:15:1508