### PR TITLE
iOS: Exclude the .node files for the real device

### DIFF
--- a/mobile/ios/App/App.xcodeproj/project.pbxproj
+++ b/mobile/ios/App/App.xcodeproj/project.pbxproj
@@ -54,6 +54,17 @@
 		FC68EB0AF532CFC21C3344DD /* Pods-App.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-App.debug.xcconfig"; path = "Pods/Target Support Files/Pods-App/Pods-App.debug.xcconfig"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
+/* Begin PBXFileSystemSynchronizedBuildFileExceptionSet section */
+		BF0C0FBB2EDE1F69002D8549 /* Exceptions for "nodejs-project" folder in "App" target */ = {
+			isa = PBXFileSystemSynchronizedBuildFileExceptionSet;
+			membershipExceptions = (
+				build/better_sqlite3.node/better_sqlite3,
+				"prebuilds/ios-arm64/bufferutil.node/bufferutil",
+			);
+			target = 504EC3031FED79650016851F /* App */;
+		};
+/* End PBXFileSystemSynchronizedBuildFileExceptionSet section */
+
 /* Begin PBXFileSystemSynchronizedRootGroup section */
 		BFB473CD2E1DCEB2008D311F /* libTests */ = {
 			isa = PBXFileSystemSynchronizedRootGroup;
@@ -62,6 +73,9 @@
 		};
 		DD0EE6372DD26C52002B679D /* nodejs-project */ = {
 			isa = PBXFileSystemSynchronizedRootGroup;
+			exceptions = (
+				BF0C0FBB2EDE1F69002D8549 /* Exceptions for "nodejs-project" folder in "App" target */,
+			);
 			path = "nodejs-project";
 			sourceTree = "<group>";
 		};


### PR DESCRIPTION
- Excluding the .node file path in the embedded binaries section of the Project file would build the app with link to that binary which causes to crash because there will be no binary there after the script removes it