### PR TITLE
IMAP: Check for message deletion or empty envelope - fixes #1019

### DIFF
--- a/app/logic/Mail/IMAP/IMAPEMail.ts
+++ b/app/logic/Mail/IMAP/IMAPEMail.ts
@@ -50,7 +50,7 @@ export class IMAPEMail extends EMail {
           throw ex;
         }
       }
-      if (!msgInfo.envelope) {
+      if (!msgInfo.envelope || this.folder.deletions.has(msgInfo.uid)) {
         await this.disappeared();
         return;
       }

--- a/app/logic/Mail/IMAP/IMAPFolder.ts
+++ b/app/logic/Mail/IMAP/IMAPFolder.ts
@@ -329,7 +329,7 @@ export class IMAPFolder extends Folder {
         }, { uid: true });
         for await (let msgInfo of msgInfos) {
           try {
-            if (this.deletions.has(msgInfo.uid)) {
+            if (!msgInfo.envelope || this.deletions.has(msgInfo.uid)) {
               continue;
             }
             let msg = this.getEMailByUID(msgInfo.uid);


### PR DESCRIPTION
- Check if msgInfo.envelope is exists before performing any actions
- Check if the message was deleted from the folder