### PR TITLE
OAuth2: isLoggedIn = false when expired #350

### DIFF
--- a/app/logic/Auth/OAuth2.ts
+++ b/app/logic/Auth/OAuth2.ts
@@ -169,7 +169,7 @@ export class OAuth2 extends WebBasedAuth {
 
   isExpired(): boolean {
     return this.expiresAt
-      ? this.expiresAt.getTime() + 2000 < Date.now()
+      ? this.expiresAt.getTime() - 2000 < Date.now()
       : false;
   }
 

--- a/app/logic/Mail/IMAP/IMAPFolder.ts
+++ b/app/logic/Mail/IMAP/IMAPFolder.ts
@@ -76,8 +76,7 @@ export class IMAPFolder extends Folder {
         }
       } catch (ex) {
         console.log("Opening IMAP folder failed", ex);
-        if (ex.code == "NoConnection" || // TCP connection dropped
-            ex.message == "Invalid credentials (Failure)") { // Gmail access token expired #350
+        if (ex.code == "NoConnection") {
           conn = await this.account.reconnect(conn);
           if (doLock) {
             lock = await this.account.connectionLock.get(conn).lock();


### PR DESCRIPTION
If the computer was asleep (notebook lid down) and waking up now, and we refresh the IMAP connection, but the access token is expired (because too much time passed since the notebook went to sleep), then `isLoggedIn` should return false, because we *know* for a fact that the access token won't be valid anymore.

In `IMAPAccount.connection()`, we're checking that. If `isLoggedIn` is false, we try to log in again, non-interactively, and wait for that before trying to connect. If we have a refresh token, we should be able to get a new access token non-interactively, and the IMAP connection should then accept it.

This should theoretically fix the #350 Gmail "Invalid credentials" bug.