### PR TITLE
Mail: RunOnce for download() and downloadMessages()

### DIFF
--- a/app/logic/Mail/ActiveSync/ActiveSyncEMail.ts
+++ b/app/logic/Mail/ActiveSync/ActiveSyncEMail.ts
@@ -32,26 +32,28 @@ export class ActiveSyncEMail extends EMail {
   }
 
   async download() {
-    let request = {
-      Fetch: {
-        Store: "Mailbox",
-        ServerId: this.serverID,
-        CollectionId: this.folder.id,
-        Options: {
-          MIMESupport: "2",
-          BodyPreference: {
-            Type: "4",
+    await this.downloadRunOnce.runOnce(async () => {
+      let request = {
+        Fetch: {
+          Store: "Mailbox",
+          ServerId: this.serverID,
+          CollectionId: this.folder.id,
+          Options: {
+            MIMESupport: "2",
+            BodyPreference: {
+              Type: "4",
+            },
           },
         },
-      },
-    };
-    let response = await this.folder.account.callEAS("ItemOperations", request);
-    if (response.Response.Fetch.Status != "1") {
-      throw new ActiveSyncError("ItemOperations", response.Response.Fetch.Status, this.folder?.account);
-    }
-    this.mime = response.Response.Fetch.Properties.Body.RawData;
-    await this.parseMIME();
-    await this.saveCompleteMessage();
+      };
+      let response = await this.folder.account.callEAS("ItemOperations", request);
+      if (response.Response.Fetch.Status != "1") {
+        throw new ActiveSyncError("ItemOperations", response.Response.Fetch.Status, this.folder?.account);
+      }
+      this.mime = response.Response.Fetch.Properties.Body.RawData;
+      await this.parseMIME();
+      await this.saveCompleteMessage();
+    });
   }
 
   fromWBXML(wbxmljs: any) {

--- a/app/logic/Mail/ActiveSync/ActiveSyncFolder.ts
+++ b/app/logic/Mail/ActiveSync/ActiveSyncFolder.ts
@@ -186,6 +186,7 @@ export class ActiveSyncFolder extends Folder implements ActiveSyncPingable {
     let emailsToDownload = emails.contents;
     for (let i = 0; i < emailsToDownload.length; i += kMaxCount) {
       let batch = emailsToDownload.slice(i, i + kMaxCount);
+      batch = batch.filter((email) => !email.downloadRunOnce.running);
       let request = {
         Fetch: batch.map(email => ({
           Store: "Mailbox",

--- a/app/logic/Mail/EMail.ts
+++ b/app/logic/Mail/EMail.ts
@@ -20,6 +20,7 @@ import { sanitize } from "../../../lib/util/sanitizeDatatypes";
 import { PromiseAllDone } from "../util/flow/PromiseAllDone";
 import { notifyChangedProperty } from "../util/Observable";
 import { Lock } from "../util/flow/Lock";
+import { RunOnce } from "../util/flow/RunOnce";
 import { logError } from "../../frontend/Util/error";
 import { Collection, ArrayColl, MapColl, SetColl } from "svelte-collections";
 import PostalMIME from "postal-mime";
@@ -445,6 +446,7 @@ export class EMail extends Message {
     super.loadExternalImages = val;
   }
 
+  readonly downloadRunOnce = new RunOnce<void>();
   async download() {
     throw new AbstractFunction();
     //this.mime = await SMTPAccount.getMIME(this);

--- a/app/logic/Mail/EWS/EWSEMail.ts
+++ b/app/logic/Mail/EWS/EWSEMail.ts
@@ -34,24 +34,26 @@ export class EWSEMail extends EMail {
   }
 
   async download() {
-    let request = {
-      m$GetItem: {
-        m$ItemShape: {
-          t$BaseShape: "IdOnly",
-          t$IncludeMimeContent: true,
-        },
-        m$ItemIds: {
-          t$ItemId: {
-            Id: this.itemID,
+    await this.downloadRunOnce.runOnce(async () => {
+      let request = {
+        m$GetItem: {
+          m$ItemShape: {
+            t$BaseShape: "IdOnly",
+            t$IncludeMimeContent: true,
+          },
+          m$ItemIds: {
+            t$ItemId: {
+              Id: this.itemID,
+            },
           },
         },
-      },
-    };
-    let result = await this.folder.account.callEWS(request);
-    let mimeBase64 = sanitize.nonemptystring(getEWSItem(result.Items).MimeContent.Value);
-    this.mime = new Uint8Array(await base64ToArrayBuffer(mimeBase64, "message/rfc822"));
-    await this.parseMIME();
-    await this.saveCompleteMessage();
+      };
+      let result = await this.folder.account.callEWS(request);
+      let mimeBase64 = sanitize.nonemptystring(getEWSItem(result.Items).MimeContent.Value);
+      this.mime = new Uint8Array(await base64ToArrayBuffer(mimeBase64, "message/rfc822"));
+      await this.parseMIME();
+      await this.saveCompleteMessage();
+    });
   }
 
   fromXML(xmljs: Record<string, any>) {

--- a/app/logic/Mail/EWS/EWSFolder.ts
+++ b/app/logic/Mail/EWS/EWSFolder.ts
@@ -322,6 +322,7 @@ export class EWSFolder extends Folder {
     let emailsToDownload = emails.contents;
     for (let i = 0; i < emailsToDownload.length; i += kMaxCount) {
       let batch = emailsToDownload.slice(i, i + kMaxCount);
+      batch = batch.filter((email) => !email.downloadRunOnce.running);
       let request = {
         m$GetItem: {
           m$ItemShape: {

--- a/app/logic/Mail/Graph/GraphEMail.ts
+++ b/app/logic/Mail/Graph/GraphEMail.ts
@@ -147,12 +147,14 @@ export class GraphEMail extends EMail {
   }
 
   async download() {
-    let account = this.folder.account;
-    let mime = await account.graphCall(`${this.path}/$value`, { method: "get", result: "text" }) as string;
-    assert(mime, "EMail no longer on server");
-    this.mime = new TextEncoder().encode(mime);
-    await this.parseMIME();
-    await this.saveCompleteMessage();
+    await this.downloadRunOnce.runOnce(async () => {
+      let account = this.folder.account;
+      let mime = await account.graphCall(`${this.path}/$value`, { method: "get", result: "text" }) as string;
+      assert(mime, "EMail no longer on server");
+      this.mime = new TextEncoder().encode(mime);
+      await this.parseMIME();
+      await this.saveCompleteMessage();
+    });
   }
 
   async markRead(read = true) {

--- a/app/logic/Mail/Graph/GraphFolder.ts
+++ b/app/logic/Mail/Graph/GraphFolder.ts
@@ -221,6 +221,9 @@ export class GraphFolder extends Folder {
     let semaphore = new Semaphore(kMaxParallelCount);
     while (needMsgs.hasItems) {
       let msg = needMsgs.pop();
+      if (msg.downloadRunOnce.running) {
+        continue;
+      }
       let lock = await semaphore.lock();
       (async () => {
         try {

--- a/app/logic/Mail/IMAP/IMAPEMail.ts
+++ b/app/logic/Mail/IMAP/IMAPEMail.ts
@@ -28,35 +28,37 @@ export class IMAPEMail extends EMail {
   }
 
   async download() {
-    let msgInfo: any;
-    try {
-      msgInfo = await this.folder.runCommand(async (conn) => {
-        this.folder.account.log(this.folder, conn, "download email", this.uid, this.subject);
-        return await conn.fetchOne(this.uid + "", {
-          uid: true,
-          size: true,
-          threadId: true,
-          envelope: true,
-          source: true,
-          flags: true,
-        }, { uid: true });
-      }, ConnectionPurpose.Display);
-    } catch (ex) {
-      if (ex.message == "IMAP UID FETCH: Invalid uidset") {
+    await this.downloadRunOnce.runOnce(async () => {
+      let msgInfo: any;
+      try {
+        msgInfo = await this.folder.runCommand(async (conn) => {
+          this.folder.account.log(this.folder, conn, "download email", this.uid, this.subject);
+          return await conn.fetchOne(this.uid + "", {
+            uid: true,
+            size: true,
+            threadId: true,
+            envelope: true,
+            source: true,
+            flags: true,
+          }, { uid: true });
+        }, ConnectionPurpose.Display);
+      } catch (ex) {
+        if (ex.message == "IMAP UID FETCH: Invalid uidset") {
+          await this.disappeared();
+          return;
+        } else {
+          throw ex;
+        }
+      }
+      if (!msgInfo.envelope) {
         await this.disappeared();
         return;
-      } else {
-        throw ex;
       }
-    }
-    if (!msgInfo.envelope) {
-      await this.disappeared();
-      return;
-    }
-    this.fromFlow(msgInfo);
-    this.mime ??= msgInfo.source; // Temp HACK when `downloadComplete` == true, but mime is not there
-    await this.parseMIME();
-    await this.saveCompleteMessage();
+      this.fromFlow(msgInfo);
+      this.mime ??= msgInfo.source; // Temp HACK when `downloadComplete` == true, but mime is not there
+      await this.parseMIME();
+      await this.saveCompleteMessage();
+    });
   }
 
   fromFlow(msgInfo: any) {

--- a/app/logic/Mail/IMAP/IMAPFolder.ts
+++ b/app/logic/Mail/IMAP/IMAPFolder.ts
@@ -313,6 +313,7 @@ export class IMAPFolder extends Folder {
     const kMaxCount = 50;
     while (needMsgs.hasItems) {
       let downloadingMsgs = needMsgs.getIndexRange(needMsgs.length - kMaxCount, kMaxCount);
+      downloadingMsgs = downloadingMsgs.filter((msg) => !msg.downloadRunOnce.running);
       needMsgs.removeAll(downloadingMsgs);
       let uids = downloadingMsgs.map(msg => msg.uid).join(",");
       await this.runCommand(async (conn) => {

--- a/app/logic/Mail/JMAP/JMAPEMail.ts
+++ b/app/logic/Mail/JMAP/JMAPEMail.ts
@@ -147,36 +147,38 @@ export class JMAPEMail extends EMail {
   }
 
   async download() {
-    let account = this.folder.account;
-    if (!this.mimeBlobId) {
-      let response = await account.makeSingleCall(
-        "Email/get", {
-        accountId: account.accountID,
-        "ids": [this.jmapID],
-        properties: ["blobId"],
-      },
-      ) as TJMAPGetResponse<TJMAPEMailHeaders>;
-      let json = response.list[0];
-      assert(json, "JMAP: EMail no longer on server");
-      this.mimeBlobId = sanitize.string(json.blobId);
-    }
+    await this.downloadRunOnce.runOnce(async () => {
+      let account = this.folder.account;
+      if (!this.mimeBlobId) {
+        let response = await account.makeSingleCall(
+          "Email/get", {
+          accountId: account.accountID,
+          "ids": [this.jmapID],
+          properties: ["blobId"],
+        },
+        ) as TJMAPGetResponse<TJMAPEMailHeaders>;
+        let json = response.list[0];
+        assert(json, "JMAP: EMail no longer on server");
+        this.mimeBlobId = sanitize.string(json.blobId);
+      }
 
-    let url = account.session.downloadUrl;
-    url = url
-      .replace("{accountId}", account.accountID)
-      .replace("{blobId}", this.mimeBlobId)
-      .replace("{name}", "email")
-      .replace("{type}", "message/rfc822");
-    let response = await account.httpGet(url, {
-      headers: {
-        "Accept": "message/rfc822",
-        "Content-Type": undefined, // override
-      },
-      result: "blob",
+      let url = account.session.downloadUrl;
+      url = url
+        .replace("{accountId}", account.accountID)
+        .replace("{blobId}", this.mimeBlobId)
+        .replace("{name}", "email")
+        .replace("{type}", "message/rfc822");
+      let response = await account.httpGet(url, {
+        headers: {
+          "Accept": "message/rfc822",
+          "Content-Type": undefined, // override
+        },
+        result: "blob",
+      });
+      this.mime = new Uint8Array(await response.arrayBuffer());
+      await this.parseMIME();
+      await this.saveCompleteMessage();
     });
-    this.mime = new Uint8Array(await response.arrayBuffer());
-    await this.parseMIME();
-    await this.saveCompleteMessage();
   }
 
   async markRead(read = true) {

--- a/app/logic/Mail/JMAP/JMAPFolder.ts
+++ b/app/logic/Mail/JMAP/JMAPFolder.ts
@@ -308,6 +308,9 @@ export class JMAPFolder extends Folder {
     let semaphore = new Semaphore(kMaxParallelCount);
     while (needMsgs.hasItems) {
       let msg = needMsgs.pop();
+      if (msg.downloadRunOnce.running) {
+        continue;
+      }
       let lock = await semaphore.lock();
       (async () => {
         try {

--- a/app/logic/Mail/OWA/OWAEMail.ts
+++ b/app/logic/Mail/OWA/OWAEMail.ts
@@ -27,11 +27,13 @@ export class OWAEMail extends EMail {
   }
 
   async download() {
-    let result = await this.folder.account.callOWA(owaDownloadMsgsRequest([ this ]));
-    let mimeBase64 = sanitize.nonemptystring(result.Items[0].MimeContent.Value);
-    this.mime = new Uint8Array(await base64ToArrayBuffer(mimeBase64, "message/rfc822"));
-    await this.parseMIME();
-    await this.saveCompleteMessage();
+    await this.downloadRunOnce.runOnce(async () => {
+      let result = await this.folder.account.callOWA(owaDownloadMsgsRequest([ this ]));
+      let mimeBase64 = sanitize.nonemptystring(result.Items[0].MimeContent.Value);
+      this.mime = new Uint8Array(await base64ToArrayBuffer(mimeBase64, "message/rfc822"));
+      await this.parseMIME();
+      await this.saveCompleteMessage();
+    });
   }
 
   fromJSON(json: Record<string, any>) {

--- a/app/logic/Mail/OWA/OWAFolder.ts
+++ b/app/logic/Mail/OWA/OWAFolder.ts
@@ -152,6 +152,7 @@ export class OWAFolder extends Folder {
     let emailsToDownload = emails.contents;
     for (let i = 0; i < emailsToDownload.length; i += kMaxFetchCount) {
       let batch = emailsToDownload.slice(i, i + kMaxFetchCount);
+      batch = batch.filter((email) => !email.downloadRunOnce.running);
       let results = await this.account.callOWA(owaDownloadMsgsRequest(batch));
       let items = results.ResponseMessages ? results.ResponseMessages.Items.map(item => item.Items[0]) : results.Items;
       for (let item of items) {


### PR DESCRIPTION
- There are multiple functions call downloading the same email at once and all call return the same result
- For IMAP the email is being downloaded twice
- Subsequent downloads for the same email are unnecessary
- `loadBody()`, `loadForDisplay()`, `downloadMessages()` do the same thing are called in parallel
- `showNewMail()` might also call `download()` in parallel
- Fixes `download()` calls mentioned in https://github.com/mustang-im/mustang/issues/1041#issuecomment-3969816167