### PR TITLE
MailRoutes: unbind selectedFolder

### DIFF
--- a/app/frontend/Mail/MailRoutes.svelte
+++ b/app/frontend/Mail/MailRoutes.svelte
@@ -8,7 +8,7 @@
     <MsgListM
       messages={searchMessages ?? params?.messages ?? $selectedFolder?.messages ?? requiredParam()}
       bind:searchMessages
-      bind:selectedFolder={$selectedFolder}
+      selectedFolder={$selectedFolder}
       bind:selectedMessage={$selectedMessage}
       bind:selectedMessages={$selectedMessages} />
   </Route>

--- a/app/frontend/Mail/Vertical/MessageListM.svelte
+++ b/app/frontend/Mail/Vertical/MessageListM.svelte
@@ -29,7 +29,7 @@
 
   export let messages: ArrayColl<EMail>; /** in */
   export let searchMessages: ArrayColl<EMail> | null; /** out */
-  export let selectedFolder: Folder; /** in/out */
+  export let selectedFolder: Folder; /** in */
   export let selectedMessage: EMail; /** in/out */
   export let selectedMessages: ArrayColl<EMail>; /** in/out */
 


### PR DESCRIPTION
- The binding `$selectedFolder` was triggering an update which called `loadFolder` twice
- Binding in Svelte seems to be causing extra updates in versions prior to Svelte5: https://github.com/sveltejs/svelte/issues/6298#issue-875675427
- `$selectedFolder` is an _in_ param
- Fixes: https://github.com/mustang-im/mustang/issues/1055#issuecomment-4001112587