### PR TITLE
Mail: SQL: Turn on WAL mode and minimize duplicates - fixes #1065

### DIFF
--- a/app/logic/Mail/EMail.ts
+++ b/app/logic/Mail/EMail.ts
@@ -191,6 +191,11 @@ export class EMail extends Message {
     this.isDeleted = true;
     this.folder.messages.remove(this);
     await this.storage.deleteMessage(this);
+    let contentDeletes = new PromiseAllDone();
+    for (let contentStorage of this.folder.account.contentStorage) {
+      contentDeletes.add(contentStorage.deleteIt(this));
+    }
+    await contentDeletes.wait();
   }
 
   async deleteMessageOnServer() {

--- a/app/logic/Mail/SQL/SQLDatabase.ts
+++ b/app/logic/Mail/SQL/SQLDatabase.ts
@@ -1,5 +1,6 @@
 import { appGlobal } from "../../app";
 import { mailDatabaseSchema } from "./createDatabase";
+import { createFolderIDDateSentIndex } from "./SQLEmailMigrate";
 import sql, { type Database } from "../../../../lib/rs-sqlite/index";
 import { getSQLiteDatabase } from "../../util/backend-wrapper";
 
@@ -12,7 +13,7 @@ export async function getDatabase(): Promise<Database> {
     return mailDatabase;
   }
   mailDatabase = await getSQLiteDatabase("mail.db");
-  await mailDatabase.migrate(mailDatabaseSchema);
+  await mailDatabase.migrate(mailDatabaseSchema, createFolderIDDateSentIndex);
   await mailDatabase.pragma('foreign_keys = true');
   await mailDatabase.pragma('journal_mode = WAL');
   return mailDatabase;

--- a/app/logic/Mail/SQL/SQLEmailMigrate.ts
+++ b/app/logic/Mail/SQL/SQLEmailMigrate.ts
@@ -1,8 +1,7 @@
 import sql from "../../../../lib/rs-sqlite";
 
 // <copied from="createDatabase.ts">
-// Runs or fails silently and doesn't increment user_version
 export const createFolderIDDateSentIndex = sql`
-  CREATE INDEX index_email_folderID_dateSent
+  CREATE INDEX IF NOT EXISTS index_email_folderID_dateSent
   ON email (folderID, dateSent DESC);
 `;

--- a/app/logic/Mail/SQL/SQLEmailMigrate.ts
+++ b/app/logic/Mail/SQL/SQLEmailMigrate.ts
@@ -1,0 +1,8 @@
+import sql from "../../../../lib/rs-sqlite";
+
+// <copied from="createDatabase.ts">
+// Runs or fails silently and doesn't increment user_version
+export const createFolderIDDateSentIndex = sql`
+  CREATE INDEX index_email_folderID_dateSent
+  ON email (folderID, dateSent DESC);
+`;

--- a/app/logic/Mail/SQL/Source/SQLSourceDatabase.ts
+++ b/app/logic/Mail/SQL/Source/SQLSourceDatabase.ts
@@ -1,7 +1,7 @@
 import { appGlobal } from "../../../app";
 import type { Database } from "../../../../../lib/rs-sqlite/index";
 import { mailSourceDatabaseSchema } from "./createSourceDatabase";
-import { migrateToNewSchema } from "./SQLSourceEMailMigrate";
+import { migrateToNewSchema } from "./SQLSourceEmailMigrate";
 import { getConfigDir, getSQLiteDatabase } from "../../../util/backend-wrapper";
 
 let mailSourceDatabase: Database;

--- a/app/logic/Mail/SQL/Source/SQLSourceDatabase.ts
+++ b/app/logic/Mail/SQL/Source/SQLSourceDatabase.ts
@@ -1,7 +1,7 @@
 import { appGlobal } from "../../../app";
 import type { Database } from "../../../../../lib/rs-sqlite/index";
 import { mailSourceDatabaseSchema } from "./createSourceDatabase";
-import { migrateToNewSchema } from "./SQLSourceEmailMigrate";
+import { migrateToNewSchema } from "./SQLSourceEMailMigrate";
 import { getConfigDir, getSQLiteDatabase } from "../../../util/backend-wrapper";
 
 let mailSourceDatabase: Database;
@@ -15,8 +15,7 @@ export async function getDatabase(): Promise<Database> {
   await appGlobal.remoteApp.fs.mkdir(dir, { recursive: true, mode: 0o700 });
   let file = await appGlobal.remoteApp.path.join("backup", "mail-backup.db");
   mailSourceDatabase = await getSQLiteDatabase(file);
-  await mailSourceDatabase.migrate(mailSourceDatabaseSchema);
-  await migrateToNewSchema(mailSourceDatabase);
+  await mailSourceDatabase.migrate(mailSourceDatabaseSchema, migrateToNewSchema);
   await mailSourceDatabase.pragma('journal_mode = WAL');
   return mailSourceDatabase;
 }

--- a/app/logic/Mail/SQL/Source/SQLSourceDatabase.ts
+++ b/app/logic/Mail/SQL/Source/SQLSourceDatabase.ts
@@ -1,6 +1,7 @@
 import { appGlobal } from "../../../app";
 import type { Database } from "../../../../../lib/rs-sqlite/index";
 import { mailSourceDatabaseSchema } from "./createSourceDatabase";
+import { migrateToNewSchema } from "./SQLSourceEmailMigrate";
 import { getConfigDir, getSQLiteDatabase } from "../../../util/backend-wrapper";
 
 let mailSourceDatabase: Database;
@@ -15,6 +16,7 @@ export async function getDatabase(): Promise<Database> {
   let file = await appGlobal.remoteApp.path.join("backup", "mail-backup.db");
   mailSourceDatabase = await getSQLiteDatabase(file);
   await mailSourceDatabase.migrate(mailSourceDatabaseSchema);
+  await migrateToNewSchema(mailSourceDatabase);
   await mailSourceDatabase.pragma('journal_mode = WAL');
   return mailSourceDatabase;
 }

--- a/app/logic/Mail/SQL/Source/SQLSourceDatabase.ts
+++ b/app/logic/Mail/SQL/Source/SQLSourceDatabase.ts
@@ -15,5 +15,6 @@ export async function getDatabase(): Promise<Database> {
   let file = await appGlobal.remoteApp.path.join("backup", "mail-backup.db");
   mailSourceDatabase = await getSQLiteDatabase(file);
   await mailSourceDatabase.migrate(mailSourceDatabaseSchema);
+  await mailSourceDatabase.pragma('journal_mode = WAL');
   return mailSourceDatabase;
 }

--- a/app/logic/Mail/SQL/Source/SQLSourceEmailMigrate.ts
+++ b/app/logic/Mail/SQL/Source/SQLSourceEmailMigrate.ts
@@ -1,39 +1,33 @@
 import { mailSourceDatabaseSchema } from "./createSourceDatabase";
-import { RunOnce } from "../../../util/flow/RunOnce";
 import sql, { type Database } from "../../../../../lib/rs-sqlite";
 
-const runOnce = new RunOnce<void>();
-
 export async function migrateToNewSchema(database: Database) {
-  // Run in runOnce because this seems to be called multiple times in parallel
-  await runOnce.runOnce(async () => {
-    if (await isEmailIDUnique(database)) {
-      return;
-    }
-    try {
-      await database.execute(sql`
-        BEGIN TRANSACTION;
+  if (await isEmailIDUnique(database)) {
+    return;
+  }
+  try {
+    await database.execute(sql`
+      BEGIN TRANSACTION;
 
-        -- Delete duplicates from the DB, keep the latest version
-        DELETE FROM emailMIME
-        WHERE id NOT IN
-          (SELECT MAX(id)
-            FROM emailMIME
-            GROUP BY emailID);
+      -- Delete duplicates from the DB, keep the latest version
+      DELETE FROM emailMIME
+      WHERE id NOT IN
+        (SELECT MAX(id)
+          FROM emailMIME
+          GROUP BY emailID);
 
-        ALTER TABLE emailMIME RENAME TO emailMIME_old;
-        $${mailSourceDatabaseSchema}
+      ALTER TABLE emailMIME RENAME TO emailMIME_old;
+      $${mailSourceDatabaseSchema}
 
-        INSERT INTO emailMIME SELECT * FROM emailMIME_old;
-        DROP TABLE emailMIME_old;
+      INSERT INTO emailMIME SELECT * FROM emailMIME_old;
+      DROP TABLE emailMIME_old;
 
-        END TRANSACTION;
-      `);
-    } catch(ex) {
-      await database.run(sql`ROLLBACK TRANSACTION`);
-      throw ex;
-    }
-  });
+      END TRANSACTION;
+    `);
+  } catch(ex) {
+    await database.run(sql`ROLLBACK TRANSACTION`);
+    throw ex;
+  }
 }
 
 export async function isEmailIDUnique(database: Database) {

--- a/app/logic/Mail/SQL/Source/SQLSourceEmailMigrate.ts
+++ b/app/logic/Mail/SQL/Source/SQLSourceEmailMigrate.ts
@@ -19,7 +19,10 @@ export async function migrateToNewSchema(database: Database) {
       ALTER TABLE emailMIME RENAME TO emailMIME_old;
       $${mailSourceDatabaseSchema}
 
-      INSERT INTO emailMIME SELECT * FROM emailMIME_old;
+      -- Don't copy DB IDs, generate new IDs
+      INSERT INTO emailMIME (emailID, messageID, mime)
+      SELECT emailID, messageID, mime FROM emailMIME_old;
+
       DROP TABLE emailMIME_old;
 
       END TRANSACTION;

--- a/app/logic/Mail/SQL/Source/SQLSourceEmailMigrate.ts
+++ b/app/logic/Mail/SQL/Source/SQLSourceEmailMigrate.ts
@@ -5,32 +5,23 @@ export async function migrateToNewSchema(database: Database) {
   if (await isEmailIDUnique(database)) {
     return;
   }
-  try {
-    await database.execute(sql`
-      BEGIN TRANSACTION;
+  await database.execute(sql`
+    -- Delete duplicates from the DB, keep the latest version
+    DELETE FROM emailMIME
+    WHERE id NOT IN
+      (SELECT MAX(id)
+        FROM emailMIME
+        GROUP BY emailID);
 
-      -- Delete duplicates from the DB, keep the latest version
-      DELETE FROM emailMIME
-      WHERE id NOT IN
-        (SELECT MAX(id)
-          FROM emailMIME
-          GROUP BY emailID);
+    ALTER TABLE emailMIME RENAME TO emailMIME_old;
+    $${mailSourceDatabaseSchema}
 
-      ALTER TABLE emailMIME RENAME TO emailMIME_old;
-      $${mailSourceDatabaseSchema}
+    -- Don't copy DB IDs, generate new IDs
+    INSERT INTO emailMIME (emailID, messageID, mime)
+    SELECT emailID, messageID, mime FROM emailMIME_old;
 
-      -- Don't copy DB IDs, generate new IDs
-      INSERT INTO emailMIME (emailID, messageID, mime)
-      SELECT emailID, messageID, mime FROM emailMIME_old;
-
-      DROP TABLE emailMIME_old;
-
-      END TRANSACTION;
-    `);
-  } catch(ex) {
-    await database.run(sql`ROLLBACK TRANSACTION`);
-    throw ex;
-  }
+    DROP TABLE emailMIME_old;
+  `);
 }
 
 export async function isEmailIDUnique(database: Database) {

--- a/app/logic/Mail/SQL/Source/SQLSourceEmailMigrate.ts
+++ b/app/logic/Mail/SQL/Source/SQLSourceEmailMigrate.ts
@@ -1,0 +1,54 @@
+import { mailSourceDatabaseSchema } from "./createSourceDatabase";
+import { RunOnce } from "../../../util/flow/RunOnce";
+import sql, { type Database } from "../../../../../lib/rs-sqlite";
+
+const runOnce = new RunOnce<void>();
+
+export async function migrateToNewSchema(database: Database) {
+  // Run in runOnce because this seems to be called multiple times in parallel
+  await runOnce.runOnce(async () => {
+    if (await isEmailIDUnique(database)) {
+      return;
+    }
+    try {
+      await database.execute(sql`
+        BEGIN TRANSACTION;
+
+        -- Delete duplicates from the DB, keep the latest version
+        DELETE FROM emailMIME
+        WHERE id NOT IN
+          (SELECT MAX(id)
+            FROM emailMIME
+            GROUP BY emailID);
+
+        ALTER TABLE emailMIME RENAME TO emailMIME_old;
+        $${mailSourceDatabaseSchema}
+
+        INSERT INTO emailMIME SELECT * FROM emailMIME_old;
+        DROP TABLE emailMIME_old;
+
+        END TRANSACTION;
+      `);
+    } catch(ex) {
+      await database.run(sql`ROLLBACK TRANSACTION`);
+      throw ex;
+    }
+  });
+}
+
+export async function isEmailIDUnique(database: Database) {
+  let indexes: any[] = await database.all(sql`SELECT * FROM pragma_index_list('emailMIME')`);
+  // Check for indexes created by the UNIQUE constraint
+  let uniqueIndexes = indexes.filter(i => i.unique == 1 && i.origin == "u");
+  if (uniqueIndexes.length == 0) {
+    return false;
+  }
+  // Check if the index has the emailID column
+  for (let uIndex of uniqueIndexes) {
+    let columns: any[] = await database.all(sql`SELECT * FROM pragma_index_info(${uIndex.name})`);
+    if (columns.some(c => c.name == "emailID")) {
+      return true;
+    }
+  }
+  return false;
+}

--- a/app/logic/Mail/SQL/Source/createSourceDatabase.ts
+++ b/app/logic/Mail/SQL/Source/createSourceDatabase.ts
@@ -6,7 +6,7 @@ export const mailSourceDatabaseSchema = sql`
   CREATE TABLE "emailMIME" (
     "id" INTEGER PRIMARY KEY,
     -- FOREIGN KEY to mail.db email.id
-    "emailID" INTEGER not null,
+    "emailID" INTEGER not null UNIQUE,
     -- RFC822 header
     "messageID" TEXT default null,
     "mime" ANY not null

--- a/app/logic/Mail/SQL/createDatabase.ts
+++ b/app/logic/Mail/SQL/createDatabase.ts
@@ -86,6 +86,7 @@ export const mailDatabaseSchema = sql`
       REFERENCES folder (ID)
       ON DELETE CASCADE
   );
+  CREATE INDEX index_email_folderID_dateSent ON email (folderID, dateSent DESC);
 
   CREATE TABLE "emailAttachment" (
     "id" INTEGER PRIMARY KEY,


### PR DESCRIPTION
- `REPLACE` didn't work because the `emailID` column didn't have a `UNIQUE` constraint
- We didn't delete the email from the content DB when it was delete from the email DB