### PR TITLE
EWS: Better item error handling during folder sync

### DIFF
--- a/app/logic/Mail/EWS/EWSFolder.ts
+++ b/app/logic/Mail/EWS/EWSFolder.ts
@@ -3,6 +3,7 @@ import type { EMail } from "../EMail";
 import { EWSEMail } from "./EWSEMail";
 import type { EWSAccount } from "./EWSAccount";
 import { EWSCreateItemRequest } from "./Request/EWSCreateItemRequest";
+import { EWSItemError } from "./EWSError";
 import type { EMailCollection } from "../Store/EMailCollection";
 import { CreateMIME } from "../SMTP/CreateMIME";
 import { sanitize } from "../../../../lib/util/sanitizeDatatypes";
@@ -290,16 +291,23 @@ export class EWSFolder extends Folder {
           },
         },
       };
-      let results = ensureArray(await this.account.callEWS(request));
-      for (let result of results) {
-        try {
-          let email = this.newEMail();
-          email.fromXML(getEWSItem(result.Items));
-          await this.storage.saveMessage(email);
-          newMsgs.add(email);
-        } catch (ex) {
-          this.account.errorCallback(ex);
+      try {
+        let results = ensureArray(await this.account.callEWS(request));
+        for (let result of results) {
+          try {
+            if (result.ResponseClass == "Error") {
+              throw new EWSItemError(result, request);
+            }
+            let email = this.newEMail();
+            email.fromXML(getEWSItem(result.Items));
+            await this.storage.saveMessage(email);
+            newMsgs.add(email);
+          } catch (ex) {
+            this.account.errorCallback(ex);
+          }
         }
+      } catch (ex) {
+        this.account.errorCallback(ex);
       }
     }
     return newMsgs;


### PR DESCRIPTION
Mustang got into a state where it couldn't sync `neil@b.onm` over EWS. It was trying to sync up the Inbox but the item that Office 365 was telling it about no longer exists. (Which seems to be an Office 365 bug, surely?)

```
Deleted item id AAMkAGY0MGQ5Mzg4LWExYTctNGMzNi1iOTYyLTJiNTgzZTIxM2M1MwBGAAAAAAAYEBsALqIRR4Wuv0+L/Y7ABwA4Jj9yBgAgRLf4U7C0SL8uAAAAAAEMAAA4Jj9yBgAgRLf4U7C0SL8uAAW0GZ5uAAA=
Inbox folder id AQMkAGY0MGQ5Mzg4AC1hMWE3LTRjMzYtYjk2Mi0yYjU4M2UyMTNjNTMALgAAAxgQGwAuohFHha6/T4v9jsABADgmP3IGACBEt/hTsLRIvy4AAAIBDAAAAA==
Inbox sync state H4sIAAAAAAAEAJWSa0iTURjHz9l7Nk1zecFQEjEDlWzT8l6I7t3aRTc9nsmWpcLrfINpe2fvhqQVhdEHU8y0DwVlJEiSlwqlhBClMOhT+SHsIkpeoqz8IF1WlHRmEpYQ7sDvw3Oe/3Oe5+F/APAH9GQeT81SpaakJasU6gxVpiJVpU5RsGpWrdDuYTPVbIY2Ky0t+aTVrDTXCTazm3Pzak7gxDqw1/dKrfNIJS8aKkGW77UWXnTZnQLYt+HSQtrM5Sa8jbfX8pXFdgfvw7ZGzuU2CC43J9j4fN6XbU1OkTe4eYerUDDzYi0v+jDyn22tFNHBidVg/8aLeZtTqKTWqJ2OGk60u5yCd2m6g6Pmt9kBAIRS4aoN3hm9DUEITSVTlF5NRPA2oOwM0Z3tHyls+tkyCkFmXI4oAzGaex7z7UH9yIoKbqYAOWC8QSAAo4vnWwcGzSCU3gZR/ADQSAAwqbDBpCrwioA2TWtZkf9z5iAA0WtiTLkI1+sk9L30NfG/Y0EAETMUdY49JMVkLHa+h9KLHp1m89CTiZEk+IJE55ZF51YTpUdUelwYvTzK6cmrsPxYyg5m0iph62UYTWnGgtDrZ+MaMrPwYYIySWZv6hSUJLSYp7zLfG7oZp/L2WkdfIvRlwMNOuKZe9hCaYPfmKYcm6R9gO3KJn23yJ0hjDGUIkTqI1HgZORlFDGcYGSiR9NZfRgm229YAyhBJE4IkVO2MIlLHeySFCOFYmEXo134wV5qwIz+SikJDiFbozBjnCmHQ/ArJkV10gKKBRJGWlIE5ZLSZVgGN8EY2pAUH+uMpyQQS907HcXIlDDNZHgGzpE3nzA56J/QSOlC5Y0PDjO2p/lsUzFGVdPzHuZEdz/7OBGjM+Oz4aTRJiugFKLm3u/xTOv7ney1AEzawqs5SgW6zssukP6qjxUUGxqM7BAwXucJWXEKAunAYl/Pf7JwtxZMFfvdjzvlb2pPWq6/GusZlq1m07P/+mK/ALIbIja4BAAA
```

There are two problems with the code handling EWS folder sync:
- If there is only one apparently new item, and an error occurs fetching that item, that error aborts the sync completely.
- If there are multiple new items, a misleading error is generated when the error is reported. ("TypeError: Cannot read properties of undefined" instead of "EWSItemError: This was deleted on the server".)