### PR TITLE
Windows: URL pathname `/D:/mail/` fails in Router - fixes #854

### DIFF
--- a/app/frontend/MainWindow/MainWindow.svelte
+++ b/app/frontend/MainWindow/MainWindow.svelte
@@ -32,7 +32,7 @@
           <NavigationM />
         </Router>
       {:else if $selectedApp}
-        <Router primary={false}>
+        <Router {basepath} primary={false}>
           <Splitter name="sidebar" initialRightRatio={0.25} hasRight={!!sidebar}>
             <AppContentRoutes slot="left"/>
             <vbox flex class="sidebar" slot="right">
@@ -96,6 +96,10 @@
   $: $sidebarApp?.sidebar, setSidebarDebounced();
   $: rtl = rtlLocales.includes(getUILocale()) ? 'rtl' : null;
   categoriesLoaded; /* make sure to import the file, so that that categories load */
+  let basepath;
+  if (window.location.pathname[2] == ":") { // #854 Windows in production mode has URLs `/D:/mail/`
+    basepath = window.location.pathname.substr(0, 3);
+  }
 
   onMount(() => catchErrors(onLoad));
 


### PR DESCRIPTION
The bug appears only in Windows, and only in production releases. It works fine in development mode.

Here's what's going on:
* During development, code files are loaded from a local HTTP server using http://localhost:5454/ and compiled on-the-fly
* On release, code files are loaded from local file system with a file:// URL
* On Linux and Mac, this works fine.
* On Windows, the page URL is `/C:/mail/` instead of `/mail/`. Even if I navigate to `/calendar/`, we end up on `/C:/calendar/`.
* Since we changed the code to use a router (svelte-navigator), the router cannot match the `/C:/mail/` URL with the `/mail/` route. (Before, we used a custom system to switch pages.)

I have tried the following approaches to fix the bug, but so far without success:
* Set `<base href>` URL in index.html
* Change svelte-navigator to a virtual in-memory history
* Loading the files not directly from file://, but from a custom protocol handler (`protocol.handle()`), which loads the files and then serves them as `app://mail/` and to load the initial page from `app://` , but that didn't work at all.

Eventually, the solution was:
* When the main window loads, look at the URL's pathname, whether it is of form `/C:/`, `/D:/` etc.
* If so, use that (`/C:`, `/D:`) as `basepath` for the `<Router>`. That will make the Router strip these prefixes from the pathname before comparing with the routes.