### PR TITLE
EWS: PoC of searching messages on the server

### DIFF
--- a/app/frontend/Mail/LeftPane/FolderFooter.svelte
+++ b/app/frontend/Mail/LeftPane/FolderFooter.svelte
@@ -133,19 +133,7 @@
       searchMessages = null;
       return;
     }
-    searchMessages = folder.messages.filterOnce(msg =>
-      (!isShowStarred || msg.isStarred === true) &&
-      (!isShowUnread || msg.isRead === false) &&
-      (!searchTerm || searchTerm.length > 1) &&
-      (!searchTerm ||
-        msg.subject?.toLowerCase().includes(searchTerm) ||
-        msg.contact?.name?.toLowerCase().includes(searchTerm) ||
-        msg.from?.name?.toLowerCase().includes(searchTerm) ||
-        msg.from?.emailAddress?.toLowerCase().includes(searchTerm) ||
-        msg.to?.some(to => to.name?.toLowerCase().includes(searchTerm) ||
-          to.emailAddress?.toLowerCase().includes(searchTerm)) ||
-        msg.text?.toLowerCase().includes(searchTerm))
-    ) as ArrayColl<EMail>;
+    searchMessages = await folder.searchMessages(isShowStarred, isShowUnread, searchTerm);
   }
 
   /** Uses the DB to make a global search */

--- a/app/logic/Mail/EWS/EWSFolder.ts
+++ b/app/logic/Mail/EWS/EWSFolder.ts
@@ -615,6 +615,6 @@ export function getEWSItem(item: any): any {
 
 /** @see getEWSItem()
  * This function is a convenience for a multiple items. */
-function getEWSItems(items: any[]): any[] {
+export function getEWSItems(items: Record<string, any | any[]>): any[] {
   return Object.values(items).flat();
 }

--- a/app/logic/Mail/EWS/EWSFolder.ts
+++ b/app/logic/Mail/EWS/EWSFolder.ts
@@ -515,6 +515,90 @@ export class EWSFolder extends Folder {
   disableChangeSpecial(): string | false {
     return "You cannot change Exchange special folders.";
   }
+
+  async searchMessages(isStarred: boolean, isUnread: boolean, searchTerm: string): Promise<ArrayColl<EWSEMail>> {
+    let results = new ArrayColl<EWSEMail>();
+    if (!searchTerm || searchTerm.length > 1) {
+      let starredRestriction = {
+        t$IsEqualTo: {
+          t$ExtendedFieldURI: {
+            PropertyTag: "0x1090",
+            PropertyType: "Integer",
+          },
+          t$FieldURIOrConstant: {
+            t$Constant: {
+              Value: 2,
+            },
+          },
+        }
+      };
+      let unreadRestriction = {
+        t$IsEqualTo: {
+          t$FieldURI: {
+            FieldURI: "message:IsRead",
+          },
+          t$FieldURIOrConstant: {
+            t$Constant: {
+              Value: false,
+            },
+          },
+        }
+      };
+      let termRestriction = {
+        t$Or: {
+          t$Contains: ["item:Subject", "message:From", "message:ToRecipients", "item:Body"].map(FieldURI => ({
+            t$FieldURI: {
+              FieldURI,
+            },
+            t$Constant: {
+              Value: searchTerm,
+            },
+            ContainmentMode: "Substring",
+            ContainmentComparison: "IgnoreCase",
+          })),
+        },
+      };
+      let restriction =
+        isStarred && isUnread ? { t$And: Object.assign({ t$IsEqualTo: [starredRestriction.t$IsEqualTo, unreadRestriction.t$IsEqualTo] }, searchTerm ? termRestriction : undefined) } :
+        (isStarred || isUnread) && searchTerm ? { t$And: Object.assign({}, isStarred ? starredRestriction : unreadRestriction, termRestriction) } :
+        isStarred ? starredRestriction : isUnread ? unreadRestriction : termRestriction;
+      let query = {
+        m$FindItem: {
+          m$ItemShape: {
+            t$BaseShape: "IdOnly",
+          },
+          m$IndexedPageItemView: {
+            BasePoint: "Beginning",
+            Offset: 0,
+          },
+          m$Restriction: restriction,
+          m$SortOrder: {
+            t$FieldOrder: {
+              t$FieldURI: {
+                FieldURI: "item:DateTimeSent",
+              },
+              Order: "Descending",
+            },
+          },
+          m$ParentFolderIds: {
+            t$FolderId: {
+              Id: this.id,
+            },
+          },
+          Traversal: "Shallow",
+        },
+      };
+      let response = await this.account.callEWS(query);
+      let messages = getEWSItems(response?.RootFolder?.Items || {});
+      for (let message of messages) {
+        let email = this.getEmailByItemID(sanitize.nonemptystring(message.ItemId.Id));
+        if (email) {
+          results.add(email);
+        }
+      }
+    }
+    return results;
+  }
 }
 
 /**

--- a/app/logic/Mail/Folder.ts
+++ b/app/logic/Mail/Folder.ts
@@ -281,6 +281,21 @@ export class Folder extends Observable implements TreeItem<Folder> {
   newEMail(): EMail {
     return new EMail(this);
   }
+
+  async searchMessages(isStarred: boolean, isUnread: boolean, searchTerm: string): Promise<ArrayColl<EMail>> {
+    return this.messages.filterOnce(msg =>
+      (!isStarred || msg.isStarred === true) &&
+      (!isUnread || msg.isRead === false) &&
+      (!searchTerm || (searchTerm.length > 1 && (
+        msg.subject?.toLowerCase().includes(searchTerm) ||
+        msg.contact?.name?.toLowerCase().includes(searchTerm) ||
+        msg.from?.name?.toLowerCase().includes(searchTerm) ||
+        msg.from?.emailAddress?.toLowerCase().includes(searchTerm) ||
+        msg.to?.some(to =>
+          to.name?.toLowerCase().includes(searchTerm) ||
+          to.emailAddress?.toLowerCase().includes(searchTerm)) ||
+        msg.text?.toLowerCase().includes(searchTerm))))) as ArrayColl<EMail>;
+  }
 }
 
 export enum SpecialFolder {

--- a/app/logic/Mail/MailAccount.ts
+++ b/app/logic/Mail/MailAccount.ts
@@ -3,6 +3,7 @@ import { MailIdentity } from "./MailIdentity";
 import { Folder, SpecialFolder } from "./Folder";
 import type { EMail } from "./EMail";
 import type { SMTPAccount } from "./SMTP/SMTPAccount";
+import type { SearchEMail } from "./Store/SearchEMail";
 import { ContactEntry } from "../Abstract/Person";
 import { FilterRuleAction } from "./FilterRules/FilterRuleAction";
 import { OAuth2 } from "../Auth/OAuth2";
@@ -130,6 +131,16 @@ export class MailAccount extends TCPAccount {
       return this.getSpecialFolder(SpecialFolder.Sent);
     }
     return this.rootFolders.first;
+  }
+
+  canSearchOnServer(search: SearchEMail): boolean {
+    return false;
+  }
+
+  startSearch(search: SearchEMail): Promise<ArrayColl<EMail>> {
+    search = search.clone();
+    search.account = this;
+    return search.startSearch();
   }
 
   fromConfigJSON(json: any) {

--- a/app/logic/Mail/OWA/Request/OWAFolderRequests.ts
+++ b/app/logic/Mail/OWA/Request/OWAFolderRequests.ts
@@ -1,5 +1,6 @@
 import { OWARequest } from "./OWARequest";
 import type { OWAEMail } from "../OWAEMail";
+import type { SearchEMail } from "../../Store/SearchEMail";
 
 export function owaFindMsgsInFolderRequest(folderID: string, maxFetchCount: number): OWARequest {
   return new OWARequest("FindItem", {
@@ -37,6 +38,119 @@ export function owaFindMsgsInFolderRequest(folderID: string, maxFetchCount: numb
       BasePoint: "Beginning",
       Offset: 0,
       MaxEntriesReturned: maxFetchCount,
+    },
+  });
+}
+
+function appendComparison(array: any[], type: string, FieldURI: string, Value: any) {
+  if (Value || Value === false) {
+    array.push({
+      __type: type + ":#Exchange",
+      Item: {
+        __type: "PropertyUri:#Exchange",
+        FieldURI,
+      },
+      FieldURIOrConstant: {
+        __type: "FieldURIOrConstantType:#Exchange",
+        Item: {
+          __type: "Constant:#Exchange",
+          Value,
+        },
+      },
+    });
+  }
+}
+
+export function owaSearchMsgsInFoldersRequest(folders: string[], search: SearchEMail) {
+  let items: any[] = [];
+  let tags = [];
+  for (let tag of search.tags) {
+    appendComparison(tags, "IsEqualTo", "item:Categories", tag.name);
+  }
+  if (tags.length > 1) {
+    items.push({
+      __type: "Or:#Exchange",
+      Items: tags,
+    });
+  } else if (tags.length) {
+    items.push(tags[0]);
+  }
+  appendComparison(items, "IsGreaterThanOrEqualTo", "item:DateTimeSent", search.sentDateMin);
+  appendComparison(items, "IsLessThanOrEqualTo", "item:DateTimeSent", search.sentDateMax);
+  appendComparison(items, "IsGreaterThanOrEqualTo", "item:Size", search.sizeMin);
+  appendComparison(items, "IsLessThanOrEqualTo", "item:Size", search.sizeMax);
+  appendComparison(items, "IsEqualTo", "message:InternetMessageId", search.messageID);
+  appendComparison(items, "IsEqualTo", "item:HasAttachments", search.hasAttachment);
+  appendComparison(items, "IsEqualTo", "message:IsRead", search.isRead);
+  if (search.isStarred != null) {
+    let starred = {
+      __type: "IsEqualTo:#Exchange",
+      Item: {
+        __type: "ExtendedPropertyUri:#Exchange",
+        PropertyTag: "0x1090",
+        PropertyType: "Integer",
+      },
+      FieldURIOrConstant: {
+        __type: "FieldURIOrConstantType:#Exchange",
+        Item: {
+          __type: "Constant:#Exchange",
+          Value: 2,
+        },
+      },
+    };
+    if (search.isStarred) {
+      items.push(starred);
+    } else {
+      items.push({
+        __type: "Not:#Exchange",
+        Item: starred,
+      });
+    }
+  }
+  if (search.bodyText) {
+    items.push({
+      __type: "Contains:#Exchange",
+      Item: {
+        __type: "PropertyUri:#Exchange",
+        FieldURI: "item:Body",
+      },
+      Constant: {
+        __type: "Constant:#Exchange",
+        Value: search.bodyText,
+      },
+      ContainmentMode: "Substring",
+      ContainmentComparison: "IgnoreCase",
+    });
+  }
+  return new OWARequest("FindItem", {
+    __type: "FindItemRequest:#Exchange",
+    ItemShape: {
+      __type: "ItemResponseShape:#Exchange",
+      BaseShape: "IdOnly",
+    },
+    ParentFolderIds: folders.map(Id => ({
+      __type: "FolderId:#Exchange",
+      Id,
+    })),
+    Traversal: "Shallow",
+    Restriction: items.length ? {
+      Item: items.length == 1 ? items[0] : {
+        __type: "And:#Exchange",
+        Items: items,
+      },
+    } : undefined,
+    SortOrder: [{
+      __type: "SortResults:#Exchange",
+      Order: "Descending",
+      Path: {
+        __type: "PropertyUri:#Exchange",
+        FieldURI: "item:DateTimeSent",
+      },
+    }],
+    Paging: {
+      __type: "IndexedPageView:#Exchange",
+      BasePoint: "Beginning",
+      Offset: 0,
     },
   });
 }


### PR DESCRIPTION
This is implemented only for the per-folder search at the bottom of the message list because Exchange does not support deep search traversal.

This is implemented only for EWS, because:
- ActiveSync only has a free-text and/or message date received search, plus it has custom IDs for search results that cannot be mapped onto the original message. Thanks, Microsoft!
- OWA does not use `FindItem` for searching, so as yet I don't even know whether you can specify search terms. Instead it uses its own free-text based search. For Office 365 you can at least search for unread messages (this works by appending ` isRead:false` to the search keyword).