### PR TITLE
Close in-app OAuth after login

### DIFF
--- a/app/frontend/Mail/MailMustangApp.ts
+++ b/app/frontend/Mail/MailMustangApp.ts
@@ -61,6 +61,7 @@ const tabsObserver = {
     for (let tab of tabs) {
       mailMustangApp.subApps.remove(tab.mustangApp);
     }
+    openApp(mailMustangApp, {});
   },
 };
 oAuth2TabsOpen.registerObserver(tabsObserver);


### PR DESCRIPTION
Steps to reproduce problem:
- Start app
- Click "disconencted" icon for OWA account
- Watch as OWA logs in

Expected result: Mail automatically selected after login completes

Actual result: Must manually click Mail icon to actually start reading mail