### PR TITLE
Mobile: Build: Run static copy in SSR environment

### DIFF
--- a/mobile/backend/vite.config.ts
+++ b/mobile/backend/vite.config.ts
@@ -47,6 +47,7 @@ export default defineConfig(({}) => {
       // Required for proper error messages
       esmShim(),
       viteStaticCopy({
+        environment: 'ssr',
         targets: [
           {
             src: 'dist/*',


### PR DESCRIPTION
- ViteStaticCopy only ran in client environments by default start in version `3.1.5`: https://github.com/sapphi-red/vite-plugin-static-copy/releases/tag/vite-plugin-static-copy%403.1.5
- The option to run it in SSR was not available until the recent version `3.2.0`: https://github.com/sapphi-red/vite-plugin-static-copy/releases/tag/vite-plugin-static-copy%403.2.0
- Our package.json is using `3.1.4` or higher
- This should fix the iOS build failure
- And the backend issue on Android because the backend was not being copied to the Android build