### PR TITLE
Android: Minimize app when at start page

### DIFF
--- a/app/frontend/MainWindow/NavigationM.svelte
+++ b/app/frontend/MainWindow/NavigationM.svelte
@@ -2,7 +2,6 @@
 
 <script lang="ts">
   import { showError } from "../Util/error";
-  import { goTo } from "../AppsBar/selectedApp";
   import { App } from "@capacitor/app";
   import { gestures } from "@composi/gestures";
   import { navigate } from "svelte-navigator";
@@ -13,8 +12,7 @@
     if (canGoBack) {
       navigate(-1);
     } else {
-      // App.exitApp(); TODO crashes on re-launch
-      goTo("/app-menu/", {});
+      App.minimizeApp();
     }
   });
 


### PR DESCRIPTION
- Minimize app when at start page instead of exiting and terminating the app which causes it to crash when you start it up again