### PR TITLE
IMAP: Don't lock again if already locked - #1012

### DIFF
--- a/app/logic/Mail/IMAP/IMAPFolder.ts
+++ b/app/logic/Mail/IMAP/IMAPFolder.ts
@@ -81,7 +81,7 @@ export class IMAPFolder extends Folder {
           conn = await this.account.reconnect(conn, purpose);
           if (doLock) {
             lock ??= await this.account.connectionLock.get(conn).lock();
-            lockMailbox = await conn.getMailboxLock(this.path);
+            lockMailbox ??= await conn.getMailboxLock(this.path);
           } else {
             await conn.mailboxOpen(this.path);
           }


### PR DESCRIPTION
- There might have been a deadlock in `runCommand()`

If the `getMailboxLock(this.path)` before it throws. We don't release the lock for that reference. But we create a new lock without releasing the old lock.
https://github.com/mustang-im/mustang/blob/5dd1f847baa8ae13b9b5870b31891efa7f701bfd/app/logic/Mail/IMAP/IMAPFolder.ts#L67-L72

- Might fix #1012 