### PR TITLE
Mobile: Update Mobile Version for Mustang

### DIFF
--- a/app/build/mustang-brand.sh
+++ b/app/build/mustang-brand.sh
@@ -9,6 +9,10 @@ perl -p -i \
   -e "s|\"version\": \".*\"|\"version\": \"$VERSION\"|;" \
   ../../e2/package.json
 
+perl -p -i \
+  -e "s|\"version\": \".*\"|\"version\": \"$VERSION\"|;" \
+  ../../mobile/package.json
+
 MARKETING_VERSION=$(echo "$VERSION" | sed 's/-.*//')
 MAJOR_MINOR=$(echo "$VERSION" | sed 's/^\([0-9]*\.[0-9]*\).*/\1/')
 BUILD_VERSION="${MAJOR_MINOR}.$(date +%Y%m%d%H%M%S)"


### PR DESCRIPTION
- We're not updating the version in our mobile/package.json
- We do update it for Parula though
https://github.com/mustang-im/mustang/blob/939d050e34b65305b9d14879c0c3c175934365ab/app/build/parula-brand.sh#L20
- This is problem for the Mobile workflows since it uses the outdated and the one with out the `-dev` which creates a latest release