### PR TITLE
EMailCollection: Read message once

### DIFF
--- a/app/logic/Mail/Store/EMailCollection.ts
+++ b/app/logic/Mail/Store/EMailCollection.ts
@@ -1,11 +1,13 @@
 import { ArrayColl, SortedCollection } from 'svelte-collections';
 import { PromiseAllDone } from '../../util/PromiseAllDone';
+import { RunOnce } from '../../util/RunOnce';
 import type { EMail } from '../EMail';
 import type { Folder } from '../Folder';
 
 export class EMailCollection<T extends EMail> extends SortedCollection<T> {
   folder: Folder;
   sortFunc: (a: T, b: T) => number;
+  protected readonly readMessageRunOnce = new Map<number, RunOnce<void>>();
 
   constructor(folder: Folder) {
     let sortFunc = (a: T, b: T) => compareValues(b.sent, a.sent); // inverted = newest first
@@ -23,7 +25,7 @@ export class EMailCollection<T extends EMail> extends SortedCollection<T> {
 
     if (emails.length) {
       // async: Return before filtering and reading emails
-      this.readMessagesFromDB(emails)
+      this.readMessagesFromDB_parallel(emails)
         .catch(emails[0].folder.account.errorCallback);
     }
     return emails;
@@ -36,8 +38,7 @@ export class EMailCollection<T extends EMail> extends SortedCollection<T> {
     }
     for (let email of needEmails) {
       if (email.dbID) {
-        await email.storage.readMessage(email);
-        (email as any).haveMetadata = true;
+        await this.readMessageOnce(email);
       }
     }
   }
@@ -50,13 +51,27 @@ export class EMailCollection<T extends EMail> extends SortedCollection<T> {
     let wait = new PromiseAllDone();
     for (let email of needEmails) {
       if (email.dbID) {
-        wait.add((async () => {
-          await email.storage.readMessage(email);
-          (email as any).haveMetadata = true;
-        })());
+        wait.add(this.readMessageOnce(email));
       }
     }
     await wait.wait();
+  }
+
+  async readMessageOnce(email: EMail) {
+    let runOnceKey = email.dbID as number;
+    let runOnce = this.readMessageRunOnce.get(runOnceKey);
+    if (!runOnce) {
+      runOnce = new RunOnce();
+      this.readMessageRunOnce.set(runOnceKey, runOnce);
+    }
+    await runOnce.runOnce(async () => {
+      try {
+        await email.storage.readMessage(email);
+        (email as any).haveMetadata = true;
+      } finally {
+        this.readMessageRunOnce.delete(runOnceKey);
+      }
+    });
   }
 }
 


### PR DESCRIPTION
- `getIndexRange()` was getting called very often and it is necessary to call it often to feel responsive. However, it also mean't that messages were being re-read while there was already a call been made to fetch the message from the DB.

**Call Process**

1. `getIndexRange(0, 10)`, while this is not resolve another called is already made
2. `getIndexRange(3, 10)`, indexes 3-12 are redundant calls in this case and the same will repeat if you scroll further

### Fix

- Wrap readMessage in `runOnce()`

### Addition

- Now that the readMessage in `runOnce()` we can use `this.readMessagesFromDB_parallel()`