### PR TITLE
Build: Allow seeing node.js network traffic including fetch() in Chrome DevTools

### DIFF
--- a/desktop/package.json
+++ b/desktop/package.json
@@ -32,6 +32,7 @@
     "bufferutil": "^4.1.0",
     "electron-updater": "^6.3.3",
     "node-network-devtools": "^1.0.29",
+    "undici": "^7.22.0",
     "utf-8-validate": "^6.0.6",
     "ws": "^8.19.0"
   },

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -31,6 +31,7 @@
     "better-sqlite3": "^12.5.0",
     "bufferutil": "^4.1.0",
     "electron-updater": "^6.3.3",
+    "node-network-devtools": "^1.0.29",
     "utf-8-validate": "^6.0.6",
     "ws": "^8.19.0"
   },

--- a/desktop/src/main/index.ts
+++ b/desktop/src/main/index.ts
@@ -4,6 +4,7 @@ import { ipcMain } from 'electron/main';
 import { join } from 'path'
 import electronUpdater from 'electron-updater';
 import { electronApp, optimizer, is } from '@electron-toolkit/utils'
+import { register as enableNetworkDebugging } from 'node-network-devtools'
 import icon from '../../build/icon.png?asset'
 const { autoUpdater } = electronUpdater;
 
@@ -109,6 +110,7 @@ async function whenReady() {
   handleCommandline(process.argv.splice(1));
 
   allowCrossDomainRequestsFromFrontend();
+  is.dev && enableNetworkDebugging();
 
   // Default open or close DevTools by F12 in development
   // and ignore CommandOrControl + R in production.
@@ -218,6 +220,3 @@ function allowCrossDomainRequestsFromFrontend() {
     }
   );
 }
-
-// In this file you can include the rest of your app"s specific main process
-// code. You can also put them in separate files and require them here.

--- a/desktop/src/main/index.ts
+++ b/desktop/src/main/index.ts
@@ -110,7 +110,16 @@ async function whenReady() {
   handleCommandline(process.argv.splice(1));
 
   allowCrossDomainRequestsFromFrontend();
-  is.dev && enableNetworkDebugging();
+  is.dev && enableNetworkDebugging({
+    intercept: {
+      fetch: true,
+      normal: true,
+      undici: {
+        fetch: true,
+        normal: true,
+      }
+    }
+  });
 
   // Default open or close DevTools by F12 in development
   // and ignore CommandOrControl + R in production.


### PR DESCRIPTION
To debug, we need to see the network requests that our app does. To get around cross-origin limitations of Chrome, almost all of them happen in the node.js. So, we need to see those.

Once this works, a developer should be able to do:
* `cd desktop/; yarn debug` (instead of `dev`)
* Start Chrome
* Type `chrome://inspect`
* Enable "[x] Discover network targets"
* Below "Remote target", you should see `localhost:9222`
* Below it, there is a small blue link "Inspect". Click that.
* You should see the normal Chrome DevTools, but now connected to node.js, instead of the webpage
* Open the "Networking" tab
* Check an EWS account, or any other HTTPS-based account
* You should see a network call in the DevTools.

But you don't. In node.js, we use `ky`, which uses node `fetch()`, which uses `undici`, not `http`. Unfortunately, the new network debugging in node.js 22.6.0+ only supports `http` and not `undici`, so the calls don't appear. @jermy-c Can you look into this, please?