### PR TITLE
Mobile: Don't overlay WebView

### DIFF
--- a/mobile/capacitor.config.ts
+++ b/mobile/capacitor.config.ts
@@ -16,6 +16,9 @@ const config: CapacitorConfig = {
     EdgeToEdge: {
       backgroundColor: "#494558", // --appbar-bg, see app.css
     },
+    StatusBar: {
+      overlaysWebView: false,
+    },
   },
 }
 

--- a/mobile/package.json
+++ b/mobile/package.json
@@ -26,6 +26,7 @@
     "@capacitor/filesystem": "^7.1.4",
     "@capacitor/ios": "^7.0.0",
     "@capacitor/splash-screen": "^7.0.3",
+    "@capacitor/status-bar": "^7.0.3",
     "@capawesome/capacitor-android-edge-to-edge-support": "^7.2.3",
     "capacitor-nodejs": "https://github.com/mustang-im/capacitor-nodejs/releases/download/1.0.0-beta.10/capacitor-nodejs-v1.0.0-beta.10.tgz"
   },


### PR DESCRIPTION
- Some of the App content was being displayed under the notification/statusbar
- This fix sets `overlaysWebView` to false