### PR TITLE
Setup: Always set `config.oAuth2` for OAuth2 accounts

### DIFF
--- a/app/frontend/Settings/Mail/Manual/ManualConfigHostServer.svelte
+++ b/app/frontend/Settings/Mail/Manual/ManualConfigHostServer.svelte
@@ -105,8 +105,6 @@
   import { dummyHostname } from "../../../../logic/Mail/AutoConfig/manualConfig";
   import { getDomainForEmailAddress } from "../../../../logic/util/netUtil";
   import { isCertError } from "../../../../logic/Mail/AutoConfig/checkConfig";
-  import { OAuth2URLs } from "../../../../logic/Auth/OAuth2URLs";
-  import { OAuth2 } from "../../../../logic/Auth/OAuth2";
   import ProtocolSelector from "./ProtocolSelector.svelte";
   import PasswordChange from "../../Shared/PasswordChange.svelte";
   import Checkbox from "../../../Shared/Checkbox.svelte";
@@ -231,11 +229,6 @@
     if (config.authMethod == AuthMethod.Unknown) {
       authError = new UserError(gt`Please enter the authentication method`);
       throw authError;
-    } else if (config.authMethod == AuthMethod.OAuth2) {
-      let oAuth = OAuth2URLs.find(o => o.hostnames.some(h => h == config.hostname));
-      if (oAuth) {
-        config.oAuth2 = new OAuth2(config, oAuth.tokenURL, oAuth.authURL, oAuth.authDoneURL, oAuth.scope, oAuth.clientID, oAuth.clientSecret, oAuth.doPKCE);
-      }
     } else {
       authError = null;
     }

--- a/app/frontend/Settings/Mail/Manual/ManualConfigURL.svelte
+++ b/app/frontend/Settings/Mail/Manual/ManualConfigURL.svelte
@@ -49,9 +49,6 @@
 <script lang="ts">
   import type { MailAccount } from "../../../../logic/Mail/MailAccount";
   import { AuthMethod } from "../../../../logic/Abstract/Account";
-  import { OAuth2URLs } from "../../../../logic/Auth/OAuth2URLs";
-  import { OAuth2 } from "../../../../logic/Auth/OAuth2";
-  import { OWAAuth } from "../../../../logic/Auth/OWAAuth";
   import { TLSSocketType } from "../../../../logic/Abstract/TCPAccount";
   import ProtocolSelector from "./ProtocolSelector.svelte";
   import PasswordChange from "../../Shared/PasswordChange.svelte";
@@ -137,15 +134,6 @@
     if (config.authMethod == AuthMethod.Unknown) {
       authError = new Error("Please enter the authentication method");
       throw authError;
-    } else if (config.authMethod == AuthMethod.OAuth2) {
-      if (config.protocol == "owa") {
-        config.oAuth2 = new OWAAuth(config);
-      } else {
-        let oAuth = OAuth2URLs.find(o => o.hostnames.some(h => h == config.hostname));
-        if (oAuth) {
-          config.oAuth2 = new OAuth2(config, oAuth.tokenURL, oAuth.authURL, oAuth.authDoneURL, oAuth.scope, oAuth.clientID, oAuth.clientSecret, oAuth.doPKCE);
-        }
-      }
     } else {
       authError = null;
     }


### PR DESCRIPTION
Setup's special embedded OAuth2 UI only works if `oAuth` is set before the login step. This is fine for manual setup, because it's special-cased, but the setup wizard fails to do this. Before #969 this appeared to work because the login step would always pose the separate window UI, but then the account would be created with that as the default UI.

By centralising the OAuth2 code out of the two manual setup pages into the main setup page I hope to make the OAuth2 UI consistent across manual and wizard setup.