### PR TITLE
FastList: Change Grid height from min-content to auto

### DIFF
--- a/app/frontend/Shared/FastList.svelte
+++ b/app/frontend/Shared/FastList.svelte
@@ -341,7 +341,7 @@
   }
   grid {
     width: 100%;
-    height: min-content;
+    height: auto;
     position: absolute;
     top: 0px; /* overridden by scrolling code */
     left: 0px;


### PR DESCRIPTION
- On Safari Browsers the FastList items were only taking the space of the screen and the items were not readable
- Changing the grid height to auto makes it take up the space it needs to display the items properly