### PR TITLE
Support IMAP namespaces via JPC `.__refresh()`

### DIFF
--- a/app/logic/Mail/IMAP/IMAPAccount.ts
+++ b/app/logic/Mail/IMAP/IMAPAccount.ts
@@ -66,9 +66,7 @@ export class IMAPAccount extends MailAccount {
   }
 
   async startup() {
-    if (await this.hasCapability('NAMESPACE')) {
-      this.namespaces = await this.getNamespaces();
-    }
+    this.namespaces = await this.getNamespaces();
     await super.startup();
     this.notifyObservers();
     (this.inbox as IMAPFolder).startPolling();
@@ -261,51 +259,21 @@ export class IMAPAccount extends MailAccount {
 
   async hasCapability(capa: string): Promise<boolean> {
     let conn = await this.connection();
-    // conn.capabilities doesn't work; it's an object property,
-    // and JPC doesn't notice direct changes to properties.
-    // Fortunately `conn.run("CAPABILITY")` has its own cache,
-    // and only makes a network request if absolutely necessary.
-    let capabilities = await conn.run("CAPABILITY");
-    return await capabilities.has(capa);
+    // conn.capabilities was automatically updated via `getNamespaces`
+    return await conn.capabilities.has(capa);
   }
 
   /**
-   * If the connection supports it, this will return the server's namespaces.
+   * This will return the server's namespaces.
    * @see this.namespaces
    */
   async getNamespaces(): Promise<Record<IMAPNamespace, {prefix: string, delimiter: string}[]>> {
     let conn = await this.connection();
-    // This should be `return await conn.run("NAMESPACE");`...
-    type ImapFlowAttribute = { type: string, value: string };
-    type ImapFlowNamespace = [prefix: ImapFlowAttribute, delimiter: ImapFlowAttribute];
-    type ImapFlowNamespaceList = ImapFlowNamespace[] | null;
-    type ImapFlowNamespaces = [personal: ImapFlowNamespaceList, other: ImapFlowNamespaceList, shared: ImapFlowNamespaceList];
-    let namespaces = Object.assign({}, kDefaultNamespaces);
-    let response = await conn.exec("NAMESPACE", false, {
-      untagged: {
-        NAMESPACE: async (untagged: { attributes?: ImapFlowNamespaces }) => {
-          if (Array.isArray(untagged.attributes)) {
-            let entries = untagged.attributes.map(list => Array.isArray(list)
-              ? list.map(entry => ({
-                prefix: sanitize.string(entry[0].value),
-                delimiter: sanitize.nonemptystring(entry[1].value),
-              }))
-              : null);
-            if (entries[0]) {
-              namespaces.personal = entries[0];
-            }
-            if (entries[1]) {
-              namespaces.other = entries[1];
-            }
-            if (entries[2]) {
-              namespaces.shared = entries[2];
-            }
-          }
-        }
-      }
-    });
-    await response.next();
-    return namespaces;
+    // This ImapFlow command checks for the NAMESPACE capability
+    // and returns the default namespaces if it doesn't support it.
+    await conn.run("NAMESPACE");
+    await conn.__refresh();
+    return conn.namespaces;
   }
 
   async listFolders(): Promise<void> {
@@ -534,7 +502,7 @@ type IMAPNamespace = "personal" | "other" | "shared";
  */
 interface IMAPNamespaceRecord { prefix: string; delimiter: string };
 /** The effective namespaces for servers that don't support namespaces. */
-const kDefaultNamespaces: Record<IMAPNamespace, IMAPNamespaceRecord[]> = { personal: [{ prefix: "", delimiter: "." }], other: [], shared: [] };
+const kDefaultNamespaces: Record<IMAPNamespace, IMAPNamespaceRecord[] | false> = { personal: [{ prefix: "", delimiter: "." }], other: false, shared: false };
 
 export enum ConnectionPurpose {
   Main = "main",

--- a/lib/jpc/obj.js
+++ b/lib/jpc/obj.js
@@ -89,6 +89,7 @@ export default class BaseProtocol {
     this.registerIncomingCall("get", this.getterListener.bind(this));
     this.registerIncomingCall("set", this.setterListener.bind(this));
     this.registerIncomingCall("notify", this.notifyListener.bind(this));
+    this.registerIncomingCall("refresh", this.refreshListener.bind(this));
     this.registerIncomingCall("del", payload => {
       this.deleteLocalObject(payload.idRecipient);
     });
@@ -203,6 +204,7 @@ export default class BaseProtocol {
     let stub = Object.create(proto);
     context.stubs.set(objDescrJSON.idSender, stub);
     stub._jpc_id = objDescrJSON.idSender;
+    stub.__refresh = this.makeRefresh();
     this.updateObjectProperties(stub, await this.mapIncomingObjects(objDescrJSON.properties, context));
     // Timing issue: This needs to happen after the caller sets the
     // Promise it gets from calling us into the remote object map.
@@ -290,6 +292,16 @@ export default class BaseProtocol {
         className: className,
         args: self.mapOutgoingObjects(args),
       }));
+    }
+  }
+
+  makeRefresh() {
+    let self = this;
+    return /** @this {RemoteClass} */ async function() {
+      // this == stub object
+      let props = await self.callRemote("refresh", { obj: this._jpc_id });
+      await self.updateObjectProperties(this, props);
+      return this;
     }
   }
 
@@ -475,6 +487,28 @@ export default class BaseProtocol {
       this._remoteObjects.set(objDescrJSON.idSender, promise);
     }
   }
+
+  async refreshListener(payload) {
+    let props = {};
+    let obj = this.getLocalObject(payload.obj);
+
+    for (let propName of Object.getOwnPropertyNames(obj)) {
+      if (isPrivateProperty(propName)) {
+        continue;
+      }
+      let property = Object.getOwnPropertyDescriptor(obj, propName);
+      if (property.get) {
+        continue;
+      }
+
+      if (typeof property.value != "function") {
+        props[propName] = this.mapOutgoingObjects(property.value);
+      }
+    }
+
+    return props;
+  }
+
   /**
    * @param value {any} string, number, boolean,
    *   array, JSON obj, or

--- a/lib/jpc/protocol.test.js
+++ b/lib/jpc/protocol.test.js
@@ -38,6 +38,22 @@ class LPCProtocol extends JPCProtocol {
   }
 }
 
+class Connection {
+  capabilities = new Map();
+  run(command) {
+    switch (command) {
+    case 'CAPABILITY':
+      this.capabilities = new Map([["IMAP4rev1", true]]);
+      return true;
+    case 'NAMESPACE':
+      this.namespaces = { personal: [{ prefix: "", delimiter: "." }], other: [], shared: [] };
+      return true;
+    default:
+      return false;
+    }
+  }
+}
+
 class Collection {
   self = this;
   _array = [];
@@ -99,6 +115,19 @@ test('Protocol', async () => {
   expect(start).toHaveProperty("callable");
   await expect(start.callable(false)).resolves.toBe(true);
   await expect(start.callable(true)).resolves.toBe(false);
+  expect(start).toHaveProperty("makeConnection");
+  let connection = await start.makeConnection();
+  await expect(connection.capabilities.size).resolves.toBe(0);
+  expect(connection.run('CAPABILITY')).resolves.toBe(true);
+  await expect(connection.capabilities.size).resolves.toBe(0);
+  await connection.__refresh();
+  await expect(connection.capabilities.size).resolves.toBe(1);
+  await expect(connection.capabilities.get('IMAP4rev1')).resolves.toBe(true);
+  expect(connection).not.toHaveProperty("namespaces");
+  expect(connection.run('NAMESPACE')).resolves.toBe(true);
+  expect(connection).not.toHaveProperty("namespaces");
+  await connection.__refresh();
+  expect(connection).toHaveProperty("namespaces");
   expect(start).toHaveProperty("makeCollection");
   let collection = await start.makeCollection();
   expect(collection).toHaveProperty("self", collection);
@@ -122,9 +151,10 @@ test('Protocol', async () => {
   await collection.clear();
   await expect(collection.isEmpty).resolves.toBe(true);
   if (globalThis.gc) {
-    expect(client._remoteObjects.size).toBe(3);
-    expect(server._localIDsToObjects.size).toBe(3);
+    expect(client._remoteObjects.size).toBe(7);
+    expect(server._localIDsToObjects.size).toBe(7);
     collection = null;
+    connection = null;
     start = null;
     await new Promise(resolve => setTimeout(resolve, 0));
     globalThis.gc();
@@ -132,7 +162,7 @@ test('Protocol', async () => {
     globalThis.gc();
     await new Promise(resolve => setTimeout(resolve, 0));
     expect(client._remoteObjects.size).toBe(0);
-    expect(server._localIDsToObjects.size).toBe(2);
+    expect(server._localIDsToObjects.size).toBe(3);
     for (let [id, obj] of server._localIDsToObjects) {
       expect(obj).toBeInstanceOf(WeakRef);
     }


### PR DESCRIPTION
As requested in #948.