### PR TITLE
Add pID to ContactBase and use it in subclasses

### DIFF
--- a/app/logic/Abstract/Contact.ts
+++ b/app/logic/Abstract/Contact.ts
@@ -11,6 +11,9 @@ export type Contact = Person | Group;
 export class ContactBase extends Observable {
   id: string;
   dbID: number;
+  /** Protocol-specific ID for this person.
+   * null = new contact that has not been saved to the server yet. */
+  pID: string | null = null;
   addressbook: Addressbook | null;
   @notifyChangedProperty
   name: string;
@@ -24,6 +27,14 @@ export class ContactBase extends Observable {
     super();
     this.id = randomID();
     this.addressbook = addressbook;
+  }
+
+  get isNew(): boolean {
+    return !this.dbID;
+  }
+
+  get existsOnServer(): boolean {
+    return !!this.pID;
   }
 
   async save() {

--- a/app/logic/Abstract/Person.ts
+++ b/app/logic/Abstract/Person.ts
@@ -7,7 +7,6 @@ import { ArrayColl } from 'svelte-collections';
 import { sanitize } from '../../../lib/util/sanitizeDatatypes';
 
 export class Person extends ContactBase {
-  id: string;
   @notifyChangedProperty
   firstName: string | null;
   @notifyChangedProperty

--- a/app/logic/Contacts/ActiveSync/ActiveSyncPerson.ts
+++ b/app/logic/Contacts/ActiveSync/ActiveSyncPerson.ts
@@ -9,10 +9,10 @@ export class ActiveSyncPerson extends Person {
   declare addressbook: ActiveSyncAddressbook | null;
 
   get serverID() {
-    return this.id;
+    return this.pID;
   }
   set serverID(val) {
-    this.id = val;
+    this.pID = val;
   }
 
   fromWBXML(wbxmljs: any) {
@@ -73,7 +73,7 @@ export class ActiveSyncPerson extends Person {
         ActiveSyncPerson.streetAddressToActiveSync(entry.value, entry.purpose, fields);
       }
     }
-    let data = this.serverID ? {
+    let data = this.existsOnServer ? {
       GetChanges: "0",
       Commands: {
         Change: {

--- a/app/logic/Contacts/CardDAV/CardDAVGroup.ts
+++ b/app/logic/Contacts/CardDAV/CardDAVGroup.ts
@@ -5,10 +5,10 @@ export class CardDAVGroup extends Group {
   declare addressbook: CardDAVAddressbook | null;
 
   get itemID() {
-    return this.id;
+    return this.pID;
   }
   set itemID(val) {
-    this.id = val;
+    this.pID = val;
   }
 
   async saveToServer() {

--- a/app/logic/Contacts/CardDAV/CardDAVPerson.ts
+++ b/app/logic/Contacts/CardDAV/CardDAVPerson.ts
@@ -14,10 +14,10 @@ export class CardDAVPerson extends Person {
   originalVCard: string;
 
   get itemID(): string | null {
-    return this.id;
+    return this.pID;
   }
   set itemID(val: string | null) {
-    this.id = val;
+    this.pID = val;
   }
   get etag(): string | null {
     return this.syncState as string;

--- a/app/logic/Contacts/EWS/EWSGroup.ts
+++ b/app/logic/Contacts/EWS/EWSGroup.ts
@@ -14,10 +14,10 @@ export class EWSGroup extends Group {
   declare addressbook: EWSAddressbook | null;
 
   get itemID() {
-    return this.id;
+    return this.pID;
   }
   set itemID(val) {
-    this.id = val;
+    this.pID = val;
   }
 
   fromXML(xmljs: any) {
@@ -29,7 +29,7 @@ export class EWSGroup extends Group {
 
   async saveToServer() {
     // XXX untested due to no UI yet
-    let request = this.itemID ? new EWSUpdateItemRequest(this.itemID) : new EWSCreateItemRequest({ m$SavedItemFolderId: { t$FolderId: { Id: this.addressbook.folderID } } });
+    let request = this.existsOnServer ? new EWSUpdateItemRequest(this.itemID) : new EWSCreateItemRequest({ m$SavedItemFolderId: { t$FolderId: { Id: this.addressbook.folderID } } });
     request.addField("DistributionList", "Body", this.description && { BodyType: "Text", _TextContent_: this.description }, "item:Body");
     request.addField("DistributionList", "DisplayName", this.name, "contacts:DisplayName");
     let participants = this.participants.contents.filter(entry => entry.emailAddresses.first?.value);

--- a/app/logic/Contacts/EWS/EWSPerson.ts
+++ b/app/logic/Contacts/EWS/EWSPerson.ts
@@ -11,10 +11,10 @@ export class EWSPerson extends Person {
   declare addressbook: EWSAddressbook | null;
 
   get itemID() {
-    return this.id;
+    return this.pID;
   }
   set itemID(val) {
-    this.id = val;
+    this.pID = val;
   }
 
   fromXML(xmljs: any) {
@@ -78,7 +78,7 @@ export class EWSPerson extends Person {
   }
 
   async saveToServer() {
-    let request = this.itemID ? new EWSUpdateItemRequest(this.itemID) : new EWSCreateItemRequest({ m$SavedItemFolderId: { t$FolderId: { Id: this.addressbook.folderID } } });
+    let request = this.existsOnServer ? new EWSUpdateItemRequest(this.itemID) : new EWSCreateItemRequest({ m$SavedItemFolderId: { t$FolderId: { Id: this.addressbook.folderID } } });
     request.addField("Contact", "Body", this.notes && { BodyType: "Text", _TextContent_: this.notes }, "item:Body");
     request.addField("Contact", "DisplayName", this.name, "contacts:DisplayName");
     request.addField("Contact", "GivenName", this.firstName, "contacts:GivenName");

--- a/app/logic/Contacts/OWA/OWAGroup.ts
+++ b/app/logic/Contacts/OWA/OWAGroup.ts
@@ -10,10 +10,10 @@ export class OWAGroup extends Group {
   declare addressbook: OWAAddressbook | null;
 
   get personaID() {
-    return this.id;
+    return this.pID;
   }
   set personaID(val) {
-    this.id = val;
+    this.pID = val;
   }
 
   fromJSON(json: any): OWAGroup {

--- a/app/logic/Contacts/OWA/OWAPerson.ts
+++ b/app/logic/Contacts/OWA/OWAPerson.ts
@@ -11,10 +11,10 @@ export class OWAPerson extends Person {
   fields: Record<string, string> = this.toFields();
 
   get personaID() {
-    return this.id;
+    return this.pID;
   }
   set personaID(val) {
-    this.id = val;
+    this.pID = val;
   }
 
   fromJSON(json: any): OWAPerson {
@@ -65,7 +65,7 @@ export class OWAPerson extends Person {
     if (Object.keys(fields).every(key => fields[key] == this.fields[key])) {
       return;
     }
-    let request = this.personaID ? new OWAUpdatePersonaRequest(this.personaID, this.fields, fields) : new OWACreatePersonaRequest(this.addressbook.folderID, this.fields, fields);
+    let request = this.existsOnServer ? new OWAUpdatePersonaRequest(this.personaID, this.fields, fields) : new OWACreatePersonaRequest(this.addressbook.folderID, this.fields, fields);
     let response = await this.addressbook.callOWA(request);
     this.name = sanitize.nonemptystring(response.DisplayName, "");
     this.personaID = sanitize.nonemptystring(response.PersonaId.Id);

--- a/app/logic/Contacts/SQL/SQLGroup.ts
+++ b/app/logic/Contacts/SQL/SQLGroup.ts
@@ -22,14 +22,14 @@ export class SQLGroup extends Group {
             name, description, pID, addressbookID, json
           ) VALUES (
             ${group.name}, ${group.description},
-            ${group.id}, ${group.addressbook?.dbID}, ${jsonStr}
+            ${group.pID}, ${group.addressbook?.dbID}, ${jsonStr}
           )`);
         group.dbID = insert.lastInsertRowid;
       } else {
         await (await getDatabase()).run(sql`
           UPDATE "group" SET
             name = ${group.name}, description = ${group.description},
-            pID = ${group.id}, addressbookID = ${group.addressbook?.dbID},
+            pID = ${group.pID}, addressbookID = ${group.addressbook?.dbID},
             json = ${jsonStr}
           WHERE id = ${group.dbID}
           `);
@@ -93,7 +93,7 @@ export class SQLGroup extends Group {
     group.dbID = sanitize.integer(dbID);
     group.name = sanitize.label(row.name);
     group.description = sanitize.label(row.description, "");
-    group.id = sanitize.string(row.pID, null);
+    group.pID = sanitize.string(row.pID, null);
     group.fromExtraJSON(sanitize.json(row.json, {}));
     if (row.addressbookID) {
       let addressbookID = sanitize.integer(row.addressbookID);

--- a/app/logic/Contacts/SQL/SQLPerson.ts
+++ b/app/logic/Contacts/SQL/SQLPerson.ts
@@ -23,7 +23,7 @@ export class SQLPerson {
           ) VALUES (
             ${person.name}, ${person.firstName}, ${person.lastName},
             ${person.picture}, ${person.notes}, ${person.popularity},
-            ${person.id}, ${person.addressbook?.dbID}, ${jsonStr}
+            ${person.pID}, ${person.addressbook?.dbID}, ${jsonStr}
           )`);
         person.dbID = insert.lastInsertRowid;
       } else {
@@ -35,7 +35,7 @@ export class SQLPerson {
             picture = ${person.picture},
             notes = ${person.notes},
             popularity = ${person.popularity},
-            pID = ${person.id},
+            pID = ${person.pID},
             addressbookID = ${person.addressbook?.dbID},
             json = ${jsonStr}
           WHERE id = ${person.dbID}
@@ -113,7 +113,7 @@ export class SQLPerson {
     person.picture = sanitize.url(row.picture, null);
     person.notes = sanitize.string(row.notes, null);
     person.popularity = sanitize.integer(row.popularity, null);
-    person.id = sanitize.string(row.pID, randomID());
+    person.pID = sanitize.string(row.pID, null);
     person.fromExtraJSON(sanitize.json(row.json, {}));
     if (row.addressbookID) {
       let addressbookID = sanitize.integer(row.addressbookID);


### PR DESCRIPTION
As of 0a31eab `id` is just a unique per-session identifier used to distinguish between new contacts.

Note: I may have missed some of the `id`s, or fixed them incorrectly, but I was at least able to create an EWS contact on Grommunio.