### PR TITLE
Mail: Attachments: Inline images: Replace data: URLs with blob: URLs #1005

### DIFF
--- a/app/frontend/Shared/WebView.svelte
+++ b/app/frontend/Shared/WebView.svelte
@@ -97,7 +97,7 @@
     </style>`;
     let servers = allowServerCalls ? `* 'unsafe-inline'` : `'unsafe-inline'` ;
     const head = `<meta http-equiv="Content-Security-Policy" content="default-src 'none';
-      style-src ${servers}; img-src data: ${servers}">\n\n` + headHTML + `\n\n`;
+      style-src ${servers}; img-src data: blob: ${servers}">\n\n` + headHTML + `\n\n`;
     let displayHTML = html ?? "";
     let headPos = displayHTML.indexOf("<head>");
     headPos = headPos < 0 ? 0 : headPos + 6;

--- a/app/logic/Mail/ComposeActions.ts
+++ b/app/logic/Mail/ComposeActions.ts
@@ -224,9 +224,6 @@ export class ComposeActions {
       return url;
     }
 
-    URL.revokeObjectURL(url);
-    attachment.blobURL = null;
-
     attachment.contentID ??= crypto.randomUUID();
     return "cid:" + attachment.contentID;
   }

--- a/app/logic/Mail/EMail.ts
+++ b/app/logic/Mail/EMail.ts
@@ -546,7 +546,7 @@ async function addCID(html: string, email: EMail): Promise<string> {
       let cid = src.substring(4);
       let attachment = email.attachments.find(a => a.contentID == "<" + cid + ">");
       src = attachment?.content
-        ? await blobToDataURL(attachment.content)
+        ? attachment.blobURL
         : "";
       img.setAttribute("src", src);
     }


### PR DESCRIPTION
- Using `blob` URLs seems to be better for memory and speed. At least with my 15MB inline image. The blobURL HTML is 12KB and the dataURL HTML is 22MB plus the existing the `File` object.

> Blob URLs are similar to [data URLs](https://developer.mozilla.org/en-US/docs/Web/URI/Reference/Schemes/data), because they both allow representing in-memory resources as URLs; the difference is that data URLs embed resources in themselves and have severe size limitations, whereas blob URLs require a backing Blob or MediaSource and can represent larger resources.

- I think it's faster and using less memory because the URL is just pointing to the existing `File` object instead of creating more data or the string

- But we have an existing issue where the once the attachment is loaded it's not cleared after viewing but clearing it will require refetching it from the DB every time displaying it.