### PR TITLE
OAuth2: Don't return expired access tokens - partially fixes #350

### DIFF
--- a/app/logic/Auth/OAuth2.ts
+++ b/app/logic/Auth/OAuth2.ts
@@ -92,7 +92,7 @@ export class OAuth2 extends WebBasedAuth {
    */
   async login(interactive: boolean): Promise<string> {
     assert(this.account, "Need to set account first");
-    if (this.accessToken) {
+    if (this.isLoggedIn) {
       return this.accessToken;
     }
     this.refreshToken ??= await this.getRefreshTokenFromStorage();


### PR DESCRIPTION
- We're returning the access token as long there's one available without checking whether it's expired or not