### PR TITLE
EWS: Fix NTLM regex match

### DIFF
--- a/app/logic/Mail/EWS/EWSAccount.ts
+++ b/app/logic/Mail/EWS/EWSAccount.ts
@@ -293,7 +293,7 @@ export class EWSAccount extends MailAccount {
       } else if (this.authMethod == AuthMethod.Unknown) {
         if (/\bBasic\b/.test(response.WWWAuthenticate)) {
           this.authMethod = AuthMethod.Password;
-        } else if (/\NTLM\b/.test(response.WWWAuthenticate)) {
+        } else if (/\bNTLM\b/.test(response.WWWAuthenticate)) {
           this.authMethod = AuthMethod.NTLM;
         } else {
           throw this.fatalError = new ConnectError(null,


### PR DESCRIPTION
Fortunately it didn't cause problems in practice (the error is that it matches any word ending `NTLM` rather than just the word `NTLM`).