### PR TITLE
OWA: Support SendFromAliasEnabled

### DIFF
--- a/app/logic/Mail/OWA/OWAAccount.ts
+++ b/app/logic/Mail/OWA/OWAAccount.ts
@@ -284,7 +284,7 @@ export class OWAAccount extends MailAccount {
     if (email.replyTo) {
       addRecipients(request, "ReplyTo", [email.replyTo]);
     }
-    request.addField("Message", "From", { Name: email.from.name, EmailAddress: email.from.emailAddress }, "message:From");
+    request.addField("Message", "From", { Mailbox: { Name: email.from.name, EmailAddress: email.from.emailAddress } }, "message:From");
     addRecipients(request, "ToRecipients", email.to.contents);
     addRecipients(request, "CcReipients", email.cc.contents);
     addRecipients(request, "BccRecipients", email.bcc.contents);


### PR DESCRIPTION
It turns out that for OWA the `From` field takes its address in a nested `Mailbox` object...

Please note that this does not fix [sigh, github please don't do this] #970 - that is for sending as another user, but this is for sending as an alias.