### PR TITLE
Android: Convert Java Package to Kotlin

### DIFF
--- a/mobile/android/app/build.gradle
+++ b/mobile/android/app/build.gradle
@@ -1,8 +1,12 @@
 import com.android.build.gradle.internal.tasks.FinalizeBundleTask
 
 apply plugin: 'com.android.application'
+apply plugin: 'org.jetbrains.kotlin.android'
 
 android {
+    kotlinOptions {
+        jvmTarget = '21'
+    }
     namespace "im.mustang.capa"
     compileSdk rootProject.ext.compileSdkVersion
     defaultConfig {

--- a/mobile/android/app/src/main/java/im/mustang/capa/MainActivity.java
+++ b/mobile/android/app/src/main/java/im/mustang/capa/MainActivity.java
@@ -1,5 +1,0 @@
-package im.mustang.capa;
-
-import com.getcapacitor.BridgeActivity;
-
-public class MainActivity extends BridgeActivity {}

--- a/mobile/android/app/src/main/java/im/mustang/capa/MainActivity.kt
+++ b/mobile/android/app/src/main/java/im/mustang/capa/MainActivity.kt
@@ -1,0 +1,5 @@
+package im.mustang.capa
+
+import com.getcapacitor.BridgeActivity
+
+class MainActivity : BridgeActivity()

--- a/mobile/android/build.gradle
+++ b/mobile/android/build.gradle
@@ -2,6 +2,9 @@
 
 buildscript {
     
+    ext {
+        kotlin_version = '2.2.0'
+    }
     repositories {
         google()
         mavenCentral()
@@ -9,6 +12,7 @@ buildscript {
     dependencies {
         classpath 'com.android.tools.build:gradle:8.12.1'
         classpath 'com.google.gms:google-services:4.4.3'
+        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files


### PR DESCRIPTION
- Convert our Java Package to Kotlin
- Kotlin is the Official Language for Android
- It has ViewModels which can have the same lifecycle as the App or Activity in this case
- It has coroutines which are more lightweight than threads