### PR TITLE
OAuth2: Use in-app tab UI by default

### DIFF
--- a/app/logic/Auth/OAuth2.ts
+++ b/app/logic/Auth/OAuth2.ts
@@ -45,7 +45,7 @@ export class OAuth2 extends WebBasedAuth {
   @notifyChangedProperty
   idToken: string;
   verificationToken: string; /** `state` URL param of authURL/doneURL */
-  uiMethod: OAuth2UIMethod = OAuth2UIMethod.Window;
+  uiMethod: OAuth2UIMethod = OAuth2UIMethod.Tab;
   protected ui: OAuth2UI | null = null;
 
   expiresAt: Date | null = null;


### PR DESCRIPTION
Mainly because we get auto fill of Office 365 accounts with the in-app tab UI.