### PR TITLE
Fix duplicate delete strategy enum value

### DIFF
--- a/app/logic/Mail/MailAccount.ts
+++ b/app/logic/Mail/MailAccount.ts
@@ -238,6 +238,6 @@ export interface MailContentStorage {
 
 export enum DeleteStrategy {
   DeleteImmediately = 1,
-  Flag = 1,
+  Flag = 2,
   MoveToTrash = 3,
 }


### PR DESCRIPTION
I assume this was an unintentional typo. This probably means that the `Flag` delete strategy has never been tested...