### PR TITLE
iOS: Capacitor camera plugin usage description

### DIFF
--- a/mobile/ios/App/App/Info.plist
+++ b/mobile/ios/App/App/Info.plist
@@ -38,7 +38,7 @@
 	<key>NSCameraUsageDescription</key>
 	<string>Your camera is needed for video conferences and optionally allows you to make your avatar.</string>
 	<key>NSLocalNetworkUsageDescription</key>
-	<string>This is required for the app to work. The user interface of the app needs to communicate via WebSocket with a backend part of this app for mail synchronization, storage and other tasks. Both parts are on your device. We want the app to run entirely locally on your device, without any cloud service, that's why the service runs locally on your device.</string>
+	<string>This is required for the app to work. The user interface of the app needs to communicate with a local backend part of this app for mail synchronization, storage and other tasks. Both parts are on your device. We use a local WebSocket, which never leaves your device. We want the app to run entirely locally on your device, without any cloud service, that's why the service runs locally on your device.</string>
 	<key>NSPhotoLibraryAddUsageDescription</key>
 	<string>We save your photos received or made from chats, emails, files, or avatars.</string>
 	<key>NSPhotoLibraryUsageDescription</key>


### PR DESCRIPTION
- Added the usage descriptions for the camera and photo library as documented on the plugin docs
- The app was rejected on TestFlight because of the missing descriptions

> 90683: Missing purpose string in Info.plist. Your app’s code references one or more APIs that access sensitive user data, or the app has one or more entitlements that permit such access. The Info.plist file for the “Mustang.app” bundle should contain a NSPhotoLibraryUsageDescription key with a user-facing purpose string explaining clearly and completely why your app needs the data. If you’re using external libraries or SDKs, they may reference APIs that require a purpose string. While your app might not use these APIs, a purpose string is still required. For details, visit: https://developer.apple.com/documentation/uikit/protecting_the_user_s_privacy/requesting_access_to_protected_resources.

> iOS requires the following usage description be added and filled out for your app in Info.plist:
> 
> NSCameraUsageDescription (Privacy - Camera Usage Description)
> NSPhotoLibraryAddUsageDescription (Privacy - Photo Library Additions Usage Description)
> NSPhotoLibraryUsageDescription (Privacy - Photo Library Usage Description)

Capacitor camera plugin usage for iOS: https://capacitorjs.com/docs/apis/camera#ios