### PR TITLE
Setup: Play background video inline

### DIFF
--- a/app/frontend/Setup/Shared/BackgroundVideo.svelte
+++ b/app/frontend/Setup/Shared/BackgroundVideo.svelte
@@ -1,4 +1,4 @@
-<video class="background-video" autoplay loop muted poster={fallbackPicURL} bind:this={videoEl}>
+<video class="background-video" autoplay loop muted playsinline poster={fallbackPicURL} bind:this={videoEl}>
   <source src={videoURL} type="video/mp4">
 </video>
 <vbox class="button">


### PR DESCRIPTION
- On iOS and Safari Mobile the background video plays in full screen mode which covers the Setup Elements
- Setting `playsinline` forces the video to play inline instead of fullscreen