### PR TITLE
EWS, OWA, IMAP: Exclude self from shared persons

### DIFF
--- a/app/logic/Calendar/EWS/EWSCalendar.ts
+++ b/app/logic/Calendar/EWS/EWSCalendar.ts
@@ -277,7 +277,7 @@ export class EWSCalendar extends Calendar {
       },
     };
     let result = await this.account.callEWS(request);
-    return getSharedPersons(result.Folders.CalendarFolder.PermissionSet.CalendarPermissions.CalendarPermission);
+    return getSharedPersons(result.Folders.CalendarFolder.PermissionSet.CalendarPermissions.CalendarPermission, this.account.emailAddress);
   }
 
   async deleteSharedPerson(otherPerson: PersonUID) {

--- a/app/logic/Calendar/OWA/OWACalendar.ts
+++ b/app/logic/Calendar/OWA/OWACalendar.ts
@@ -152,7 +152,7 @@ export class OWACalendar extends Calendar {
 
   async getSharedPersons(): Promise<ArrayColl<PersonUID>> {
     let result = await this.account.callOWA(owaGetPermissionsRequest(this.folderID));
-    return getSharedPersons(result.Folders[0].PermissionSet.CalendarPermissions);
+    return getSharedPersons(result.Folders[0].PermissionSet.CalendarPermissions, this.account.emailAddress);
   }
 
   async deleteSharedPerson(otherPerson: PersonUID) {

--- a/app/logic/Contacts/EWS/EWSAddressbook.ts
+++ b/app/logic/Contacts/EWS/EWSAddressbook.ts
@@ -265,7 +265,7 @@ export class EWSAddressbook extends Addressbook {
       },
     };
     let result = await this.account.callEWS(request);
-    return getSharedPersons(result.Folders.ContactsFolder.PermissionSet.Permissions.Permission);
+    return getSharedPersons(result.Folders.ContactsFolder.PermissionSet.Permissions.Permission, this.account.emailAddress);
   }
 
   async deleteSharedPerson(otherPerson: PersonUID) {

--- a/app/logic/Contacts/OWA/OWAAddressbook.ts
+++ b/app/logic/Contacts/OWA/OWAAddressbook.ts
@@ -146,7 +146,7 @@ export class OWAAddressbook extends Addressbook {
 
   async getSharedPersons(): Promise<ArrayColl<PersonUID>> {
     let result = await this.account.callOWA(owaGetPermissionsRequest(this.folderID));
-    return getSharedPersons(result.Folders[0].PermissionSet.Permissions);
+    return getSharedPersons(result.Folders[0].PermissionSet.Permissions, this.account.emailAddress);
   }
 
   async deleteSharedPerson(otherPerson: PersonUID) {

--- a/app/logic/Mail/EWS/EWSFolder.ts
+++ b/app/logic/Mail/EWS/EWSFolder.ts
@@ -559,7 +559,7 @@ export class EWSFolder extends Folder {
       },
     };
     let result = await this.account.callEWS(request);
-    return getSharedPersons(result.Folders.Folder.PermissionSet.Permissions.Permission);
+    return getSharedPersons(result.Folders.Folder.PermissionSet.Permissions.Permission, this.account.emailAddress);
   }
 
   async getPermissions(): Promise<ExchangePermission[]> {
@@ -692,8 +692,8 @@ export class ExchangePermission {
   }
 }
 
-export function getSharedPersons(permissions: ExchangeUser[]): ArrayColl<PersonUID> {
-  return new ArrayColl(permissions.filter(permission => !permission.UserId.DistinguishedUser).map(permission => new PersonUID(permission.UserId.PrimarySmtpAddress, permission.UserId.DisplayName)));
+export function getSharedPersons(permissions: ExchangeUser[], thisUser: string): ArrayColl<PersonUID> {
+  return new ArrayColl(permissions.filter(permission => !permission.UserId.DistinguishedUser && permission.UserId.PrimarySmtpAddress != thisUser).map(permission => new PersonUID(permission.UserId.PrimarySmtpAddress, permission.UserId.DisplayName)));
 }
 
 export async function deleteExchangePermissions(target: { getPermissions(): Promise<ExchangePermission[]>, setPermissions(permission: ExchangePermission[]): Promise<void> }, otherPerson: PersonUID) {

--- a/app/logic/Mail/IMAP/IMAPFolder.ts
+++ b/app/logic/Mail/IMAP/IMAPFolder.ts
@@ -658,6 +658,9 @@ export class IMAPFolder extends Folder {
     await response.next();
     for (let i = 1; i < attributes.length; i += 2) {
       let name = sanitize.nonemptystring(attributes[i].value);
+      if (name == this.account.username) {
+        continue;
+      }
       let emailAddress = name.includes('@') ? name : name + this.account.emailAddress.slice(this.account.emailAddress.indexOf('@'));
       persons.add(new PersonUID(emailAddress, name));
     }

--- a/app/logic/Mail/OWA/OWAFolder.ts
+++ b/app/logic/Mail/OWA/OWAFolder.ts
@@ -12,8 +12,8 @@ import {
   owaSetFolderPermissionsRequest, owaGetPermissionsRequest
 } from "./Request/OWAFolderRequests";
 import type { EMailCollection } from "../Store/EMailCollection";
-import { ExchangePermission } from "../EWS/EWSFolder";
-import { PersonUID } from "../../Abstract/PersonUID";
+import { getSharedPersons, ExchangePermission } from "../EWS/EWSFolder";
+import type { PersonUID } from "../../Abstract/PersonUID";
 import { CreateMIME } from "../SMTP/CreateMIME";
 import { base64ToArrayBuffer, blobToBase64 } from "../../util/util";
 import { sanitize } from "../../../../lib/util/sanitizeDatatypes";
@@ -283,7 +283,7 @@ export class OWAFolder extends Folder {
 
   async getSharedPersons(): Promise<ArrayColl<PersonUID>> {
     let result = await this.account.callOWA(owaGetPermissionsRequest(this.id));
-    return new ArrayColl(result.Folders[0].PermissionSet.Permissions.filter(permission => !permission.UserId.DistinguishedUser).map(permission => new PersonUID(permission.UserId.PrimarySmtpAddress, permission.UserId.DisplayName)));
+    return getSharedPersons(result.Folders[0].PermissionSet.Permissions, this.account.emailAddress);
   }
 
   async getPermissions(): Promise<ExchangePermission[]> {


### PR DESCRIPTION
For `OWAFolder` I noticed I wasn't using my helper function that I had been using in `EWSFolder`, `OWACalendar`, `EWSCalendar`, `OWAAddressbook` and `EWSAddressbook` so I switched the code over to use that too.