### PR TITLE
Mail: Update html only on change - fixes #1041

### DIFF
--- a/app/logic/Mail/EMail.ts
+++ b/app/logic/Mail/EMail.ts
@@ -430,6 +430,9 @@ export class EMail extends Message {
     return super.html;
   }
   set html(val: string) {
+    if (this._rawHTML == val) {
+      return;
+    }
     super.html = val;
     this.loadedBody = false;
   }


### PR DESCRIPTION
- If html is the same don't set `loadedBody` to false because that makes it update
- But also don't set `super.html` because it sets the sanitizedHTML to `null`
- parseMIME and some other functions always set the html which set `loadedBody` to `false` even if the html is the same
- follow up to eece6ea4e7673cd7018419c4d5fb0c025d9d5c86