### PR TITLE
FastList doesn't update properly when its items change

### DIFF
--- a/app/frontend/Shared/FastList.svelte
+++ b/app/frontend/Shared/FastList.svelte
@@ -156,7 +156,7 @@
       rowHeight = contentRow.offsetHeight;
       let availableHeight = listE.offsetHeight - headerE.offsetHeight;
 
-      showRows = Math.min(items.length, Math.ceil(availableHeight / rowHeight));
+      showRows = Math.ceil(availableHeight / rowHeight);
       //console.log("size", "contentrow", contentRow.offsetHeight, "list", listE.offsetHeight, "header", headerE.offsetHeight, "rowheight", rowHeight, "available", availableHeight, " showrows", showRows);
     } catch (ex) {
       console.error(ex);
@@ -234,17 +234,20 @@
   }
 
   function scrollIntoView(index: number) {
-    if (index >= startPos && index < startPos + showRows - 1) {
-      return; // already in view
+    let indexMinY = index * rowHeight + headerHeight;
+    let indexMaxY = indexMinY + rowHeight - listE.clientHeight;
+    if (indexMinY < listE.scrollTop) {
+      listE.scrollTop = indexMinY;
+    } else if (indexMaxY > listE.scrollTop) {
+      listE.scrollTop = indexMaxY;
     }
-    startPos = Math.min(Math.max(startPos, 0), items.length - showRows);
   }
 
   const onScrollThrottled = throttle(onScroll, 10);
   function onScroll() {
     let topY = listE.scrollTop - headerHeight;
     let startPosCalc = Math.floor(topY / rowHeight);
-    startPos = Math.min(Math.max(startPosCalc, 0), items.length - showRows);
+    startPos = Math.max(Math.min(startPosCalc, items.length - showRows), 0);
     //console.log("startpos", startPos, "top y", topY, "scrolltop", listE.scrollTop, "rowheight", rowHeight);
   }
 


### PR DESCRIPTION
The `updateSize` that triggers when `items` changes never does anything because there are no content rows at this point. This means that when the `onScroll` triggers, `hasRows` is greater than `items.length`, resulting in a silly negative `startPos`.

While I was there I noticed that `scrollIntoView` was completely broken so I rewrote it.

Since `onScroll` couldn't rely on `showRows` being no greater than `items.length`, I thought I might as well remove the dependency and always have `showRows` be defined by the visible size only.