### PR TITLE
Mac: Build: Include bufferutil and utf-8-validate in x64ArchFiles - fixes #1037

### DIFF
--- a/desktop/electron-builder.yml
+++ b/desktop/electron-builder.yml
@@ -35,6 +35,7 @@ mac:
     target: default
     arch:
       - universal
+  x64ArchFiles: '**/{bufferutil,utf-8-validate}.node'
 dmg:
   artifactName: ${name}-${version}.${ext}
 linux:


### PR DESCRIPTION
- Include bufferutil and utf-8-validate in x64ArchFiles
- Both of these packages download the prebuild for all OSs and Archs and it's trying to merge the `.node` files
- The `Release/` has a `.node` file also
- This makes it keep them without trying to merge them
- Also it's a fixed based on the error message:
> "Contents/Resources/app.asar.unpacked/node_modules/bufferutil/prebuilds/darwin-arm64/bufferutil.node" that's the same in both x64 and arm64 builds and not covered by the x64ArchFiles rule: "undefined"