### PR TITLE
Mail: Select correct email after deleting - fixes #1055

### DIFF
--- a/app/frontend/Mail/3pane/TableMessageListItem.svelte
+++ b/app/frontend/Mail/3pane/TableMessageListItem.svelte
@@ -97,9 +97,9 @@
 </ContextMenu>
 <Popup bind:popupOpen {popupAnchor} placement="bottom" boundaryElSel=".message-list-pane">
   {#if $selectedMessages.length > 1 && $selectedMessages.contains(message)}
-    <MessageMovePopup messages={$selectedMessages} on:close={onPopupClose} bind:selectedMessage={$selectedMessage} />
+    <MessageMovePopup messages={$selectedMessages} on:close={onPopupClose} />
   {:else}
-    <MessageMovePopup messages={new ArrayColl([message])} on:close={onPopupClose} bind:selectedMessage={$selectedMessage} />
+    <MessageMovePopup messages={new ArrayColl([message])} on:close={onPopupClose} />
   {/if}
 </Popup>
 
@@ -107,7 +107,7 @@
   import type { EMail } from "../../../logic/Mail/EMail";
   import { personDisplayName } from "../../../logic/Abstract/PersonUID";
   import { onDragStartMail } from "../Message/drag";
-  import { selectedMessage, selectedMessages } from "../Selected";
+  import { selectedMessages } from "../Selected";
   import MessageMenu from "../Message/MessageMenu.svelte";
   import MessageMovePopup from "../Message/MessageMovePopup.svelte";
   import TagSelector from "../../Shared/Tag/TagSelector.svelte";

--- a/app/frontend/Mail/Message/MessageDisplayBarM.svelte
+++ b/app/frontend/Mail/Message/MessageDisplayBarM.svelte
@@ -66,7 +66,7 @@
   </AppBarM>
 </hbox>
 <Popup bind:popupOpen popupAnchor={popupAnchorE} placement="bottom" boundaryElSel=".message-list-pane">
-  <MessageMovePopup messages={new ArrayColl([message])} on:close={onPopupClose} bind:selectedMessage={message} />
+  <MessageMovePopup messages={new ArrayColl([message])} on:close={onPopupClose} />
 </Popup>
 
 <Print {message} bind:this={printE} />

--- a/app/frontend/Mail/Message/MessageMovePopup.svelte
+++ b/app/frontend/Mail/Message/MessageMovePopup.svelte
@@ -84,6 +84,7 @@
 <script lang="ts">
   import type { EMail } from "../../../logic/Mail/EMail";
   import type { Folder } from "../../../logic/Mail/Folder";
+  import { selectedMessage } from "../Selected";
   import { availableTags } from "../../../logic/Abstract/Tag";
   import { appGlobal } from "../../../logic/app";
   import TagSelector from "../../Shared/Tag/TagSelector.svelte";
@@ -103,14 +104,13 @@
   const dispatch = createEventDispatcher<{ close: void }>();
 
   export let messages: Collection<EMail>;
-  /** out */
-  export let selectedMessage: EMail;
 
   let sourceFolder = messages.first.folder;
   let selectedFolder = sourceFolder;
   let selectedFolders = new ArrayColl<Folder>();
   let selectedAccount = sourceFolder.account;
   let selectedMessageIndex = sourceFolder.messages.getKeyForValue(messages.first);
+  let wasSelected = $selectedMessage == messages.first; // just safety measure
   let showAccounts = false;
 
   function onClose() {
@@ -150,7 +150,11 @@
   }
 
   function goToNextMessage() {
-    selectedMessage = sourceFolder.messages.getIndex(selectedMessageIndex) ??
+    if (!wasSelected) {
+      return;
+    }
+    $selectedMessage =
+      sourceFolder.messages.getIndex(selectedMessageIndex) ??
       sourceFolder.messages.first ??
       sourceFolder.account.inbox.messages.first ??
       sourceFolder.newEMail();

--- a/app/frontend/Mail/Message/MessageToolbar.svelte
+++ b/app/frontend/Mail/Message/MessageToolbar.svelte
@@ -92,7 +92,7 @@
   </hbox>
 </hbox>
 <Popup bind:popupOpen popupAnchor={popupAnchorE} placement="bottom" boundaryElSel=".message-list-pane">
-  <MessageMovePopup messages={new ArrayColl([message])} on:close={onPopupClose} bind:selectedMessage={message} />
+  <MessageMovePopup messages={new ArrayColl([message])} on:close={onPopupClose} />
 </Popup>
 
 <Print {message} bind:this={printE} />

--- a/app/frontend/Mail/Vertical/VerticalMessageListItem.svelte
+++ b/app/frontend/Mail/Vertical/VerticalMessageListItem.svelte
@@ -97,9 +97,9 @@
 </ContextMenu>
 <Popup bind:popupOpen {popupAnchor} placement="bottom-end" boundaryElSel=".message-list-pane">
   {#if $selectedMessages.length > 1 && $selectedMessages.contains(message)}
-    <MessageMovePopup messages={$selectedMessages} on:close={onPopupClose} bind:selectedMessage={$selectedMessage} />
+    <MessageMovePopup messages={$selectedMessages} on:close={onPopupClose} />
   {:else}
-    <MessageMovePopup messages={new ArrayColl([message])} on:close={onPopupClose} bind:selectedMessage={$selectedMessage} />
+    <MessageMovePopup messages={new ArrayColl([message])} on:close={onPopupClose} />
   {/if}
 </Popup>
 


### PR DESCRIPTION
- The out prop for selectedMessage was being outputted to the renderItem instead of the selectedMessage store
- `selectedMessage.nextMessage()` never did anything or selected a message in another folder
- We save the messageIndex as soon as the popup is created so we get the index in the target folder
- The while loop could possibly cause some updates while it's looping