### PR TITLE
iOS: Set unique build numbers

### DIFF
--- a/app/build/mustang-brand.sh
+++ b/app/build/mustang-brand.sh
@@ -10,7 +10,7 @@ perl -p -i \
   ../../e2/package.json
 
 MAJOR_MINOR=$(echo "$VERSION" | sed 's/^\([0-9]*\.[0-9]*\).*/\1/')
-BUILD_VERSION="${MAJOR_MINOR}.$(date +%s)"
+BUILD_VERSION="${MAJOR_MINOR}.$(date +%Y%m%d%H%M%S)"
 echo Setting iOS Build Version to $BUILD_VERSION
 perl -p -i \
   -e "s|MARKETING_VERSION = .*|MARKETING_VERSION = \"$VERSION\";|;" \

--- a/app/build/parula-brand.sh
+++ b/app/build/parula-brand.sh
@@ -41,7 +41,7 @@ perl -p -i \
   ../../mobile/backend/backend.ts
 
 MAJOR_MINOR=$(echo "$VERSION" | sed 's/^\([0-9]*\.[0-9]*\).*/\1/')
-BUILD_VERSION="${MAJOR_MINOR}.$(date +%s)"
+BUILD_VERSION="${MAJOR_MINOR}.$(date +%Y%m%d%H%M%S)"
 echo Setting iOS Build Version to $BUILD_VERSION
 perl -p -i \
   -e "s|Mustang|Parula|;" \


### PR DESCRIPTION
- Set's the build number to `Major.Minor.Unix time in seconds`
- This for uploading builds to TestFlight where the build number needs to be unique and incremented
- Haven't tested if TestFlight accepts this format yet