### PR TITLE
Android: Run Node.js based on native App lifecycle

### DIFF
--- a/.github/workflows/installer-android-parula.yml
+++ b/.github/workflows/installer-android-parula.yml
@@ -36,7 +36,6 @@ jobs:
     - run: cd backend; yarn install
     - run: cd mobile; yarn install
     - run: cd mobile/backend; yarn install
-    - run: cd mobile; yarn build
 
     - run: |
         mkdir -p ${{ github.workspace }}/private_keys/

--- a/.github/workflows/installer-android.yml
+++ b/.github/workflows/installer-android.yml
@@ -36,7 +36,6 @@ jobs:
     - run: cd backend; yarn install
     - run: cd mobile; yarn install
     - run: cd mobile/backend; yarn install
-    - run: cd mobile; yarn build
 
     - run: |
         mkdir -p ${{ github.workspace }}/private_keys/

--- a/app/frontend/MainWindow/NavigationM.svelte
+++ b/app/frontend/MainWindow/NavigationM.svelte
@@ -2,7 +2,6 @@
 
 <script lang="ts">
   import { showError } from "../Util/error";
-  import { goTo } from "../AppsBar/selectedApp";
   import { App } from "@capacitor/app";
   import { gestures } from "@composi/gestures";
   import { navigate } from "svelte-navigator";
@@ -13,8 +12,7 @@
     if (canGoBack) {
       navigate(-1);
     } else {
-      // App.exitApp(); TODO crashes on re-launch
-      goTo("/app-menu/", {});
+      App.exitApp();
     }
   });
 

--- a/mobile/android/app/.gitignore
+++ b/mobile/android/app/.gitignore
@@ -1,2 +1,3 @@
 /build/*
 !/build/.npmkeep
+libnode

--- a/mobile/android/app/CMakeLists.txt
+++ b/mobile/android/app/CMakeLists.txt
@@ -10,29 +10,53 @@ cmake_minimum_required(VERSION 3.4.1)
 # You can define multiple libraries, and CMake builds them for you.
 # Gradle automatically packages shared libraries with your APK.
 
-add_library(native-lib
-        SHARED
-        native-lib.cpp)
+add_library( # Sets the name of the library.
+        native-lib
 
+        # Sets the library as a shared library.
+        SHARED
+
+        # Provides a relative path to your source file(s).
+        src/main/cpp/native-lib.cpp)
+
+#Includes node's header files.
 include_directories(libnode/include/node/)
 
 add_library(libnode
         SHARED
         IMPORTED)
+
 set_target_properties( # Specifies the target library.
         libnode
+
         # Specifies the parameter you want to define.
         PROPERTIES IMPORTED_LOCATION
+
         # Provides the path to the library you want to import.
         ${CMAKE_SOURCE_DIR}/libnode/bin/${ANDROID_ABI}/libnode.so)
 
-find_library(log-lib
+# Searches for a specified prebuilt library and stores the path as a
+# variable. Because CMake includes system libraries in the search path by
+# default, you only need to specify the name of the public NDK library
+# you want to add. CMake verifies that the library exists before
+# completing its build.
+
+find_library( # Sets the name of the path variable.
+        log-lib
+
+        # Specifies the name of the NDK library that
+        # you want CMake to locate.
         log)
+
+# Specifies libraries CMake should link to your target library. You
+# can link multiple libraries, such as libraries you define in this
+# build script, prebuilt third-party libraries, or system libraries.
 
 target_link_libraries( # Specifies the target library.
         native-lib
-        # Links imported library.
+
         libnode
+
         # Links the target library to the log library
         # included in the NDK.
         ${log-lib})

--- a/mobile/android/app/build.gradle
+++ b/mobile/android/app/build.gradle
@@ -3,6 +3,12 @@ import com.android.build.gradle.internal.tasks.FinalizeBundleTask
 apply plugin: 'com.android.application'
 
 android {
+    externalNativeBuild {
+        cmake {
+            path file('CMakeLists.txt')
+            version '3.22.1'
+        }
+    }
     namespace "im.mustang.capa"
     compileSdk rootProject.ext.compileSdkVersion
     defaultConfig {
@@ -19,7 +25,7 @@ android {
         }
         externalNativeBuild {
             cmake {
-                cppFlags ""
+                cppFlags ''
                 arguments "-DANDROID_STL=c++_shared"
             }
         }

--- a/mobile/android/app/build.gradle
+++ b/mobile/android/app/build.gradle
@@ -83,6 +83,8 @@ dependencies {
     androidTestImplementation "androidx.test.ext:junit:$androidxJunitVersion"
     androidTestImplementation "androidx.test.espresso:espresso-core:$androidxEspressoCoreVersion"
     implementation project(':capacitor-cordova-android-plugins')
+    implementation "androidx.core:core-ktx:$androidxCoreKtxVersion"
+    implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
 }
 
 apply from: 'capacitor.build.gradle'

--- a/mobile/android/app/build.gradle
+++ b/mobile/android/app/build.gradle
@@ -6,7 +6,7 @@ android {
     externalNativeBuild {
         cmake {
             path file('CMakeLists.txt')
-            version '3.22.1'
+            version rootProject.ext.cmakeVersion
         }
     }
     namespace "im.mustang.capa"

--- a/mobile/android/app/build.gradle
+++ b/mobile/android/app/build.gradle
@@ -77,6 +77,7 @@ dependencies {
 }
 
 apply from: 'capacitor.build.gradle'
+apply plugin: 'org.jetbrains.kotlin.android'
 
 try {
     def servicesJSON = file('google-services.json')

--- a/mobile/android/app/build.gradle
+++ b/mobile/android/app/build.gradle
@@ -17,6 +17,15 @@ android {
              // Default: https://android.googlesource.com/platform/frameworks/base/+/282e181b58cf72b6ca770dc7ca5f91f135444502/tools/aapt/AaptAssets.cpp#61
             ignoreAssetsPattern '!.svn:!.git:!.ds_store:!*.scc:.*:!CVS:!thumbs.db:!picasa.ini:!*~'
         }
+        externalNativeBuild {
+            cmake {
+                cppFlags ""
+                arguments "-DANDROID_STL=c++_shared"
+            }
+        }
+        ndk {
+            abiFilters "arm64-v8a"
+        }
     }
     signingConfigs {
         release {

--- a/mobile/android/app/capacitor.build.gradle
+++ b/mobile/android/app/capacitor.build.gradle
@@ -14,7 +14,6 @@ dependencies {
     implementation project(':capacitor-camera')
     implementation project(':capacitor-splash-screen')
     implementation project(':capawesome-capacitor-android-edge-to-edge-support')
-    implementation project(':capacitor-nodejs')
 
 }
 

--- a/mobile/android/app/capacitor.build.gradle
+++ b/mobile/android/app/capacitor.build.gradle
@@ -9,7 +9,6 @@ android {
 
 apply from: "../capacitor-cordova-android-plugins/cordova.variables.gradle"
 dependencies {
-    implementation 'androidx.core:core-ktx:1.17.0'
     implementation project(':capacitor-app')
     implementation project(':capacitor-browser')
     implementation project(':capacitor-camera')

--- a/mobile/android/app/capacitor.build.gradle
+++ b/mobile/android/app/capacitor.build.gradle
@@ -9,6 +9,7 @@ android {
 
 apply from: "../capacitor-cordova-android-plugins/cordova.variables.gradle"
 dependencies {
+    implementation 'androidx.core:core-ktx:1.17.0'
     implementation project(':capacitor-app')
     implementation project(':capacitor-browser')
     implementation project(':capacitor-camera')

--- a/mobile/android/app/src/main/cpp/CMakeLists.txt
+++ b/mobile/android/app/src/main/cpp/CMakeLists.txt
@@ -1,0 +1,38 @@
+# For more information about using CMake with Android Studio, read the
+# documentation: https://d.android.com/studio/projects/add-native-code.html
+
+# Sets the minimum version of CMake required to build the native library.
+
+cmake_minimum_required(VERSION 3.4.1)
+
+# Creates and names a library, sets it as either STATIC
+# or SHARED, and provides the relative paths to its source code.
+# You can define multiple libraries, and CMake builds them for you.
+# Gradle automatically packages shared libraries with your APK.
+
+add_library( native-lib
+        SHARED
+        native-lib.cpp )
+
+include_directories(libnode/include/node/)
+
+add_library( libnode
+        SHARED
+        IMPORTED )
+set_target_properties( # Specifies the target library.
+        libnode
+        # Specifies the parameter you want to define.
+        PROPERTIES IMPORTED_LOCATION
+        # Provides the path to the library you want to import.
+        ${CMAKE_SOURCE_DIR}/libnode/bin/${ANDROID_ABI}/libnode.so )
+
+find_library( log-lib
+        log )
+
+target_link_libraries( # Specifies the target library.
+        native-lib
+        # Links imported library.
+        libnode
+        # Links the target library to the log library
+        # included in the NDK.
+        ${log-lib} )

--- a/mobile/android/app/src/main/cpp/CMakeLists.txt
+++ b/mobile/android/app/src/main/cpp/CMakeLists.txt
@@ -10,24 +10,24 @@ cmake_minimum_required(VERSION 3.4.1)
 # You can define multiple libraries, and CMake builds them for you.
 # Gradle automatically packages shared libraries with your APK.
 
-add_library( native-lib
+add_library(native-lib
         SHARED
-        native-lib.cpp )
+        native-lib.cpp)
 
 include_directories(libnode/include/node/)
 
-add_library( libnode
+add_library(libnode
         SHARED
-        IMPORTED )
+        IMPORTED)
 set_target_properties( # Specifies the target library.
         libnode
         # Specifies the parameter you want to define.
         PROPERTIES IMPORTED_LOCATION
         # Provides the path to the library you want to import.
-        ${CMAKE_SOURCE_DIR}/libnode/bin/${ANDROID_ABI}/libnode.so )
+        ${CMAKE_SOURCE_DIR}/libnode/bin/${ANDROID_ABI}/libnode.so)
 
-find_library( log-lib
-        log )
+find_library(log-lib
+        log)
 
 target_link_libraries( # Specifies the target library.
         native-lib
@@ -35,4 +35,4 @@ target_link_libraries( # Specifies the target library.
         libnode
         # Links the target library to the log library
         # included in the NDK.
-        ${log-lib} )
+        ${log-lib})

--- a/mobile/android/app/src/main/cpp/native-lib.cpp
+++ b/mobile/android/app/src/main/cpp/native-lib.cpp
@@ -1,0 +1,131 @@
+// Do not forget to dynamically load the C++ library into your application.
+//
+// For instance,
+//
+// In MainActivity.java:
+//    static {
+//       System.loadLibrary("capa");
+//    }
+//
+// Or, in MainActivity.kt:
+//    companion object {
+//      init {
+//         System.loadLibrary("capa")
+//      }
+//    }
+
+#include <jni.h>
+#include <string>
+#include <cstdlib>
+#include "node.h"
+#include <pthread.h>
+#include <unistd.h>
+#include <android/log.h>
+
+int pipe_stdout[2];
+int pipe_stderr[2];
+pthread_t thread_stdout;
+pthread_t thread_stderr;
+const char *ADBTAG = "NODEJS-MOBILE";
+
+void *thread_stderr_func(void*) {
+    ssize_t redirect_size;
+    char buf[2048];
+    while((redirect_size = read(pipe_stderr[0], buf, sizeof buf - 1)) > 0) {
+        //__android_log will add a new line anyway.
+        if(buf[redirect_size - 1] == '\n')
+            --redirect_size;
+        buf[redirect_size] = 0;
+        __android_log_write(ANDROID_LOG_ERROR, ADBTAG, buf);
+    }
+    return 0;
+}
+
+void *thread_stdout_func(void*) {
+    ssize_t redirect_size;
+    char buf[2048];
+    while((redirect_size = read(pipe_stdout[0], buf, sizeof buf - 1)) > 0) {
+        //__android_log will add a new line anyway.
+        if(buf[redirect_size - 1] == '\n')
+            --redirect_size;
+        buf[redirect_size] = 0;
+        __android_log_write(ANDROID_LOG_INFO, ADBTAG, buf);
+    }
+    return 0;
+}
+
+int start_redirecting_stdout_stderr() {
+    //set stdout as unbuffered.
+    setvbuf(stdout, 0, _IONBF, 0);
+    pipe(pipe_stdout);
+    dup2(pipe_stdout[1], STDOUT_FILENO);
+
+    //set stderr as unbuffered.
+    setvbuf(stderr, 0, _IONBF, 0);
+    pipe(pipe_stderr);
+    dup2(pipe_stderr[1], STDERR_FILENO);
+
+    if(pthread_create(&thread_stdout, 0, thread_stdout_func, 0) == -1)
+        return -1;
+    pthread_detach(thread_stdout);
+
+    if(pthread_create(&thread_stderr, 0, thread_stderr_func, 0) == -1)
+        return -1;
+    pthread_detach(thread_stderr);
+
+    return 0;
+}
+
+//node's libUV requires all arguments being on contiguous memory.
+extern "C" jint JNICALL
+Java_im_mustang_capa_NodeJS_startNode(
+        JNIEnv *env,
+        jobject /* this */,
+        jobjectArray arguments) {
+
+    //argc
+    jsize argument_count = env->GetArrayLength(arguments);
+
+    //Compute byte size need for all arguments in contiguous memory.
+    int c_arguments_size = 0;
+    for (int i = 0; i < argument_count ; i++) {
+        c_arguments_size += strlen(env->GetStringUTFChars((jstring)env->GetObjectArrayElement(arguments, i), 0));
+        c_arguments_size++; // for '\0'
+    }
+
+    //Stores arguments in contiguous memory.
+    char* args_buffer = (char*) calloc(c_arguments_size, sizeof(char));
+
+    //argv to pass into node.
+    char* argv[argument_count];
+
+    //To iterate through the expected start position of each argument in args_buffer.
+    char* current_args_position = args_buffer;
+
+    //Populate the args_buffer and argv.
+    for (int i = 0; i < argument_count ; i++)
+    {
+        const char* current_argument = env->GetStringUTFChars((jstring)env->GetObjectArrayElement(arguments, i), 0);
+
+        //Copy current argument to its expected position in args_buffer
+        strncpy(current_args_position, current_argument, strlen(current_argument));
+
+        //Save current argument start position in argv
+        argv[i] = current_args_position;
+
+        //Increment to the next argument's expected position.
+        current_args_position += strlen(current_args_position) + 1;
+    }
+
+    //Start threads to show stdout and stderr in logcat.
+    if (start_redirecting_stdout_stderr()==-1) {
+        __android_log_write(ANDROID_LOG_ERROR, ADBTAG, "Couldn't start redirecting stdout and stderr to logcat.");
+    }
+
+    //Start node, with argc and argv.
+    int node_result = node::Start(argument_count, argv);
+    free(args_buffer);
+
+    return jint(node_result);
+
+}

--- a/mobile/android/app/src/main/cpp/native-lib.cpp
+++ b/mobile/android/app/src/main/cpp/native-lib.cpp
@@ -21,12 +21,29 @@
 #include <pthread.h>
 #include <unistd.h>
 #include <android/log.h>
+#include <cassert>
+#include "cppgc/platform.h"
+#include "node.h"
+#include "uv.h"
+
+#include <algorithm>
+
+using node::CommonEnvironmentSetup;
+using node::Environment;
+using node::MultiIsolatePlatform;
+using v8::Context;
+using v8::HandleScope;
+using v8::Isolate;
+using v8::Locker;
+using v8::MaybeLocal;
+using v8::V8;
+using v8::Value;
 
 int pipe_stdout[2];
 int pipe_stderr[2];
 pthread_t thread_stdout;
 pthread_t thread_stderr;
-const char *ADBTAG = "NODEJS-MOBILE";
+const char *ADBTAG = "NodeJS-Mobile";
 
 void *thread_stderr_func(void*) {
     ssize_t redirect_size;
@@ -76,6 +93,99 @@ int start_redirecting_stdout_stderr() {
     return 0;
 }
 
+static Environment* nodeEnv;
+
+int RunNodeInstance(MultiIsolatePlatform* platform,
+                    const std::vector<std::string>& args,
+                    const std::vector<std::string>& exec_args) {
+    int exit_code = 0;
+
+    // Setup up a libuv event loop, v8::Isolate, and Node.js Environment.
+    std::vector<std::string> errors;
+    std::unique_ptr<CommonEnvironmentSetup> setup =
+            CommonEnvironmentSetup::Create(platform, &errors, args, exec_args);
+    if (!setup) {
+        for (const std::string& err : errors)
+            fprintf(stderr, "%s: %s\n", args[0].c_str(), err.c_str());
+        return 1;
+    }
+
+    Isolate* isolate = setup->isolate();
+    nodeEnv = setup->env();
+
+    {
+        Locker locker(isolate);
+        Isolate::Scope isolate_scope(isolate);
+        HandleScope handle_scope(isolate);
+        // The v8::Context needs to be entered when node::CreateEnvironment() and
+        // node::LoadEnvironment() are being called.
+        Context::Scope context_scope(setup->context());
+
+        // Set up the Node.js instance for execution, and run code inside of it.
+        // There is also a variant that takes a callback and provides it with
+        // the `require` and `process` objects, so that it can manually compile
+        // and run scripts as needed.
+        // The `require` function inside this script does *not* access the file
+        // system, and can only load built-in Node.js modules.
+        // `module.createRequire()` is being used to create one that is able to
+        // load files from the disk, and uses the standard CommonJS file loader
+        // instead of the internal-only `require` function.
+        MaybeLocal<Value> loadenv_ret = node::LoadEnvironment(
+                nodeEnv,
+                "(async () => { await import(process.argv[1]); })().catch(e => { console.error(e); process.exit(1); });");
+
+
+        if (loadenv_ret.IsEmpty())  // There has been a JS exception.
+            return 1;
+
+        exit_code = node::SpinEventLoop(nodeEnv).FromMaybe(1);
+
+        // node::Stop() can be used to explicitly stop the event loop and keep
+        // further JavaScript from running. It can be called from any thread,
+        // and will act like worker.terminate() if called from another thread.
+        node::Stop(nodeEnv);
+    }
+
+    return exit_code;
+}
+
+int startNode(int argc, char** argv) {
+    argv = uv_setup_args(argc, argv);
+    std::vector<std::string> args(argv, argv + argc);
+    // Parse Node.js CLI options, and print any errors that have occurred while
+    // trying to parse them.
+    std::shared_ptr<node::InitializationResult> result =
+            node::InitializeOncePerProcess(args, {
+                    node::ProcessInitializationFlags::kNoInitializeV8,
+                    node::ProcessInitializationFlags::kNoInitializeNodeV8Platform
+            });
+
+    for (const std::string& error : result->errors())
+        fprintf(stderr, "%s: %s\n", args[0].c_str(), error.c_str());
+    if (result->early_return() != 0) {
+        return result->exit_code();
+    }
+
+    // Create a v8::Platform instance. `MultiIsolatePlatform::Create()` is a way
+    // to create a v8::Platform instance that Node.js can use when creating
+    // Worker threads. When no `MultiIsolatePlatform` instance is present,
+    // Worker threads are disabled.
+    std::unique_ptr<MultiIsolatePlatform> platform =
+            MultiIsolatePlatform::Create(4);
+    V8::InitializePlatform(platform.get());
+    V8::Initialize();
+
+    // See below for the contents of this function.
+    int ret = RunNodeInstance(
+            platform.get(), result->args(), result->exec_args());
+
+    V8::Dispose();
+    V8::DisposePlatform();
+
+    node::TearDownOncePerProcess();
+    return ret;
+}
+
 //node's libUV requires all arguments being on contiguous memory.
 extern "C" jint JNICALL
 Java_im_mustang_capa_NodeJS_startNode(
@@ -123,9 +233,16 @@ Java_im_mustang_capa_NodeJS_startNode(
     }
 
     //Start node, with argc and argv.
-    int node_result = node::Start(argument_count, argv);
+    int node_result = startNode(argument_count, argv);
     free(args_buffer);
 
     return jint(node_result);
 
+}
+
+extern "C" void JNICALL
+Java_im_mustang_capa_NodeJS_stopNode(
+        JNIEnv *env,
+        jobject /* this */) {
+    node::Stop(nodeEnv);
 }

--- a/mobile/android/app/src/main/cpp/native-lib.cpp
+++ b/mobile/android/app/src/main/cpp/native-lib.cpp
@@ -93,7 +93,7 @@ int start_redirecting_stdout_stderr() {
     return 0;
 }
 
-static Environment* nodeEnv;
+static Environment* nodeEnv = nullptr;
 
 int RunNodeInstance(MultiIsolatePlatform* platform,
                     const std::vector<std::string>& args,
@@ -171,7 +171,7 @@ int startNode(int argc, char** argv) {
     // Worker threads. When no `MultiIsolatePlatform` instance is present,
     // Worker threads are disabled.
     std::unique_ptr<MultiIsolatePlatform> platform =
-            MultiIsolatePlatform::Create(0);
+            MultiIsolatePlatform::Create(4);
     V8::InitializePlatform(platform.get());
     V8::Initialize();
 
@@ -245,4 +245,8 @@ Java_im_mustang_capa_NodeJS_stopNode(
         JNIEnv *env,
         jobject /* this */) {
     node::Stop(nodeEnv);
+    V8::Dispose();
+    V8::DisposePlatform();
+    node::TearDownOncePerProcess();
+    nodeEnv = nullptr;
 }

--- a/mobile/android/app/src/main/cpp/native-lib.cpp
+++ b/mobile/android/app/src/main/cpp/native-lib.cpp
@@ -171,7 +171,7 @@ int startNode(int argc, char** argv) {
     // Worker threads. When no `MultiIsolatePlatform` instance is present,
     // Worker threads are disabled.
     std::unique_ptr<MultiIsolatePlatform> platform =
-            MultiIsolatePlatform::Create(4);
+            MultiIsolatePlatform::Create(0);
     V8::InitializePlatform(platform.get());
     V8::Initialize();
 

--- a/mobile/android/app/src/main/cpp/native-lib.cpp
+++ b/mobile/android/app/src/main/cpp/native-lib.cpp
@@ -222,4 +222,6 @@ Java_im_mustang_capa_NodeJS_stopNode(JNIEnv *env, jobject thiz) {
     V8::DisposePlatform();
     node::TearDownOncePerProcess();
     nodeEnv = nullptr;
+    pthread_detach(thread_stdout);
+    pthread_detach(thread_stderr);
 }

--- a/mobile/android/app/src/main/cpp/native-lib.cpp
+++ b/mobile/android/app/src/main/cpp/native-lib.cpp
@@ -1,4 +1,7 @@
-// From <>
+// A combination of
+// <https://github.com/nodejs-mobile/nodejs-mobile-samples/blob/master/android/native-gradle-node-folder/app/src/main/cpp/native-lib.cpp>
+// and
+// <https://nodejs.org/api/embedding.html>
 
 #include <jni.h>
 #include <string>

--- a/mobile/android/app/src/main/cpp/native-lib.cpp
+++ b/mobile/android/app/src/main/cpp/native-lib.cpp
@@ -14,6 +14,9 @@
 //      }
 //    }
 
+// From <https://nodejs.org/api/embedding.html> example
+// From <https://nodejs-mobile.github.io/docs/guide/guide-android/building-complex> example
+
 #include <jni.h>
 #include <string>
 #include <cstdlib>

--- a/mobile/android/app/src/main/cpp/native-lib.cpp
+++ b/mobile/android/app/src/main/cpp/native-lib.cpp
@@ -1,21 +1,4 @@
-// Do not forget to dynamically load the C++ library into your application.
-//
-// For instance,
-//
-// In MainActivity.java:
-//    static {
-//       System.loadLibrary("capa");
-//    }
-//
-// Or, in MainActivity.kt:
-//    companion object {
-//      init {
-//         System.loadLibrary("capa")
-//      }
-//    }
-
-// From <https://nodejs.org/api/embedding.html> example
-// From <https://nodejs-mobile.github.io/docs/guide/guide-android/building-complex> example
+// From <>
 
 #include <jni.h>
 #include <string>
@@ -24,29 +7,18 @@
 #include <pthread.h>
 #include <unistd.h>
 #include <android/log.h>
-#include <cassert>
-#include "cppgc/platform.h"
-#include "node.h"
 #include "uv.h"
+#include <v8.h>
 
-#include <algorithm>
+using namespace node;
+using namespace v8;
 
-using node::CommonEnvironmentSetup;
-using node::Environment;
-using node::MultiIsolatePlatform;
-using v8::Context;
-using v8::HandleScope;
-using v8::Isolate;
-using v8::Locker;
-using v8::MaybeLocal;
-using v8::V8;
-using v8::Value;
-
+// Start threads to redirect stdout and stderr to logcat.
 int pipe_stdout[2];
 int pipe_stderr[2];
 pthread_t thread_stdout;
 pthread_t thread_stderr;
-const char *ADBTAG = "NodeJS-Mobile";
+const char *ADBTAG = "NODEJS-MOBILE";
 
 void *thread_stderr_func(void *) {
     ssize_t redirect_size;
@@ -96,98 +68,101 @@ int start_redirecting_stdout_stderr() {
     return 0;
 }
 
-// Global platform pointer
-std::unique_ptr<MultiIsolatePlatform> platform;
+static Environment *nodeEnv;
 
-void InitializeV8() {
-    if (platform) return;
+int RunNodeInstance(MultiIsolatePlatform *platform,
+                    const std::vector<std::string> &args,
+                    const std::vector<std::string> &exec_args) {
+    int exit_code = 0;
 
-    // Create a v8::Platform instance. `MultiIsolatePlatform::Create()` is a way
-    // to create a v8::Platform instance that Node.js can use when creating
-    // Worker threads. When no `MultiIsolatePlatform` instance is present,
-    // Worker threads are disabled.
-    platform = MultiIsolatePlatform::Create(1);
-    V8::InitializePlatform(platform.get());
-    V8::Initialize();
-}
-
-void DisposeV8() {
-    if (!platform) return;
-
-    v8::V8::Dispose();
-    v8::V8::DisposePlatform();
-    platform.reset();
-}
-
-node::Environment *RunNodeInstance(MultiIsolatePlatform *platform,
-                                   const std::vector<std::string> &args,
-                                   const std::vector<std::string> &exec_args) {
+    // Setup up a libuv event loop, v8::Isolate, and Node.js Environment.
     std::vector<std::string> errors;
-
-    std::unique_ptr<node::CommonEnvironmentSetup> setup =
-            node::CommonEnvironmentSetup::Create(platform, &errors, args, exec_args);
+    std::unique_ptr<CommonEnvironmentSetup> setup =
+            CommonEnvironmentSetup::Create(platform, &errors, args, exec_args);
     if (!setup) {
-        for (const auto &err: errors) std::fprintf(stderr, "Error: %s\n", err.c_str());
-        return nullptr;
-    }
-    v8::Isolate *isolate = setup->isolate();
-    node::Environment *env = setup->env();
-
-    v8::Locker locker(isolate);
-    v8::Isolate::Scope isolate_scope(isolate);
-    v8::HandleScope handle_scope(isolate);
-    v8::Context::Scope context_scope(setup->context());
-
-    v8::MaybeLocal<v8::Value> load_result = node::LoadEnvironment(
-            env,
-            "import(process.argv[1]).catch(e => { console.error(e); process.exit(1); });"
-    );
-
-    if (load_result.IsEmpty()) {
-        std::fprintf(stderr, "Failed to load JS environment\n");
-        return nullptr;
+        for (const std::string &err: errors)
+            fprintf(stderr, "%s: %s\n", args[0].c_str(), err.c_str());
+        return 1;
     }
 
-    return env;
+    Isolate *isolate = setup->isolate();
+    nodeEnv = setup->env();
+
+    {
+        Locker locker(isolate);
+        Isolate::Scope isolate_scope(isolate);
+        HandleScope handle_scope(isolate);
+        // The v8::Context needs to be entered when node::CreateEnvironment() and
+        // node::LoadEnvironment() are being called.
+        Context::Scope context_scope(setup->context());
+
+        // Set up the Node.js instance for execution, and run code inside of it.
+        // There is also a variant that takes a callback and provides it with
+        // the `require` and `process` objects, so that it can manually compile
+        // and run scripts as needed.
+        // The `require` function inside this script does *not* access the file
+        // system, and can only load built-in Node.js modules.
+        // `module.createRequire()` is being used to create one that is able to
+        // load files from the disk, and uses the standard CommonJS file loader
+        // instead of the internal-only `require` function.
+        MaybeLocal<Value> loadenv_ret = node::LoadEnvironment(
+                nodeEnv,
+                "import(process.argv[1]).catch(e => { console.error(e); process.exit(1); });");
+
+        if (loadenv_ret.IsEmpty())  // There has been a JS exception.
+            return 1;
+
+        exit_code = node::SpinEventLoop(nodeEnv).FromMaybe(1);
+
+        // node::Stop() can be used to explicitly stop the event loop and keep
+        // further JavaScript from running. It can be called from any thread,
+        // and will act like worker.terminate() if called from another thread.
+        node::Stop(nodeEnv);
+    }
+
+    return exit_code;
 }
 
-
-node::Environment *runNodeEnv(int argc, char **argv) {
+int RunNodeProcess(int argc, char **argv) {
     argv = uv_setup_args(argc, argv);
     std::vector<std::string> args(argv, argv + argc);
-
-    auto init_res =
+    // Parse Node.js CLI options, and print any errors that have occurred while
+    // trying to parse them.
+    std::shared_ptr<node::InitializationResult> result =
             node::InitializeOncePerProcess(args, {
                     node::ProcessInitializationFlags::kNoInitializeV8,
                     node::ProcessInitializationFlags::kNoInitializeNodeV8Platform
             });
 
-    if (init_res->early_return() != 0) {
-        return nullptr;
+    for (const std::string &error: result->errors())
+        fprintf(stderr, "%s: %s\n", args[0].c_str(), error.c_str());
+    if (result->early_return() != 0) {
+        return result->exit_code();
     }
 
-    // Run embedded environment (single-threaded)
-    node::Environment *env = RunNodeInstance(platform.get(), init_res->args(),
-                                             init_res->exec_args());
-    if (!env) {
-        std::fprintf(stderr, "Could not create Node environment\n");
-        DisposeV8();
-        return nullptr;
-    }
+    // Create a v8::Platform instance. `MultiIsolatePlatform::Create()` is a way
+    // to create a v8::Platform instance that Node.js can use when creating
+    // Worker threads. When no `MultiIsolatePlatform` instance is present,
+    // Worker threads are disabled.
+    std::unique_ptr<MultiIsolatePlatform> platform =
+            MultiIsolatePlatform::Create(1);
+    V8::InitializePlatform(platform.get());
+    V8::Initialize();
 
-    return env;
-}
+    // See below for the contents of this function.
+    int ret = RunNodeInstance(
+            platform.get(), result->args(), result->exec_args());
 
-extern "C" void JNICALL
-Java_im_mustang_capa_NodeJS_initializeV8(
-        JNIEnv *env,
-        jobject /* this */) {
-    InitializeV8();
+    V8::Dispose();
+    V8::DisposePlatform();
+
+    node::TearDownOncePerProcess();
+    return ret;
 }
 
 //node's libUV requires all arguments being on contiguous memory.
-extern "C" jlong JNICALL
-Java_im_mustang_capa_NodeJS_runNodeEnv(
+extern "C" jint JNICALL
+Java_im_mustang_capa_NodeJS_startNode(
         JNIEnv *env,
         jobject /* this */,
         jobjectArray arguments) {
@@ -214,52 +189,34 @@ Java_im_mustang_capa_NodeJS_runNodeEnv(
 
     //Populate the args_buffer and argv.
     for (int i = 0; i < argument_count; i++) {
-        jstring arg_jstr = (jstring) env->GetObjectArrayElement(arguments, i);
-        jsize arg_len = env->GetStringUTFLength(arg_jstr);
-        env->GetStringUTFRegion(arg_jstr, 0, arg_len, current_args_position);
-        argv[i] = current_args_position;
-        current_args_position += arg_len + 1;
-        env->DeleteLocalRef(arg_jstr);
-    }
+        const char *current_argument = env->GetStringUTFChars(
+                (jstring) env->GetObjectArrayElement(arguments, i), 0);
 
+        //Copy current argument to its expected position in args_buffer
+        strncpy(current_args_position, current_argument, strlen(current_argument));
+
+        //Save current argument start position in argv
+        argv[i] = current_args_position;
+
+        //Increment to the next argument's expected position.
+        current_args_position += strlen(current_args_position) + 1;
+    }
     //Start threads to show stdout and stderr in logcat.
     if (start_redirecting_stdout_stderr() == -1) {
         __android_log_write(ANDROID_LOG_ERROR, ADBTAG,
                             "Couldn't start redirecting stdout and stderr to logcat.");
     }
 
-    //Run node env
-    node::Environment *nodeEnvPtr = runNodeEnv(argument_count, argv);
-    free(args_buffer);
+    //Start node, with argc and argv.
+    return jint(RunNodeProcess(argument_count, argv));
 
-    return jlong(nodeEnvPtr);
 }
-
-extern "C" jint JNICALL
-Java_im_mustang_capa_NodeJS_spinNodeEventLoop(
-        JNIEnv *env,
-        jobject /* this */,
-        jlong nodeEnvPtr) {
-    node::Environment *nodeEnv = reinterpret_cast<node::Environment *>(nodeEnvPtr);
-    int exit_code = node::SpinEventLoop(nodeEnv).FromMaybe(1);
-    return jint(exit_code);
-}
-
-extern "C" void JNICALL
-Java_im_mustang_capa_NodeJS_stopNode(
-        JNIEnv *env,
-        jobject /* this */,
-        jlong nodeEnvPtr
-) {
-    node::Environment *nodeEnv = reinterpret_cast<node::Environment *>(nodeEnvPtr);
-    if (nodeEnv) {
-        node::Stop(nodeEnv);
-    }
-}
-
-extern "C" void JNICALL
-Java_im_mustang_capa_NodeJS_disposeV8(
-        JNIEnv *env,
-        jobject /* this */) {
-    DisposeV8();
+extern "C"
+JNIEXPORT void JNICALL
+Java_im_mustang_capa_NodeJS_stopNode(JNIEnv *env, jobject thiz) {
+    node::Stop(nodeEnv);
+    V8::Dispose();
+    V8::DisposePlatform();
+    node::TearDownOncePerProcess();
+    nodeEnv = nullptr;
 }

--- a/mobile/android/app/src/main/cpp/native-lib.cpp
+++ b/mobile/android/app/src/main/cpp/native-lib.cpp
@@ -132,7 +132,7 @@ int RunNodeInstance(MultiIsolatePlatform *platform,
         // instead of the internal-only `require` function.
         MaybeLocal<Value> loadenv_ret = node::LoadEnvironment(
                 nodeEnv,
-                "(async () => { await import(process.argv[1]); })().catch(e => { console.error(e); process.exit(1); });");
+                "import(process.argv[1]).catch(e => { console.error(e); process.exit(1); });");
 
 
         if (loadenv_ret.IsEmpty())  // There has been a JS exception.

--- a/mobile/android/app/src/main/cpp/native-lib.cpp
+++ b/mobile/android/app/src/main/cpp/native-lib.cpp
@@ -134,7 +134,10 @@ int RunNodeProcess(int argc, char **argv) {
     std::shared_ptr<node::InitializationResult> result =
             node::InitializeOncePerProcess(args, {
                     node::ProcessInitializationFlags::kNoInitializeV8,
-                    node::ProcessInitializationFlags::kNoInitializeNodeV8Platform
+                    node::ProcessInitializationFlags::kNoInitializeNodeV8Platform,
+                    node::ProcessInitializationFlags::kDisableNodeOptionsEnv,
+                    node::ProcessInitializationFlags::kNoParseGlobalDebugVariables,
+                    node::ProcessInitializationFlags::kNoPrintHelpOrVersionOutput
             });
 
     for (const std::string &error: result->errors())

--- a/mobile/android/app/src/main/cpp/native-lib.cpp
+++ b/mobile/android/app/src/main/cpp/native-lib.cpp
@@ -96,123 +96,98 @@ int start_redirecting_stdout_stderr() {
     return 0;
 }
 
-void ExternalStopFunction(node::Environment* nodeEnv) {
-    node::Stop(nodeEnv);
+// Global platform pointer
+std::unique_ptr<MultiIsolatePlatform> platform;
+
+void InitializeV8() {
+    if (platform) return;
+
+    // Create a v8::Platform instance. `MultiIsolatePlatform::Create()` is a way
+    // to create a v8::Platform instance that Node.js can use when creating
+    // Worker threads. When no `MultiIsolatePlatform` instance is present,
+    // Worker threads are disabled.
+    platform = MultiIsolatePlatform::Create(1);
+    V8::InitializePlatform(platform.get());
+    V8::Initialize();
 }
 
-int RunNodeInstance(MultiIsolatePlatform *platform,
-                    const std::vector<std::string> &args,
-                    const std::vector<std::string> &exec_args) {
-    int exit_code = 0;
+void DisposeV8() {
+    if (!platform) return;
 
-    // Setup up a libuv event loop, v8::Isolate, and Node.js Environment.
+    v8::V8::Dispose();
+    v8::V8::DisposePlatform();
+    platform.reset();
+}
+
+node::Environment *RunNodeInstance(MultiIsolatePlatform *platform,
+                                   const std::vector<std::string> &args,
+                                   const std::vector<std::string> &exec_args) {
     std::vector<std::string> errors;
-    std::unique_ptr<CommonEnvironmentSetup> setup =
-            CommonEnvironmentSetup::Create(platform, &errors, args, exec_args);
+
+    std::unique_ptr<node::CommonEnvironmentSetup> setup =
+            node::CommonEnvironmentSetup::Create(platform, &errors, args, exec_args);
     if (!setup) {
-        for (const std::string &err: errors)
-            fprintf(stderr, "%s: %s\n", args[0].c_str(), err.c_str());
-        return 1;
+        for (const auto &err: errors) std::fprintf(stderr, "Error: %s\n", err.c_str());
+        return nullptr;
+    }
+    v8::Isolate *isolate = setup->isolate();
+    node::Environment *env = setup->env();
+
+    v8::Locker locker(isolate);
+    v8::Isolate::Scope isolate_scope(isolate);
+    v8::HandleScope handle_scope(isolate);
+    v8::Context::Scope context_scope(setup->context());
+
+    v8::MaybeLocal<v8::Value> load_result = node::LoadEnvironment(
+            env,
+            "import(process.argv[1]).catch(e => { console.error(e); process.exit(1); });"
+    );
+
+    if (load_result.IsEmpty()) {
+        std::fprintf(stderr, "Failed to load JS environment\n");
+        return nullptr;
     }
 
-    Isolate *isolate = setup->isolate();
-    node::Environment* nodeEnv = setup->env();
-
-    {
-        Locker locker(isolate);
-        Isolate::Scope isolate_scope(isolate);
-        HandleScope handle_scope(isolate);
-        // The v8::Context needs to be entered when node::CreateEnvironment() and
-        // node::LoadEnvironment() are being called.
-        Context::Scope context_scope(setup->context());
-
-        // Set up the Node.js instance for execution, and run code inside of it.
-        // There is also a variant that takes a callback and provides it with
-        // the `require` and `process` objects, so that it can manually compile
-        // and run scripts as needed.
-        // The `require` function inside this script does *not* access the file
-        // system, and can only load built-in Node.js modules.
-        // `module.createRequire()` is being used to create one that is able to
-        // load files from the disk, and uses the standard CommonJS file loader
-        // instead of the internal-only `require` function.
-        MaybeLocal<Value> loadenv_ret = node::LoadEnvironment(
-                nodeEnv,
-                "import(process.argv[1]).catch(e => { console.error(e); process.exit(1); });");
-
-
-        if (loadenv_ret.IsEmpty())  // There has been a JS exception.
-            return 1;
-
-        exit_code = node::SpinEventLoop(nodeEnv).FromMaybe(1);
-
-        // node::Stop() can be used to explicitly stop the event loop and keep
-        // further JavaScript from running. It can be called from any thread,
-        // and will act like worker.terminate() if called from another thread.
-        ExternalStopFunction(nodeEnv);
-    }
-
-    return exit_code;
+    return env;
 }
 
 
-// Keep global platform pointer
-std::unique_ptr<MultiIsolatePlatform> g_platform;
-
-void InitializeV8PlatformOnce() {
-    if (!g_platform) {
-        g_platform = MultiIsolatePlatform::Create(
-                2);  // Use fewer threads (2 instead of 4) to reduce overhead
-        V8::InitializePlatform(g_platform.get());
-        V8::Initialize();
-    }
-}
-
-void DisposeV8PlatformOnce() {
-    if (g_platform) {
-        V8::Dispose();
-        V8::DisposePlatform();
-        g_platform.reset();
-    }
-}
-
-int startNode(int argc, char **argv) {
+node::Environment *runNodeEnv(int argc, char **argv) {
     argv = uv_setup_args(argc, argv);
     std::vector<std::string> args(argv, argv + argc);
-    // Parse Node.js CLI options, and print any errors that have occurred while
-    // trying to parse them.
-    std::shared_ptr<node::InitializationResult> result =
+
+    auto init_res =
             node::InitializeOncePerProcess(args, {
                     node::ProcessInitializationFlags::kNoInitializeV8,
                     node::ProcessInitializationFlags::kNoInitializeNodeV8Platform
             });
 
-    for (const std::string &error: result->errors())
-        fprintf(stderr, "%s: %s\n", args[0].c_str(), error.c_str());
-    if (result->early_return() != 0) {
-        return result->exit_code();
+    if (init_res->early_return() != 0) {
+        return nullptr;
     }
 
-    InitializeV8PlatformOnce();
+    // Run embedded environment (single-threaded)
+    node::Environment *env = RunNodeInstance(platform.get(), init_res->args(),
+                                             init_res->exec_args());
+    if (!env) {
+        std::fprintf(stderr, "Could not create Node environment\n");
+        DisposeV8();
+        return nullptr;
+    }
 
-    // See below for the contents of this function.
-    int ret = RunNodeInstance(
-            g_platform.get(), result->args(), result->exec_args());
-
-    DisposeV8PlatformOnce();
-
-    return ret;
+    return env;
 }
 
 extern "C" void JNICALL
 Java_im_mustang_capa_NodeJS_initializeV8(
         JNIEnv *env,
         jobject /* this */) {
-    InitializeV8PlatformOnce();
+    InitializeV8();
 }
 
 //node's libUV requires all arguments being on contiguous memory.
-extern "C" jint JNICALL
-Java_im_mustang_capa_NodeJS_startNode(
+extern "C" jlong JNICALL
+Java_im_mustang_capa_NodeJS_runNodeEnv(
         JNIEnv *env,
         jobject /* this */,
         jobjectArray arguments) {
@@ -253,25 +228,38 @@ Java_im_mustang_capa_NodeJS_startNode(
                             "Couldn't start redirecting stdout and stderr to logcat.");
     }
 
-    //Start node, with argc and argv.
-    int node_result = startNode(argument_count, argv);
+    //Run node env
+    node::Environment *nodeEnvPtr = runNodeEnv(argument_count, argv);
     free(args_buffer);
 
-    return jint(node_result);
+    return jlong(nodeEnvPtr);
+}
 
+extern "C" jint JNICALL
+Java_im_mustang_capa_NodeJS_spinNodeEventLoop(
+        JNIEnv *env,
+        jobject /* this */,
+        jlong nodeEnvPtr) {
+    node::Environment *nodeEnv = reinterpret_cast<node::Environment *>(nodeEnvPtr);
+    int exit_code = node::SpinEventLoop(nodeEnv).FromMaybe(1);
+    return jint(exit_code);
 }
 
 extern "C" void JNICALL
 Java_im_mustang_capa_NodeJS_stopNode(
         JNIEnv *env,
-        jobject /* this */) {
-    node::Stop(nodeEnv);
-    nodeEnv = nullptr;
+        jobject /* this */,
+        jlong nodeEnvPtr
+) {
+    node::Environment *nodeEnv = reinterpret_cast<node::Environment *>(nodeEnvPtr);
+    if (nodeEnv) {
+        node::Stop(nodeEnv);
+    }
 }
 
 extern "C" void JNICALL
 Java_im_mustang_capa_NodeJS_disposeV8(
         JNIEnv *env,
         jobject /* this */) {
-    DisposeV8PlatformOnce();
+    DisposeV8();
 }

--- a/mobile/android/app/src/main/java/im/mustang/capa/FileOperations.kt
+++ b/mobile/android/app/src/main/java/im/mustang/capa/FileOperations.kt
@@ -1,3 +1,7 @@
+// From <https://github.com/hampoelz/Capacitor-NodeJS/blob/main/android/src/main/java/net/hampoelz/capacitor/nodejs/FileOperations.java>
+// Copyright (c) 2023 Rene Hampölz
+// MIT License (MIT)
+
 package im.mustang.capa
 
 import android.content.res.AssetManager

--- a/mobile/android/app/src/main/java/im/mustang/capa/FileOperations.kt
+++ b/mobile/android/app/src/main/java/im/mustang/capa/FileOperations.kt
@@ -1,0 +1,168 @@
+package im.mustang.capa
+
+import android.content.res.AssetManager
+import com.getcapacitor.Logger
+import java.io.BufferedReader
+import java.io.File
+import java.io.FileOutputStream
+import java.io.FileReader
+import java.io.IOException
+import java.io.InputStream
+import java.io.OutputStream
+
+object FileOperations {
+    fun existsPath(path: String): Boolean {
+        val file = File(path)
+        return file.exists()
+    }
+
+    fun combinePath(vararg paths: String?): String {
+        var file = File(paths[0])
+
+        for (index in 1..<paths.size) {
+            file = File(file, paths[index])
+        }
+
+        return file.path
+    }
+
+    fun combineEnv(vararg variables: String?): String {
+        val builder = StringBuilder()
+
+        for (index in variables.indices) {
+            val variable: String? = variables[index]
+
+            if (variable == null || variable.isEmpty()) {
+                continue
+            }
+
+            builder.append(variable)
+            if (index < variables.size - 1) {
+                builder.append(":")
+            }
+        }
+
+        return builder.toString()
+    }
+
+    @Throws(IOException::class)
+    fun readFileFromPath(path: String): String {
+        val file = File(path)
+
+        val builder = StringBuilder()
+        val reader = BufferedReader(FileReader(file))
+
+        var line: String?
+        while ((reader.readLine().also { line = it }) != null) {
+            builder.append(line)
+            builder.append("\n")
+        }
+
+        reader.close()
+
+        return builder.toString()
+    }
+
+    fun createDir(dirPath: String): Boolean {
+        val directory = File(dirPath)
+        if (directory.exists()) return true
+        return directory.mkdirs()
+    }
+
+    fun deleteDir(dirPath: String): Boolean {
+        val directory = File(dirPath)
+        return deleteDir(directory)
+    }
+
+    fun deleteDir(directory: File): Boolean {
+        if (!directory.exists()) return true
+
+        val files = directory.listFiles()
+        var success = true
+
+        if (files != null) {
+            for (file in files) {
+                success = if (file.isDirectory()) {
+                    success and deleteDir(file)
+                } else {
+                    success and file.delete()
+                }
+            }
+        }
+
+        success = success and directory.delete()
+        return success
+    }
+
+    fun copyAssetDir(
+        assetManager: AssetManager,
+        assetPath: String,
+        destinationPath: String
+    ): Boolean {
+        try {
+            val files = assetManager.list(assetPath)
+            if (files == null) return false
+
+            var success = true
+
+            if (files.size == 0) {
+                success = copyAsset(assetManager, assetPath, destinationPath)
+            } else {
+                createDir(destinationPath)
+
+                for (file in files) {
+                    success = success and copyAssetDir(
+                        assetManager,
+                        combinePath(assetPath, file),
+                        combinePath(destinationPath, file)
+                    )
+                }
+            }
+
+            return success
+        } catch (e: IOException) {
+            Logger.error(
+                TAG,
+                "Failed to copy assets from '$assetPath'.",
+                e
+            )
+            return false
+        }
+    }
+
+    fun copyAsset(assetManager: AssetManager, assetPath: String, destinationPath: String): Boolean {
+        try {
+            val destinationFile = File(destinationPath)
+
+            destinationFile.createNewFile()
+
+            val `in` = assetManager.open(assetPath)
+            val out: OutputStream = FileOutputStream(destinationPath)
+
+            copyStream(`in`, out)
+
+            `in`.close()
+            out.flush()
+            out.close()
+
+            return true
+        } catch (e: Exception) {
+            Logger.error(
+                TAG,
+                "Failed to copy the asset '$assetPath' to '$destinationPath'.",
+                e
+            )
+            return false
+        }
+    }
+
+    @Throws(IOException::class)
+    fun copyStream(`in`: InputStream, out: OutputStream) {
+        val buffer = ByteArray(1024)
+
+        var size: Int
+        while ((`in`.read(buffer).also { size = it }) != -1) {
+            out.write(buffer, 0, size)
+        }
+    }
+}

--- a/mobile/android/app/src/main/java/im/mustang/capa/FileOperations.kt
+++ b/mobile/android/app/src/main/java/im/mustang/capa/FileOperations.kt
@@ -2,10 +2,8 @@ package im.mustang.capa
 
 import android.content.res.AssetManager
 import com.getcapacitor.Logger
-import java.io.BufferedReader
 import java.io.File
 import java.io.FileOutputStream
-import java.io.FileReader
 import java.io.IOException
 import java.io.InputStream
 import java.io.OutputStream
@@ -16,7 +14,7 @@ object FileOperations {
         return file.exists()
     }
 
-    fun combinePath(vararg paths: String?): String {
+    fun combinePath(vararg paths: String): String {
         var file = File(paths[0])
 
         for (index in 1..<paths.size) {
@@ -24,43 +22,6 @@ object FileOperations {
         }
 
         return file.path
-    }
-
-    fun combineEnv(vararg variables: String?): String {
-        val builder = StringBuilder()
-
-        for (index in variables.indices) {
-            val variable: String? = variables[index]
-
-            if (variable == null || variable.isEmpty()) {
-                continue
-            }
-
-            builder.append(variable)
-            if (index < variables.size - 1) {
-                builder.append(":")
-            }
-        }
-
-        return builder.toString()
-    }
-
-    @Throws(IOException::class)
-    fun readFileFromPath(path: String): String {
-        val file = File(path)
-
-        val builder = StringBuilder()
-        val reader = BufferedReader(FileReader(file))
-
-        var line: String?
-        while ((reader.readLine().also { line = it }) != null) {
-            builder.append(line)
-            builder.append("\n")
-        }
-
-        reader.close()
-
-        return builder.toString()
     }
 
     fun createDir(dirPath: String): Boolean {
@@ -82,7 +43,7 @@ object FileOperations {
 
         if (files != null) {
             for (file in files) {
-                success = if (file.isDirectory()) {
+                success = if (file.isDirectory) {
                     success and deleteDir(file)
                 } else {
                     success and file.delete()
@@ -122,7 +83,7 @@ object FileOperations {
             return success
         } catch (e: IOException) {
             Logger.error(
-                TAG,
+                Constants.TAG,
                 "Failed to copy assets from '$assetPath'.",
                 e
             )
@@ -148,7 +109,7 @@ object FileOperations {
             return true
         } catch (e: Exception) {
             Logger.error(
-                TAG,
+                Constants.TAG,
                 "Failed to copy the asset '$assetPath' to '$destinationPath'.",
                 e
             )

--- a/mobile/android/app/src/main/java/im/mustang/capa/MainActivity.java
+++ b/mobile/android/app/src/main/java/im/mustang/capa/MainActivity.java
@@ -1,5 +1,0 @@
-package im.mustang.capa;
-
-import com.getcapacitor.BridgeActivity;
-
-public class MainActivity extends BridgeActivity {}

--- a/mobile/android/app/src/main/java/im/mustang/capa/MainActivity.kt
+++ b/mobile/android/app/src/main/java/im/mustang/capa/MainActivity.kt
@@ -24,7 +24,7 @@ class MainActivity : BridgeActivity() {
     }
 
     override fun onDestroy() {
-        super.onDestroy()
         this.nodeJS.stop()
+        super.onDestroy()
     }
 }

--- a/mobile/android/app/src/main/java/im/mustang/capa/MainActivity.kt
+++ b/mobile/android/app/src/main/java/im/mustang/capa/MainActivity.kt
@@ -2,4 +2,12 @@ package im.mustang.capa
 
 import com.getcapacitor.BridgeActivity
 
-class MainActivity : BridgeActivity()
+class MainActivity : BridgeActivity() {
+    private lateinit var nodeJS: NodeJS
+
+    override fun onStart() {
+        this.nodeJS = NodeJS(this.applicationContext)
+        this.nodeJS.start()
+        super.onStart()
+    }
+}

--- a/mobile/android/app/src/main/java/im/mustang/capa/MainActivity.kt
+++ b/mobile/android/app/src/main/java/im/mustang/capa/MainActivity.kt
@@ -1,0 +1,5 @@
+package im.mustang.capa
+
+import com.getcapacitor.BridgeActivity
+
+class MainActivity : BridgeActivity()

--- a/mobile/android/app/src/main/java/im/mustang/capa/MainActivity.kt
+++ b/mobile/android/app/src/main/java/im/mustang/capa/MainActivity.kt
@@ -23,13 +23,8 @@ class MainActivity : BridgeActivity() {
         super.onStart()
     }
 
-    override fun onStop() {
-        super.onStop()
-        this.nodeJS.stop()
-    }
-
     override fun onDestroy() {
         super.onDestroy()
-        this.nodeJS.destroy()
+        this.nodeJS.stop()
     }
 }

--- a/mobile/android/app/src/main/java/im/mustang/capa/MainActivity.kt
+++ b/mobile/android/app/src/main/java/im/mustang/capa/MainActivity.kt
@@ -2,13 +2,19 @@ package im.mustang.capa
 
 import android.os.Bundle
 import com.getcapacitor.BridgeActivity
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
 
 class MainActivity : BridgeActivity() {
+    private val coroutineScope = CoroutineScope(Dispatchers.IO)
     private lateinit var nodeJS: NodeJS
 
     override fun onCreate(savedInstanceState: Bundle?) {
-        this.nodeJS = NodeJS(this.applicationContext)
-        this.nodeJS.start()
+        coroutineScope.launch {
+            this@MainActivity.nodeJS = NodeJS(this@MainActivity.applicationContext)
+            this@MainActivity.nodeJS.start()
+        }
         super.onCreate(savedInstanceState)
     }
 
@@ -17,8 +23,8 @@ class MainActivity : BridgeActivity() {
         super.onStart()
     }
 
-    override fun onPause() {
-        super.onPause()
+    override fun onStop() {
+        super.onStop()
         this.nodeJS.stop()
     }
 }

--- a/mobile/android/app/src/main/java/im/mustang/capa/MainActivity.kt
+++ b/mobile/android/app/src/main/java/im/mustang/capa/MainActivity.kt
@@ -18,11 +18,6 @@ class MainActivity : BridgeActivity() {
         super.onCreate(savedInstanceState)
     }
 
-    override fun onStart() {
-        this.nodeJS.start()
-        super.onStart()
-    }
-
     override fun onDestroy() {
         this.nodeJS.stop()
         super.onDestroy()

--- a/mobile/android/app/src/main/java/im/mustang/capa/MainActivity.kt
+++ b/mobile/android/app/src/main/java/im/mustang/capa/MainActivity.kt
@@ -1,13 +1,24 @@
 package im.mustang.capa
 
+import android.os.Bundle
 import com.getcapacitor.BridgeActivity
 
 class MainActivity : BridgeActivity() {
     private lateinit var nodeJS: NodeJS
 
-    override fun onStart() {
+    override fun onCreate(savedInstanceState: Bundle?) {
         this.nodeJS = NodeJS(this.applicationContext)
         this.nodeJS.start()
+        super.onCreate(savedInstanceState)
+    }
+
+    override fun onStart() {
+        this.nodeJS.start()
         super.onStart()
+    }
+
+    override fun onPause() {
+        super.onPause()
+        this.nodeJS.stop()
     }
 }

--- a/mobile/android/app/src/main/java/im/mustang/capa/MainActivity.kt
+++ b/mobile/android/app/src/main/java/im/mustang/capa/MainActivity.kt
@@ -27,4 +27,9 @@ class MainActivity : BridgeActivity() {
         super.onStop()
         this.nodeJS.stop()
     }
+
+    override fun onDestroy() {
+        super.onDestroy()
+        this.nodeJS.destroy()
+    }
 }

--- a/mobile/android/app/src/main/java/im/mustang/capa/NodeJS.kt
+++ b/mobile/android/app/src/main/java/im/mustang/capa/NodeJS.kt
@@ -9,9 +9,9 @@ import androidx.core.content.edit
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
+import kotlinx.coroutines.async
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.withContext
 
 
 object Constants {
@@ -51,57 +51,101 @@ class NodeJS {
 
     private external fun startNode(args: Array<String>)
 
-    private val nodeScope = CoroutineScope(Dispatchers.IO)
+    private val nodeScope = CoroutineScope(Dispatchers.Default)
     private var job: Job? = null
+
+    private external fun initializeV8()
+
+    private fun create() {
+        try {
+            initializeV8()
+        } catch (e: Throwable) {
+            Log.e(
+                Constants.TAG,
+                "Error while initializing V8",
+                e
+            )
+        }
+    }
 
     fun start() {
         if (job != null) return
 
         job = nodeScope.launch {
-            val filesPath = context.filesDir.absolutePath
+            val projectMainPath = async(Dispatchers.IO) {
+                val filesPath = context.filesDir.absolutePath
 
-            val basePath = FileOperations.combinePath(filesPath, "public")
-            val projectPath = FileOperations.combinePath(basePath, "nodejs")
+                val basePath = FileOperations.combinePath(filesPath, "public")
+                val projectPath = FileOperations.combinePath(basePath, "nodejs")
 
-            val copyNodeProjectSuccess =
-                copyNodeProjectFromAPK(projectPath)
-            if (!copyNodeProjectSuccess) {
-                Log.e(Constants.TAG, "Unable to copy the Node.js project from APK.")
-                cancel()
-            }
-
-            if (!FileOperations.existsPath(projectPath)) {
-                Log.e(Constants.TAG, "Unable to access the Node.js project. (No such directory)")
-                cancel()
-            }
-
-            val projectMainPath =
-                FileOperations.combinePath(projectPath, Constants.PROJECT_MAIN_FILE)
-
-            if (!FileOperations.existsPath(projectMainPath)) {
-                Log.e(
-                    Constants.TAG,
-                    "Unable to access main script of the Node.js project. (No such file) $projectMainPath"
-                )
-                cancel()
-            }
-
-            withContext(Dispatchers.Default) {
-                try {
-                    Log.d(Constants.TAG, "Starting Node.js...")
-                    startNode(arrayOf("node", projectMainPath))
-                } catch (e: Throwable) {
-                    Log.e(Constants.TAG, "Error starting Node.js", e)
+                val copyNodeProjectSuccess =
+                    copyNodeProjectFromAPK(projectPath)
+                if (!copyNodeProjectSuccess) {
+                    Log.e(Constants.TAG, "Unable to copy the Node.js project from APK.")
+                    cancel()
                 }
+
+                if (!FileOperations.existsPath(projectPath)) {
+                    Log.e(
+                        Constants.TAG,
+                        "Unable to access the Node.js project. (No such directory)"
+                    )
+                    cancel()
+                }
+
+                val projectMainPath =
+                    FileOperations.combinePath(projectPath, Constants.PROJECT_MAIN_FILE)
+
+                if (!FileOperations.existsPath(projectMainPath)) {
+                    Log.e(
+                        Constants.TAG,
+                        "Unable to access main script of the Node.js project. (No such file) $projectMainPath"
+                    )
+                    cancel()
+                }
+                return@async projectMainPath
+            }.await()
+
+            async {
+                create()
+            }.await()
+
+            try {
+                Log.d(Constants.TAG, "Starting Node.js...")
+                startNode(arrayOf("node", projectMainPath))
+            } catch (e: Throwable) {
+                Log.e(Constants.TAG, "Error starting Node.js", e)
             }
         }
     }
 
     private external fun stopNode()
     fun stop() {
-        stopNode()
-        job?.cancel()
-        job = null
+        try {
+            stopNode()
+            disposeV8()
+            job?.cancel()
+            job = null
+        } catch (e: Throwable) {
+            Log.e(
+                Constants.TAG,
+                "Error stopping Node.js",
+                e
+            )
+        }
+    }
+
+    private external fun disposeV8()
+    fun destroy() {
+        try {
+            disposeV8()
+        } catch (e: Throwable) {
+            Log.e(
+                Constants.TAG,
+                "Error disposing V8",
+                e
+            )
+        }
     }
 
     private fun copyNodeProjectFromAPK(

--- a/mobile/android/app/src/main/java/im/mustang/capa/NodeJS.kt
+++ b/mobile/android/app/src/main/java/im/mustang/capa/NodeJS.kt
@@ -94,10 +94,8 @@ class NodeJS {
 
     private external fun stopNode()
     fun stop() {
-        if (!isStarted) return
         stopNode()
         nodeScope.cancel()
-        isStarted = false
     }
 
     private fun copyNodeProjectFromAPK(

--- a/mobile/android/app/src/main/java/im/mustang/capa/NodeJS.kt
+++ b/mobile/android/app/src/main/java/im/mustang/capa/NodeJS.kt
@@ -1,3 +1,7 @@
+// From <https://github.com/hampoelz/Capacitor-NodeJS/blob/main/android/src/main/java/net/hampoelz/capacitor/nodejs/CapacitorNodeJS.java>
+// Copyright (c) 2023 Rene Hampölz
+// MIT License (MIT)
+
 package im.mustang.capa
 
 import android.content.Context

--- a/mobile/android/app/src/main/java/im/mustang/capa/NodeJS.kt
+++ b/mobile/android/app/src/main/java/im/mustang/capa/NodeJS.kt
@@ -1,0 +1,116 @@
+package im.mustang.capa
+
+import android.content.Context
+import android.util.Log
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+import org.json.JSONException
+import org.json.JSONObject
+import java.io.IOException
+
+const val TAG = "NodeJS-Mobile"
+
+class NodeJS {
+    companion object {
+        init {
+            System.loadLibrary("native-lib")
+            System.loadLibrary("node")
+        }
+    }
+    private val context: Context
+    constructor(context: Context) {
+        this.context = context
+    }
+    private val projectDir = "nodejs"
+    private external fun startNode(args: Array<String>)
+    fun start() {
+        CoroutineScope(Dispatchers.IO).launch(Dispatchers.IO) {
+            val filesPath = context.filesDir.absolutePath
+            var projectMainPath: String
+            val mainFile = "index.mjs"
+
+            val basePath = FileOperations.combinePath(filesPath, "public")
+            val projectPath = FileOperations.combinePath(basePath, "nodejs")
+            val dataPath = FileOperations.combinePath(basePath, "data")
+
+            val copyNodeProjectSuccess =
+                copyNodeProjectFromAPK(projectDir, projectPath)
+            if (!copyNodeProjectSuccess) {
+                Log.e(TAG, "Unable to copy the Node.js project from APK.")
+                cancel()
+            }
+
+            if (!FileOperations.existsPath(projectPath)) {
+                Log.e(TAG, "Unable to access the Node.js project. (No such directory)")
+                cancel()
+            }
+
+            val createDataDirSuccess = FileOperations.createDir(dataPath)
+            if (!createDataDirSuccess) {
+                Log.d(
+                    TAG,
+                    "Unable to create a directory for persistent data storage."
+                )
+            }
+
+            val projectPackageJsonPath = FileOperations.combinePath(projectPath, "package.json")
+
+            var projectMainFile = "index.mjs"
+            if (mainFile != null && !mainFile.isEmpty()) {
+                projectMainFile = mainFile
+            } else if (FileOperations.existsPath(projectPackageJsonPath)) {
+                try {
+                    val projectPackageJsonData =
+                        FileOperations.readFileFromPath(projectPackageJsonPath)
+                    val projectPackageJson = JSONObject(projectPackageJsonData)
+                    val projectPackageJsonMainFile = projectPackageJson.getString("main")
+
+                    if (!projectPackageJsonMainFile.isEmpty()) {
+                        projectMainFile = projectPackageJsonMainFile
+                    }
+                } catch (e: JSONException) {
+                    Log.e(TAG, 
+                        "Failed to read the package.json file of the Node.js project.",
+                        e
+                    )
+                    cancel()
+                } catch (e: IOException) {
+                    Log.e(TAG, 
+                        "Failed to read the package.json file of the Node.js project.",
+                        e
+                    )
+                    cancel()
+                }
+            }
+
+            projectMainPath = FileOperations.combinePath(projectPath, projectMainFile)
+
+            if (!FileOperations.existsPath(projectMainPath)) {
+                Log.e(TAG, "Unable to access main script of the Node.js project. (No such file) $projectMainPath")
+                cancel()
+            }
+
+            withContext(Dispatchers.Default) {
+                startNode(arrayOf("node", projectMainPath))
+            }
+        }
+    }
+    private fun copyNodeProjectFromAPK(
+        projectDir: String?,
+        projectPath: String,
+    ): Boolean {
+        val nodeAssetDir = FileOperations.combinePath("public", projectDir)
+        val assetManager = context.assets
+
+        var success = true
+        if (FileOperations.existsPath(projectPath)) {
+            success = FileOperations.deleteDir(projectPath)
+        }
+        success = success and FileOperations.copyAssetDir(assetManager, nodeAssetDir, projectPath)
+
+        return success
+    }
+}

--- a/mobile/android/app/src/main/java/im/mustang/capa/NodeJS.kt
+++ b/mobile/android/app/src/main/java/im/mustang/capa/NodeJS.kt
@@ -28,6 +28,7 @@ class NodeJS {
             System.loadLibrary("node")
         }
     }
+
     private val context: Context
     private val preferences: SharedPreferences
     private lateinit var packageInfo: PackageInfo
@@ -47,6 +48,7 @@ class NodeJS {
             )
         }
     }
+
     private external fun startNode(args: Array<String>)
 
     private val nodeScope = CoroutineScope(Dispatchers.IO)
@@ -62,7 +64,7 @@ class NodeJS {
             val projectPath = FileOperations.combinePath(basePath, "nodejs")
 
             val copyNodeProjectSuccess =
-                copyNodeProjectFromAPK(Constants.PROJECT_DIR, projectPath)
+                copyNodeProjectFromAPK(projectPath)
             if (!copyNodeProjectSuccess) {
                 Log.e(Constants.TAG, "Unable to copy the Node.js project from APK.")
                 cancel()
@@ -73,10 +75,14 @@ class NodeJS {
                 cancel()
             }
 
-            val projectMainPath = FileOperations.combinePath(projectPath, Constants.PROJECT_MAIN_FILE)
+            val projectMainPath =
+                FileOperations.combinePath(projectPath, Constants.PROJECT_MAIN_FILE)
 
             if (!FileOperations.existsPath(projectMainPath)) {
-                Log.e(Constants.TAG, "Unable to access main script of the Node.js project. (No such file) $projectMainPath")
+                Log.e(
+                    Constants.TAG,
+                    "Unable to access main script of the Node.js project. (No such file) $projectMainPath"
+                )
                 cancel()
             }
 
@@ -99,10 +105,9 @@ class NodeJS {
     }
 
     private fun copyNodeProjectFromAPK(
-        projectDir: String,
         projectPath: String,
     ): Boolean {
-        val nodeAssetDir = FileOperations.combinePath("public", projectDir)
+        val nodeAssetDir = FileOperations.combinePath("public", Constants.PROJECT_DIR)
         val assetManager = context.assets
 
         var success = true
@@ -114,6 +119,7 @@ class NodeJS {
         saveAppUpdateTime()
         return success
     }
+
     private val isAppUpdated: Boolean
         get() {
             val previousLastUpdateTime =

--- a/mobile/android/app/src/main/java/im/mustang/capa/NodeJS.kt
+++ b/mobile/android/app/src/main/java/im/mustang/capa/NodeJS.kt
@@ -53,10 +53,13 @@ class NodeJS {
         }
     }
 
-    private external fun startNode(args: Array<String>)
+    private external fun runNodeEnv(args: Array<String>): Long
+    private external fun spinNodeEventLoop(envPtr: Long)
 
     private val nodeScope = CoroutineScope(Dispatchers.Default)
     private var job: Job? = null
+
+    private var nativeNodeEnvPtr: Long = 0
 
     private external fun initializeV8()
 
@@ -116,17 +119,18 @@ class NodeJS {
 
             try {
                 Log.d(Constants.TAG, "Starting Node.js...")
-                startNode(arrayOf("node", projectMainPath))
+                nativeNodeEnvPtr = runNodeEnv(arrayOf("node", projectMainPath))
+                spinNodeEventLoop(nativeNodeEnvPtr)
             } catch (e: Throwable) {
                 Log.e(Constants.TAG, "Error starting Node.js", e)
             }
         }
     }
 
-    private external fun stopNode()
+    private external fun stopNode(envPtr: Long)
     fun stop() {
         try {
-            stopNode()
+            stopNode(nativeNodeEnvPtr)
             disposeV8()
             job?.cancel()
             job = null

--- a/mobile/android/app/src/main/java/im/mustang/capa/NodeJS.kt
+++ b/mobile/android/app/src/main/java/im/mustang/capa/NodeJS.kt
@@ -128,7 +128,10 @@ class NodeJS {
         }
     }
 
+    private external fun stopNode()
     fun stop() {
+        if (!isStarted) return
+        stopNode()
         nodeScope.cancel()
         isStarted = false
     }

--- a/mobile/android/app/src/main/java/im/mustang/capa/NodeJS.kt
+++ b/mobile/android/app/src/main/java/im/mustang/capa/NodeJS.kt
@@ -53,27 +53,10 @@ class NodeJS {
         }
     }
 
-    private external fun runNodeEnv(args: Array<String>): Long
-    private external fun spinNodeEventLoop(envPtr: Long)
+    private external fun startNode(args: Array<String>): Int
 
     private val nodeScope = CoroutineScope(Dispatchers.Default)
     private var job: Job? = null
-
-    private var nativeNodeEnvPtr: Long = 0
-
-    private external fun initializeV8()
-
-    private fun create() {
-        try {
-            initializeV8()
-        } catch (e: Throwable) {
-            Log.e(
-                Constants.TAG,
-                "Error while initializing V8",
-                e
-            )
-        }
-    }
 
     fun start() {
         if (job != null) return
@@ -113,44 +96,25 @@ class NodeJS {
                 return@async projectMainPath
             }.await()
 
-            async {
-                create()
-            }.await()
-
             try {
                 Log.d(Constants.TAG, "Starting Node.js...")
-                nativeNodeEnvPtr = runNodeEnv(arrayOf("node", projectMainPath))
-                spinNodeEventLoop(nativeNodeEnvPtr)
+                startNode(arrayOf("node", projectMainPath))
             } catch (e: Throwable) {
                 Log.e(Constants.TAG, "Error starting Node.js", e)
             }
         }
     }
 
-    private external fun stopNode(envPtr: Long)
+    private external fun stopNode()
     fun stop() {
         try {
-            stopNode(nativeNodeEnvPtr)
-            disposeV8()
+            stopNode()
             job?.cancel()
             job = null
         } catch (e: Throwable) {
             Log.e(
                 Constants.TAG,
                 "Error stopping Node.js",
-                e
-            )
-        }
-    }
-
-    private external fun disposeV8()
-    fun destroy() {
-        try {
-            disposeV8()
-        } catch (e: Throwable) {
-            Log.e(
-                Constants.TAG,
-                "Error disposing V8",
                 e
             )
         }

--- a/mobile/android/build.gradle
+++ b/mobile/android/build.gradle
@@ -10,7 +10,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:8.12.1'
+        classpath 'com.android.tools.build:gradle:8.12.3'
         classpath 'com.google.gms:google-services:4.4.3'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
 

--- a/mobile/android/build.gradle
+++ b/mobile/android/build.gradle
@@ -2,6 +2,9 @@
 
 buildscript {
     
+    ext {
+        kotlin_version = '2.2.0'
+    }
     repositories {
         google()
         mavenCentral()
@@ -9,6 +12,7 @@ buildscript {
     dependencies {
         classpath 'com.android.tools.build:gradle:8.12.1'
         classpath 'com.google.gms:google-services:4.4.3'
+        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/mobile/android/capacitor.settings.gradle
+++ b/mobile/android/capacitor.settings.gradle
@@ -16,6 +16,3 @@ project(':capacitor-splash-screen').projectDir = new File('../node_modules/@capa
 
 include ':capawesome-capacitor-android-edge-to-edge-support'
 project(':capawesome-capacitor-android-edge-to-edge-support').projectDir = new File('../node_modules/@capawesome/capacitor-android-edge-to-edge-support/android')
-
-include ':capacitor-nodejs'
-project(':capacitor-nodejs').projectDir = new File('../node_modules/capacitor-nodejs/android')

--- a/mobile/android/gradle.properties
+++ b/mobile/android/gradle.properties
@@ -20,3 +20,6 @@ org.gradle.jvmargs=-Xmx1536m
 # Android operating system, and which are packaged with your app's APK
 # https://developer.android.com/topic/libraries/support-library/androidx-rn
 android.useAndroidX=true
+
+# Enable configuration cache to speed up local builds
+org.gradle.configuration-cache=true

--- a/mobile/android/variables.gradle
+++ b/mobile/android/variables.gradle
@@ -8,6 +8,7 @@ ext {
     androidxAppCompatVersion = '1.7.0'
     androidxCoordinatorLayoutVersion = '1.2.0'
     androidxCoreVersion = '1.15.0'
+    androidxCoreKtxVersion = '1.17.0'
     androidxFragmentVersion = '1.8.4'
     coreSplashScreenVersion = '1.0.1'
     androidxWebkitVersion = '1.12.1'

--- a/mobile/android/variables.gradle
+++ b/mobile/android/variables.gradle
@@ -1,9 +1,9 @@
 ext {
     ndkVersion = '28.2.13676358'
     cmakeVersion = '3.31.5'
-    minSdkVersion = 23
-    compileSdkVersion = 35
-    targetSdkVersion = 35
+    minSdkVersion = 24
+    compileSdkVersion = 36
+    targetSdkVersion = 36
     androidxActivityVersion = '1.9.2'
     androidxAppCompatVersion = '1.7.0'
     androidxCoordinatorLayoutVersion = '1.2.0'

--- a/mobile/backend/prebuild.sh
+++ b/mobile/backend/prebuild.sh
@@ -1,9 +1,10 @@
 #!/usr/bin/env bash
 
 source ../hooks/ios/variables.sh
-export ANDROID_LIBNODE="https://github.com/mustang-im/nodejs-mobile/releases/download/v22.9.0/nodejs-mobile-v22.9.0-android.zip"
-export ANDROID_SDK="--sdk35"
 export IOS_LIBNODE
+source ../hooks/common/variables.sh # TODO move to ../hooks/android/variables.sh
+export ANDROID_LIBNODE
+export ANDROID_SDK="--sdk$ANDROID_SDK"
 
 cd node_modules;
 (cd better-sqlite3 && npx prebuild-for-nodejs-mobile $MOBILE_ARCH $ANDROID_SDK) &&

--- a/mobile/capacitor.config.ts
+++ b/mobile/capacitor.config.ts
@@ -5,11 +5,6 @@ const config: CapacitorConfig = {
   appName: "Mustang",
   webDir: "./dist",
   plugins: {
-    CapacitorNodeJS: {
-      nodeDir: "nodejs",
-      androidLibNode: "https://github.com/mustang-im/nodejs-mobile/releases/download/v22.9.0/nodejs-mobile-v22.9.0-android.zip",
-      androidArchitectures: ["arm64"],
-    },
     SplashScreen: {
       launchAutoHide: true,
     },

--- a/mobile/hooks/android/setup.sh
+++ b/mobile/hooks/android/setup.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+
+source ./hooks/common/variables.sh
+
+mkdir -p ./android/app/src/main/cpp/libnode
+cd ./android/app/src/main/cpp/libnode
+
+DOWNLOAD_URL="$IOS_LIBNODE"
+TMP_ZIP_FILE="tmp.zip"
+
+# Download the file
+echo "Downloading $DOWNLOAD_URL"
+curl -L -o $TMP_ZIP_FILE "$DOWNLOAD_URL"
+Expand commentComment on line R17Resolved
+
+unzip -o $TMP_ZIP_FILE -d ./
+rm -r $TMP_ZIP_FILE ./include
+
+echo "Download and extraction complete."

--- a/mobile/hooks/android/setup.sh
+++ b/mobile/hooks/android/setup.sh
@@ -1,19 +1,22 @@
 #!/usr/bin/env bash
 
+if [ -f "./android/app/libnode/bin/arm64-v8a/libnode.so" ]; then
+  echo "Libnode already exists, skipping download."
+  exit 0
+fi
+
 source ./hooks/common/variables.sh
 
-mkdir -p ./android/app/src/main/cpp/libnode
-cd ./android/app/src/main/cpp/libnode
+mkdir -p ./android/app/libnode
+cd ./android/app/libnode
 
-DOWNLOAD_URL="$IOS_LIBNODE"
+DOWNLOAD_URL="$ANDROID_LIBNODE"
 TMP_ZIP_FILE="tmp.zip"
 
 # Download the file
 echo "Downloading $DOWNLOAD_URL"
 curl -L -o $TMP_ZIP_FILE "$DOWNLOAD_URL"
-Expand commentComment on line R17Resolved
 
 unzip -o $TMP_ZIP_FILE -d ./
-rm -r $TMP_ZIP_FILE ./include
 
 echo "Download and extraction complete."

--- a/mobile/hooks/android/update-project.ts
+++ b/mobile/hooks/android/update-project.ts
@@ -48,7 +48,6 @@ let templateDir: string;
 async function updateTemplateBasedFiles() {
   await getTemplate();
   await Promise.all([
-    updateMainActivityFile(),
     updateStringsXML(),
   ]);
 }

--- a/mobile/hooks/common/variables.sh
+++ b/mobile/hooks/common/variables.sh
@@ -4,4 +4,4 @@
 ANDROID_LIBNODE="https://github.com/mustang-im/nodejs-mobile/releases/download/v22.9.0/nodejs-mobile-v22.9.0-android.zip"
 
 # Android SDK version two-digit, e.g. 35 for SDK 35
-ANDROID_SDK="35
+ANDROID_SDK="35"

--- a/mobile/hooks/common/variables.sh
+++ b/mobile/hooks/common/variables.sh
@@ -1,0 +1,7 @@
+# !/usr/bin/env bash
+
+# Link to Android libnode
+ANDROID_LIBNODE="https://github.com/mustang-im/nodejs-mobile/releases/download/v22.9.0/nodejs-mobile-v22.9.0-android.zip"
+
+# Android SDK version two-digit, e.g. 35 for SDK 35
+ANDROID_SDK="35

--- a/mobile/ios/App/Podfile
+++ b/mobile/ios/App/Podfile
@@ -15,7 +15,6 @@ def capacitor_pods
   pod 'CapacitorBrowser', :path => '../../node_modules/@capacitor/browser'
   pod 'CapacitorCamera', :path => '../../node_modules/@capacitor/camera'
   pod 'CapacitorSplashScreen', :path => '../../node_modules/@capacitor/splash-screen'
-  pod 'CapacitorNodejs', :path => '../../node_modules/capacitor-nodejs'
 end
 
 target 'App' do

--- a/mobile/package.json
+++ b/mobile/package.json
@@ -25,8 +25,7 @@
     "@capacitor/core": "^7.0.0",
     "@capacitor/ios": "^7.0.0",
     "@capacitor/splash-screen": "^7.0.3",
-    "@capawesome/capacitor-android-edge-to-edge-support": "^7.2.3",
-    "capacitor-nodejs": "https://github.com/mustang-im/capacitor-nodejs/releases/download/1.0.0-beta.10/capacitor-nodejs-v1.0.0-beta.10.tgz"
+    "@capawesome/capacitor-android-edge-to-edge-support": "^7.2.3"
   },
   "devDependencies": {
     "@capacitor/cli": "^7.0.0",

--- a/mobile/package.json
+++ b/mobile/package.json
@@ -14,8 +14,9 @@
     "build:android:aab": "export MOBILE_ARCH=android-arm64; npm run build && cap sync android && cd android && ./gradlew :app:bundleRelease",
     "build:ios:release": "export MOBILE_ARCH=ios-arm64; (cd ios && bash ./build/build.sh) && cap sync ios && cap build ios --xcode-signing-style=manual --xcode-team-id=$IOS_TEAM_ID --xcode-signing-certificate=$IOS_CERTIFICATE_OWNER_NAME --xcode-provisioning-profile=$IOS_PROVISION_PROFILE_NAME",
     "build:ios": "export MOBILE_ARCH=ios-arm64; (cd ios && bash ./build/build.sh) && cap sync ios && cap build ios",
-    "preview": "vite preview",
-    "setup:ios": "bash ./hooks/ios/setup.sh"
+    "setup:ios": "bash ./hooks/ios/setup.sh",
+    "setup:android": "bash ./hooks/android/setup.sh",
+    "preview": "vite preview"
   },
   "dependencies": {
     "@capacitor/android": "^7.0.0",


### PR DESCRIPTION
- Run Node.js based on native App lifecycle
- Remove Capacitor-nodejs dependency
- Capacitor Bridge is not used anymore since Node.js runs a local server