### PR TITLE
ActiveSync: Detect user calendars and addressbooks again

### DIFF
--- a/app/logic/Mail/ActiveSync/ActiveSyncAccount.ts
+++ b/app/logic/Mail/ActiveSync/ActiveSyncAccount.ts
@@ -460,8 +460,11 @@ export class ActiveSyncAccount extends MailAccount {
               appGlobal.addressbooks.add(addressbook);
             }
             if (!isMainAddressbook) {
+              // Rename and new address books
               addressbook.name = sanitize.nonemptylabel(change.DisplayName, addressbook.name);
             }
+            // ActiveSync doesn't list all folders, only the changed ones.
+            // So, if we're here, then the address book changed.
             await addressbook.save();
             break;
           case FolderType.Calendar:


### PR DESCRIPTION
Regression from 535dad46969c21cb86b0064d5c18e5dc3f66ead0 which prevented ActiveSync from detecting any user calendars or addressbooks.

This PR restores the previous behaviour, which is:
- All user folders, calendars and addressbooks are detected on account creation
- Creations and renamings of user folders, calendars and addressbooks are detected on folder sync
- User calendar and addressbook accounts can be deleted from mustang, but will reappear if renamed on the server

Additionally I removed all the remaining references to URLs which was the way that user calendars and addressbooks were detected before the server ID was added to the config JSON.