### PR TITLE
EWS, OWA: Refresh shared folders on login

### DIFF
--- a/app/logic/Mail/EWS/EWSAccount.ts
+++ b/app/logic/Mail/EWS/EWSAccount.ts
@@ -94,6 +94,7 @@ export class EWSAccount extends MailAccount {
   async login(interactive: boolean): Promise<void> {
     if (this.mainAccount) {
       await this.mainAccount.login(interactive);
+      await this.listFolders();
       return;
     }
     await ensureLicensed(); // Not in generic `Account`, to keep license code in the proprietary parts

--- a/app/logic/Mail/OWA/OWAAccount.ts
+++ b/app/logic/Mail/OWA/OWAAccount.ts
@@ -164,6 +164,7 @@ export class OWAAccount extends MailAccount {
   async login(interactive: boolean): Promise<void> {
     if (this.mainAccount) {
       await this.mainAccount.login(interactive);
+      await this.listFolders();
       return;
     }
     await ensureLicensed();
@@ -172,10 +173,6 @@ export class OWAAccount extends MailAccount {
     this.authorizationHeader = await appGlobal.remoteApp.OWA.getAnyScrapedAuth(this.partition);
     this.hasLoggedIn = true;
     await this.listFolders();
-
-    if (this.sharedFolderRoot) {
-      return;
-    }
 
     // `listFolders()` will subscribe to new user-added calendars
 


### PR DESCRIPTION
Although we list the shared folders of another user when we add them, we don't ever refresh them. This at least makes us refresh them on every startup. (I don't know how to get notifications of changes to the shared folder hierarchy though.)

(The last hunk is dead code but feel free to leave it in if you prefer.)