### PR TITLE
Mobile: Hide SplashScreen as soon app is loaded

### DIFF
--- a/app/frontend/MainWindow/MainWindow.svelte
+++ b/app/frontend/MainWindow/MainWindow.svelte
@@ -81,6 +81,9 @@
   import { onMount } from "svelte";
   import { useDebounce } from "@svelteuidev/composables";
   import { Router } from "svelte-navigator";
+  // #if [MOBILE]
+  import { SplashScreen } from '@capacitor/splash-screen';
+  // #endif
 
   // $: sidebarApp = $mustangApps.filter(app => app.showSidebar).first; // TODO watch `app` property changes
   $: $sidebarApp = $meetMustangApp.showSidebar ? meetMustangApp : null;
@@ -95,6 +98,9 @@
     loadMustangApps();
     $selectedApp = mailMustangApp;
     changeTheme($themeSetting.value);
+    // #if [MOBILE]
+    await SplashScreen.hide();
+    // #endif
     await startup();
   }
 

--- a/app/frontend/MainWindow/MainWindow.svelte
+++ b/app/frontend/MainWindow/MainWindow.svelte
@@ -99,7 +99,7 @@
     $selectedApp = mailMustangApp;
     changeTheme($themeSetting.value);
     // #if [MOBILE]
-    await SplashScreen.hide();
+    SplashScreen.hide();
     // #endif
     await startup();
   }

--- a/app/package.json
+++ b/app/package.json
@@ -21,6 +21,7 @@
     "@capacitor/app": "^7.0.2",
     "@capacitor/browser": "^7.0.2",
     "@capacitor/core": "^7.0.0",
+    "@capacitor/splash-screen": "^7.0.3",
     "@faker-js/faker": "^9.8.0",
     "@popperjs/core": "^2.11.8",
     "@sentry/svelte": "^8.15.0",

--- a/mobile/capacitor.config.ts
+++ b/mobile/capacitor.config.ts
@@ -11,7 +11,7 @@ const config: CapacitorConfig = {
       androidArchitectures: ["arm64"],
     },
     SplashScreen: {
-      launchAutoHide: false,
+      launchAutoHide: true,
     },
     EdgeToEdge: {
       backgroundColor: "#494558", // --appbar-bg, see app.css

--- a/mobile/capacitor.config.ts
+++ b/mobile/capacitor.config.ts
@@ -11,7 +11,7 @@ const config: CapacitorConfig = {
       androidArchitectures: ["arm64"],
     },
     SplashScreen: {
-      "launchAutoHide": true
+      launchAutoHide: false,
     },
     EdgeToEdge: {
       backgroundColor: "#494558", // --appbar-bg, see app.css

--- a/mobile/package.json
+++ b/mobile/package.json
@@ -22,7 +22,7 @@
     "@capacitor/camera": "^7.0.0",
     "@capacitor/core": "^7.0.0",
     "@capacitor/ios": "^7.0.0",
-    "@capacitor/splash-screen": "^7.0.0",
+    "@capacitor/splash-screen": "^7.0.3",
     "@capawesome/capacitor-android-edge-to-edge-support": "^7.2.3",
     "capacitor-nodejs": "https://github.com/mustang-im/capacitor-nodejs/releases/download/1.0.0-beta.10/capacitor-nodejs-v1.0.0-beta.10.tgz"
   },


### PR DESCRIPTION
- We should hide the SplashScreen as soon as the app is loaded
- Use autoHide as a fallback