### PR TITLE
Desktop: Select app with openApp (#854)

### DIFF
--- a/app/frontend/MainWindow/MainWindow.svelte
+++ b/app/frontend/MainWindow/MainWindow.svelte
@@ -46,7 +46,7 @@
 <WebAppsInBackground />
 
 <script lang="ts">
-  import { selectedApp, sidebarApp, mustangApps, goTo } from "../AppsBar/selectedApp";
+  import { selectedApp, sidebarApp, mustangApps, goTo, openApp } from "../AppsBar/selectedApp";
   import { appGlobal } from "../../logic/app";
   // #if [!WEBMAIL]
   // @ts-ignore ts2300
@@ -96,7 +96,7 @@
 
   async function onLoad() {
     loadMustangApps();
-    $selectedApp = mailMustangApp;
+    openApp(mailMustangApp, {});
     changeTheme($themeSetting.value);
     // #if [MOBILE]
     SplashScreen.hide();


### PR DESCRIPTION
- On Mac, the app was blank for me because no app was not selected
- Since we use the router now, we need to set the app with `openApp()`
- But this also opens the Mail app for Mobile now when there's a Mail account logged in.