### PR TITLE
Build: Don't mark `-dev` builds as latest

### DIFF
--- a/.github/workflows/installer-android-parula.yml
+++ b/.github/workflows/installer-android-parula.yml
@@ -79,7 +79,7 @@ jobs:
       with:
         tag_name: ${{ env.APP_VERSION }}
         make_latest: ${{ env.RELEASE }}
-        prerelease: ${{ env.RELEASE != 'true' }}
+        prerelease: ${{ env.RELEASE == 'false' }}
         files: |
           mobile/android/app/build/outputs/apk/release/*.apk
           mobile/android/app/build/outputs/bundle/release/*.aab

--- a/.github/workflows/installer-android.yml
+++ b/.github/workflows/installer-android.yml
@@ -79,7 +79,7 @@ jobs:
       with:
         tag_name: ${{ env.APP_VERSION }}
         make_latest: ${{ env.RELEASE }}
-        prerelease: ${{ env.RELEASE != 'true' }}
+        prerelease: ${{ env.RELEASE == 'false' }}
         files: |
           mobile/android/app/build/outputs/apk/release/*.apk
           mobile/android/app/build/outputs/bundle/release/*.aab

--- a/.github/workflows/installer-ios-parula.yml
+++ b/.github/workflows/installer-ios-parula.yml
@@ -86,7 +86,7 @@ jobs:
         with:
           tag_name: ${{ env.APP_VERSION }}
           make_latest: ${{ env.RELEASE }}
-          prerelease: ${{ env.RELEASE != 'true' }}
+          prerelease: ${{ env.RELEASE == 'false' }}
           files: ${{ env.IPA_FILE_PATH }}
 
       - name: Upload app to TestFlight

--- a/.github/workflows/installer-ios.yml
+++ b/.github/workflows/installer-ios.yml
@@ -85,7 +85,7 @@ jobs:
         with:
           tag_name: ${{ env.APP_VERSION }}
           make_latest: ${{ env.RELEASE }}
-          prerelease: ${{ env.RELEASE != 'true' }}
+          prerelease: ${{ env.RELEASE == 'false' }}
           files: ${{ env.IPA_FILE_PATH }}
 
       - name: Upload app to TestFlight


### PR DESCRIPTION
- If the version number ends with `-dev` lets not mark it as latest, this messes up our auto update for Desktop