### PR TITLE
Fix ActiveSyncAccount.verifyLogin #841

### DIFF
--- a/app/logic/Calendar/ActiveSync/ActiveSyncCalendar.ts
+++ b/app/logic/Calendar/ActiveSync/ActiveSyncCalendar.ts
@@ -35,7 +35,7 @@ export class ActiveSyncCalendar extends Calendar implements ActiveSyncPingable {
     return new ActiveSyncEvent(this, parentEvent);
   }
 
-  getIncomingInvitationForEMail(message: ActiveSyncEMail) {
+  getIncomingInvitationForEMail(message: ActiveSyncEMail): ActiveSyncIncomingInvitation {
     return new ActiveSyncIncomingInvitation(this, message);
   }
 

--- a/app/logic/Calendar/ActiveSync/ActiveSyncEvent.ts
+++ b/app/logic/Calendar/ActiveSync/ActiveSyncEvent.ts
@@ -135,7 +135,7 @@ export class ActiveSyncEvent extends Event {
     };
   }
 
-  get outgoingInvitation() {
+  get outgoingInvitation(): ActiveSyncOutgoingInvitation {
     return new ActiveSyncOutgoingInvitation(this);
   }
 

--- a/app/logic/Calendar/Calendar.ts
+++ b/app/logic/Calendar/Calendar.ts
@@ -39,7 +39,7 @@ export class Calendar extends Account {
   protected invalidateRecurringCache() {
   }
 
-  getIncomingInvitationForEMail(message: EMail) {
+  getIncomingInvitationForEMail(message: EMail): ICalIncomingInvitation {
     return new ICalIncomingInvitation(this, message);
   }
 

--- a/app/logic/Calendar/EWS/EWSCalendar.ts
+++ b/app/logic/Calendar/EWS/EWSCalendar.ts
@@ -25,7 +25,7 @@ export class EWSCalendar extends Calendar {
     return new EWSEvent(this, parentEvent);
   }
 
-  getIncomingInvitationForEMail(message: EWSEMail) {
+  getIncomingInvitationForEMail(message: EWSEMail): EWSIncomingInvitation {
     return new EWSIncomingInvitation(this, message);
   }
 

--- a/app/logic/Calendar/EWS/EWSEvent.ts
+++ b/app/logic/Calendar/EWS/EWSEvent.ts
@@ -146,7 +146,7 @@ export class EWSEvent extends Event {
     return new RecurrenceRule({ masterDuration, seriesStartTime, seriesEndTime, count, frequency, interval, weekdays, week, first });
   }
 
-  get outgoingInvitation() {
+  get outgoingInvitation(): EWSOutgoingInvitation {
     return new EWSOutgoingInvitation(this);
   }
 

--- a/app/logic/Calendar/Event.ts
+++ b/app/logic/Calendar/Event.ts
@@ -407,7 +407,7 @@ export class Event extends Observable {
     return json;
   }
 
-  get outgoingInvitation() {
+  get outgoingInvitation(): OutgoingInvitation {
     return new OutgoingInvitation(this);
   }
 

--- a/app/logic/Calendar/OWA/OWACalendar.ts
+++ b/app/logic/Calendar/OWA/OWACalendar.ts
@@ -28,7 +28,7 @@ export class OWACalendar extends Calendar {
     return new OWAEvent(this, parentEvent);
   }
 
-  getIncomingInvitationForEMail(message: OWAEMail) {
+  getIncomingInvitationForEMail(message: OWAEMail): OWAIncomingInvitation {
     return new OWAIncomingInvitation(this, message);
   }
 

--- a/app/logic/Calendar/OWA/OWAEvent.ts
+++ b/app/logic/Calendar/OWA/OWAEvent.ts
@@ -143,7 +143,7 @@ export class OWAEvent extends Event {
     return new RecurrenceRule({ masterDuration, seriesStartTime, seriesEndTime, count, frequency, interval, weekdays, week, first });
   }
 
-  get outgoingInvitation() {
+  get outgoingInvitation(): OWAOutgoingInvitation {
     return new OWAOutgoingInvitation(this);
   }
 

--- a/app/logic/Mail/ActiveSync/ActiveSyncAccount.ts
+++ b/app/logic/Mail/ActiveSync/ActiveSyncAccount.ts
@@ -189,9 +189,8 @@ export class ActiveSyncAccount extends MailAccount {
     if (response.status == 401) {
       const repeat = async () => {
         this.retries++;
-        let result = await this.verifyLogin(); // repeat the call
+        await this.verifyLogin(); // repeat the call
         this.retries = 0;
-        return result;
       }
       if (this.retries) {
         let ex = Error(`HTTP ${response.status} ${response.statusText}`);
@@ -199,7 +198,7 @@ export class ActiveSyncAccount extends MailAccount {
       } else if (this.oAuth2) {
         this.oAuth2.reset();
         await this.oAuth2.login(false); // will throw error, if interactive login is needed
-        return repeat();
+        await repeat();
       } else if (!/\bBasic\b/.test(response.WWWAuthenticate)) {
         throw this.fatalError = new ConnectError(null,
           "Unsupported authentication protocol(s): " + response.WWWAuthenticate);


### PR DESCRIPTION
The code for `verifyLogin` appears to be based on similar code for `callEAS` but the difference there is that `callEAS` does actually return a value while `verifyLogin` does not.

Also fixes some cases where TypeScript has trouble working out the type. (These all produce the same TypeScript error.)