### PR TITLE
Mobile: Don't include capacitor on desktop builds - #1004

### DIFF
--- a/app/frontend/MainWindow/MainWindow.svelte
+++ b/app/frontend/MainWindow/MainWindow.svelte
@@ -19,7 +19,7 @@
     {/if}
     <vbox flex>
       <NotificationBar notifications={$notifications} />
-      {#if appGlobal.isMobile}
+      // #if [MOBILE]
         <Router primary={false} {history}>
           <SplitterHorizontal name="sidebar" initialBottomRatio={0.7} hasTop={!!sidebar}>
             <vbox flex class="sidebar" slot="top">
@@ -29,16 +29,18 @@
           </SplitterHorizontal>
           <NavigationM />
         </Router>
-      {:else if $selectedApp}
-        <Router primary={false} {history}>
-          <Splitter name="sidebar" initialRightRatio={0.25} hasRight={!!sidebar}>
-            <AppContentRoutes slot="left"/>
-            <vbox flex class="sidebar" slot="right">
-              <svelte:component this={sidebar} />
-            </vbox>
-          </Splitter>
-        </Router>
-      {/if}
+      // #else
+        {#if $selectedApp}
+          <Router primary={false} {history}>
+            <Splitter name="sidebar" initialRightRatio={0.25} hasRight={!!sidebar}>
+              <AppContentRoutes slot="left"/>
+              <vbox flex class="sidebar" slot="right">
+                <svelte:component this={sidebar} />
+              </vbox>
+            </Splitter>
+          </Router>
+        {/if}
+      // #endif
     </vbox>
   </hbox>
 </vbox>


### PR DESCRIPTION
Fix #1004 Capacitor should not be included in desktop builds

Use compile-time `#if [MOBILE]` instead of runtime Svelte `{#if isMobile}`.

Completely untested @jermy-c Can you check whether this works on desktop and mobile, and whether it fixes the bug? If not, please adopt the PR and fix it to make it work.