### PR TITLE
Mail: Lock for read #1041

### DIFF
--- a/app/logic/Mail/ActiveSync/ActiveSyncEMail.ts
+++ b/app/logic/Mail/ActiveSync/ActiveSyncEMail.ts
@@ -31,27 +31,32 @@ export class ActiveSyncEMail extends EMail {
     this.pID = val;
   }
 
-  async download() {
-    let request = {
-      Fetch: {
-        Store: "Mailbox",
-        ServerId: this.serverID,
-        CollectionId: this.folder.id,
-        Options: {
-          MIMESupport: "2",
-          BodyPreference: {
-            Type: "4",
+  async download(doLock = true) {
+    let lock = doLock ? await this.readLock.lock() : null;
+    try {
+      let request = {
+        Fetch: {
+          Store: "Mailbox",
+          ServerId: this.serverID,
+          CollectionId: this.folder.id,
+          Options: {
+            MIMESupport: "2",
+            BodyPreference: {
+              Type: "4",
+            },
           },
         },
-      },
-    };
-    let response = await this.folder.account.callEAS("ItemOperations", request);
-    if (response.Response.Fetch.Status != "1") {
-      throw new ActiveSyncError("ItemOperations", response.Response.Fetch.Status, this.folder?.account);
+      };
+      let response = await this.folder.account.callEAS("ItemOperations", request);
+      if (response.Response.Fetch.Status != "1") {
+        throw new ActiveSyncError("ItemOperations", response.Response.Fetch.Status, this.folder?.account);
+      }
+      this.mime = response.Response.Fetch.Properties.Body.RawData;
+      await this.parseMIMEUnlocked();
+      await this.saveCompleteMessage();
+    } finally {
+      lock?.release();
     }
-    this.mime = response.Response.Fetch.Properties.Body.RawData;
-    await this.parseMIME();
-    await this.saveCompleteMessage();
   }
 
   fromWBXML(wbxmljs: any) {

--- a/app/logic/Mail/EMail.ts
+++ b/app/logic/Mail/EMail.ts
@@ -256,13 +256,13 @@ export class EMail extends Message {
   async parseMIME() {
     let lock = await this.readLock.lock();
     try {
-      await this.parseMIMELocked();
+      await this.parseMIMEUnlocked();
     } finally {
       lock.release();
     }
   }
 
-  protected async parseMIMELocked() {
+  protected async parseMIMEUnlocked() {
     assert(this.mime?.length, "MIME source not yet downloaded");
     assert(this.mime instanceof Uint8Array, "MIME source should be a byte array");
     //console.log("MIME source", this.mime, new TextDecoder("utf-8").decode(this.mime));
@@ -398,14 +398,14 @@ export class EMail extends Message {
           await this.storage.readMessage(this);
           await this.folder.account.contentStorage.first.read(this);
           if (this.mime) {
-            await this.parseMIMELocked();
+            await this.parseMIMEUnlocked();
             return;
           }
         } catch (ex) {
           this.folder?.account.errorCallback(ex);
         }
       }
-      await this.download();
+      await this.download(false);
     } finally {
       lock.release();
     }
@@ -448,7 +448,7 @@ export class EMail extends Message {
           await this.storage.readMessageBody(this);
         }
         if (!this._rawHTML && !this._text) {
-          await this.download();
+          await this.download(false);
         }
       }
 
@@ -481,7 +481,7 @@ export class EMail extends Message {
     super.loadExternalImages = val;
   }
 
-  async download() {
+  async download(doLock = true) {
     throw new AbstractFunction();
     //this.mime = await SMTPAccount.getMIME(this);
   }

--- a/app/logic/Mail/EWS/EWSEMail.ts
+++ b/app/logic/Mail/EWS/EWSEMail.ts
@@ -33,25 +33,30 @@ export class EWSEMail extends EMail {
     this.pID = val;
   }
 
-  async download() {
-    let request = {
-      m$GetItem: {
-        m$ItemShape: {
-          t$BaseShape: "IdOnly",
-          t$IncludeMimeContent: true,
-        },
-        m$ItemIds: {
-          t$ItemId: {
-            Id: this.itemID,
+  async download(doLock = true) {
+    let lock = doLock ? await this.readLock.lock() : null;
+    try {
+      let request = {
+        m$GetItem: {
+          m$ItemShape: {
+            t$BaseShape: "IdOnly",
+            t$IncludeMimeContent: true,
+          },
+          m$ItemIds: {
+            t$ItemId: {
+              Id: this.itemID,
+            },
           },
         },
-      },
-    };
-    let result = await this.folder.account.callEWS(request);
-    let mimeBase64 = sanitize.nonemptystring(getEWSItem(result.Items).MimeContent.Value);
-    this.mime = new Uint8Array(await base64ToArrayBuffer(mimeBase64, "message/rfc822"));
-    await this.parseMIME();
-    await this.saveCompleteMessage();
+      };
+      let result = await this.folder.account.callEWS(request);
+      let mimeBase64 = sanitize.nonemptystring(getEWSItem(result.Items).MimeContent.Value);
+      this.mime = new Uint8Array(await base64ToArrayBuffer(mimeBase64, "message/rfc822"));
+      await this.parseMIMEUnlocked();
+      await this.saveCompleteMessage();
+    } finally {
+      lock?.release();
+    }
   }
 
   fromXML(xmljs: Record<string, any>) {

--- a/app/logic/Mail/Graph/GraphEMail.ts
+++ b/app/logic/Mail/Graph/GraphEMail.ts
@@ -146,13 +146,18 @@ export class GraphEMail extends EMail {
     return e;
   }
 
-  async download() {
-    let account = this.folder.account;
-    let mime = await account.graphCall(`${this.path}/$value`, { method: "get", result: "text" }) as string;
-    assert(mime, "EMail no longer on server");
-    this.mime = new TextEncoder().encode(mime);
-    await this.parseMIME();
-    await this.saveCompleteMessage();
+  async download(doLock = true) {
+    let lock = doLock ? await this.readLock.lock() : null;
+    try {
+      let account = this.folder.account;
+      let mime = await account.graphCall(`${this.path}/$value`, { method: "get", result: "text" }) as string;
+      assert(mime, "EMail no longer on server");
+      this.mime = new TextEncoder().encode(mime);
+      await this.parseMIMEUnlocked();
+      await this.saveCompleteMessage();
+    } finally {
+      lock?.release();
+    }
   }
 
   async markRead(read = true) {

--- a/app/logic/Mail/IMAP/IMAPEMail.ts
+++ b/app/logic/Mail/IMAP/IMAPEMail.ts
@@ -27,36 +27,41 @@ export class IMAPEMail extends EMail {
     this.pID = val;
   }
 
-  async download() {
-    let msgInfo: any;
+  async download(doLock = true) {
+    let lock = doLock ? await this.readLock.lock() : null;
     try {
-      msgInfo = await this.folder.runCommand(async (conn) => {
-        this.folder.account.log(this.folder, conn, "download email", this.uid, this.subject);
-        return await conn.fetchOne(this.uid + "", {
-          uid: true,
-          size: true,
-          threadId: true,
-          envelope: true,
-          source: true,
-          flags: true,
-        }, { uid: true });
-      }, ConnectionPurpose.Display);
-    } catch (ex) {
-      if (ex.message == "IMAP UID FETCH: Invalid uidset") {
+      let msgInfo: any;
+      try {
+        msgInfo = await this.folder.runCommand(async (conn) => {
+          this.folder.account.log(this.folder, conn, "download email", this.uid, this.subject);
+          return await conn.fetchOne(this.uid + "", {
+            uid: true,
+            size: true,
+            threadId: true,
+            envelope: true,
+            source: true,
+            flags: true,
+          }, { uid: true });
+        }, ConnectionPurpose.Display);
+      } catch (ex) {
+        if (ex.message == "IMAP UID FETCH: Invalid uidset") {
+          await this.disappeared();
+          return;
+        } else {
+          throw ex;
+        }
+      }
+      if (!msgInfo.envelope) {
         await this.disappeared();
         return;
-      } else {
-        throw ex;
       }
+      this.fromFlow(msgInfo);
+      this.mime ??= msgInfo.source; // Temp HACK when `downloadComplete` == true, but mime is not there
+      await this.parseMIMEUnlocked();
+      await this.saveCompleteMessage();
+    } finally {
+      lock?.release();
     }
-    if (!msgInfo.envelope) {
-      await this.disappeared();
-      return;
-    }
-    this.fromFlow(msgInfo);
-    this.mime ??= msgInfo.source; // Temp HACK when `downloadComplete` == true, but mime is not there
-    await this.parseMIME();
-    await this.saveCompleteMessage();
   }
 
   fromFlow(msgInfo: any) {

--- a/app/logic/Mail/JMAP/JMAPEMail.ts
+++ b/app/logic/Mail/JMAP/JMAPEMail.ts
@@ -146,37 +146,42 @@ export class JMAPEMail extends EMail {
     return e;
   }
 
-  async download() {
-    let account = this.folder.account;
-    if (!this.mimeBlobId) {
-      let response = await account.makeSingleCall(
-        "Email/get", {
-        accountId: account.accountID,
-        "ids": [this.jmapID],
-        properties: ["blobId"],
-      },
-      ) as TJMAPGetResponse<TJMAPEMailHeaders>;
-      let json = response.list[0];
-      assert(json, "JMAP: EMail no longer on server");
-      this.mimeBlobId = sanitize.string(json.blobId);
-    }
+  async download(doLock = true) {
+    let lock = doLock ? await this.readLock.lock() : null;
+    try {
+      let account = this.folder.account;
+      if (!this.mimeBlobId) {
+        let response = await account.makeSingleCall(
+          "Email/get", {
+          accountId: account.accountID,
+          "ids": [this.jmapID],
+          properties: ["blobId"],
+        },
+        ) as TJMAPGetResponse<TJMAPEMailHeaders>;
+        let json = response.list[0];
+        assert(json, "JMAP: EMail no longer on server");
+        this.mimeBlobId = sanitize.string(json.blobId);
+      }
 
-    let url = account.session.downloadUrl;
-    url = url
-      .replace("{accountId}", account.accountID)
-      .replace("{blobId}", this.mimeBlobId)
-      .replace("{name}", "email")
-      .replace("{type}", "message/rfc822");
-    let response = await account.httpGet(url, {
-      headers: {
-        "Accept": "message/rfc822",
-        "Content-Type": undefined, // override
-      },
-      result: "blob",
-    });
-    this.mime = new Uint8Array(await response.arrayBuffer());
-    await this.parseMIME();
-    await this.saveCompleteMessage();
+      let url = account.session.downloadUrl;
+      url = url
+        .replace("{accountId}", account.accountID)
+        .replace("{blobId}", this.mimeBlobId)
+        .replace("{name}", "email")
+        .replace("{type}", "message/rfc822");
+      let response = await account.httpGet(url, {
+        headers: {
+          "Accept": "message/rfc822",
+          "Content-Type": undefined, // override
+        },
+        result: "blob",
+      });
+      this.mime = new Uint8Array(await response.arrayBuffer());
+      await this.parseMIMEUnlocked();
+      await this.saveCompleteMessage();
+    } finally {
+      lock?.release();
+    }
   }
 
   async markRead(read = true) {

--- a/app/logic/Mail/OWA/OWAEMail.ts
+++ b/app/logic/Mail/OWA/OWAEMail.ts
@@ -26,12 +26,17 @@ export class OWAEMail extends EMail {
     this.pID = val;
   }
 
-  async download() {
-    let result = await this.folder.account.callOWA(owaDownloadMsgsRequest([ this ]));
-    let mimeBase64 = sanitize.nonemptystring(result.Items[0].MimeContent.Value);
-    this.mime = new Uint8Array(await base64ToArrayBuffer(mimeBase64, "message/rfc822"));
-    await this.parseMIME();
-    await this.saveCompleteMessage();
+  async download(doLock = true) {
+    let lock = doLock ? await this.readLock.lock() : null;
+    try {
+      let result = await this.folder.account.callOWA(owaDownloadMsgsRequest([ this ]));
+      let mimeBase64 = sanitize.nonemptystring(result.Items[0].MimeContent.Value);
+      this.mime = new Uint8Array(await base64ToArrayBuffer(mimeBase64, "message/rfc822"));
+      await this.parseMIMEUnlocked();
+      await this.saveCompleteMessage();
+    } finally {
+      lock?.release();
+    }
   }
 
   fromJSON(json: Record<string, any>) {


### PR DESCRIPTION
* When displaying an email that has not been downloaded yet, we flash the body display 4 times, visibly.
* Add lock around functions that read from DB, fetch from server, or parse the MIME, i.e. anything that will set the body and trigger `loadedBody` to change.
