### PR TITLE
Mail: Email: Load and parse MIME once

### DIFF
--- a/app/logic/Mail/EMail.ts
+++ b/app/logic/Mail/EMail.ts
@@ -251,88 +251,92 @@ export class EMail extends Message {
     // indirectly calls @see `ICalEMailProcessor.process()`
   }
 
+  readonly parseMIMERunOnce = new RunOnce<void>();
   async parseMIME() {
     assert(this.mime?.length, "MIME source not yet downloaded");
     assert(this.mime instanceof Uint8Array, "MIME source should be a byte array");
     //console.log("MIME source", this.mime, new TextDecoder("utf-8").decode(this.mime));
-    // We may need access to internal PostalMIME data.
-    let postalMIME = new PostalMIME();
-    let mail = await postalMIME.parse(this.mime);
 
-    // Headers
-    /** TODO header.key returns Uint8Array
-    for (let header of mail.headers) {
-      try {
-        this.headers.set(sanitize.nonemptystring(header.key), sanitize.nonemptystring(header.value));
-      } catch (ex) {
-        this.folder.account.errorCallback(ex);
+    await this.parseMIMERunOnce.runOnce(async () => {
+      // We may need access to internal PostalMIME data.
+      let postalMIME = new PostalMIME();
+      let mail = await postalMIME.parse(this.mime);
+
+      // Headers
+      /** TODO header.key returns Uint8Array
+      for (let header of mail.headers) {
+        try {
+          this.headers.set(sanitize.nonemptystring(header.key), sanitize.nonemptystring(header.value));
+        } catch (ex) {
+          this.folder.account.errorCallback(ex);
+        }
+      }*/
+
+      this.id ??= sanitize.string(mail.messageId, this.id ?? "");
+      this.subject ??= sanitize.string(mail.subject, this.subject ?? "");
+      this.sent ??= sanitize.date(mail.date, this.sent ?? new Date());
+      if (!this.from || this.from.emailAddress == kDummyPerson.emailAddress) {
+        this.from = mail.from?.address
+          ? findOrCreatePersonUID(
+              sanitize.emailAddress(mail.from.address, null),
+              sanitize.nonemptylabel(mail.from.name, null))
+          : kDummyPerson;
       }
-    }*/
-
-    this.id ??= sanitize.string(mail.messageId, this.id ?? "");
-    this.subject ??= sanitize.string(mail.subject, this.subject ?? "");
-    this.sent ??= sanitize.date(mail.date, this.sent ?? new Date());
-    if (!this.from || this.from.emailAddress == kDummyPerson.emailAddress) {
-      this.from = mail.from?.address
-        ? findOrCreatePersonUID(
-            sanitize.emailAddress(mail.from.address, null),
-            sanitize.nonemptylabel(mail.from.name, null))
-        : kDummyPerson;
-    }
-    setPersons(this.to, mail.to);
-    setPersons(this.cc, mail.cc);
-    setPersons(this.bcc, mail.bcc);
-    this.outgoing = this.folder?.account.isMyEMailAddress(this.from.emailAddress);
-    this.contact = this.outgoing ? this.to.first : this.from;
-    if (!this.replyTo && mail.replyTo?.length) {
-      let p = mail.replyTo[0];
-      this.replyTo = findOrCreatePersonUID(
-        sanitize.emailAddress(p.address, null),
-        sanitize.nonemptylabel(p.name, null));
-    }
-    if (!this.inReplyTo) {
-      this.inReplyTo = this.threadID = sanitize.string(mail.inReplyTo, null);
-    }
-    this.references = sanitize.string(mail.references, null)?.split(" ");
-
-    // Body
-    this.text = mail.text;
-    let html = sanitize.string(mail.html, null);
-    if (html) {
-      this.html = html;
-    }
-
-    // Attachments
-    let fallbackID = 0;
-    this.attachments.clear();
-    this.attachments.addAll(mail.attachments.map(a => {
-      try {
-        let attachment = new Attachment();
-        attachment.contentID = sanitize.nonemptystring(a.contentId, "" + ++fallbackID);
-        attachment.mimeType = sanitize.nonemptystring(a.mimeType, "application/octet-stream");
-        attachment.filename = sanitize.nonemptystring(a.filename, "attachment-" + fallbackID + "." + fileExtensionForMIMEType(attachment.mimeType));
-        attachment.disposition = sanitize.translate(a.disposition, {
-          attachment: ContentDisposition.attachment,
-          inline: ContentDisposition.inline,
-        }, ContentDisposition.unknown);
-        attachment.related = sanitize.boolean(a.related, false);
-        attachment.content = new File([a.content], attachment.filename, { type: attachment.mimeType });
-        attachment.size = sanitize.integer(attachment.content.size, -1);
-        return attachment;
-      } catch (ex) {
-        this.folder.account.errorCallback(ex);
-        return null;
+      setPersons(this.to, mail.to);
+      setPersons(this.cc, mail.cc);
+      setPersons(this.bcc, mail.bcc);
+      this.outgoing = this.folder?.account.isMyEMailAddress(this.from.emailAddress);
+      this.contact = this.outgoing ? this.to.first : this.from;
+      if (!this.replyTo && mail.replyTo?.length) {
+        let p = mail.replyTo[0];
+        this.replyTo = findOrCreatePersonUID(
+          sanitize.emailAddress(p.address, null),
+          sanitize.nonemptylabel(p.name, null));
       }
-    }).filter(attachment => !!attachment));
-
-    // Run processors, filters, calendar invitations, SML, etc.
-    for (let processor of EMailProcessorList.processors) {
-      if (processor.runOn != ProcessingStartOn.Parse) {
-        continue;
+      if (!this.inReplyTo) {
+        this.inReplyTo = this.threadID = sanitize.string(mail.inReplyTo, null);
       }
-      processor.process(this, postalMIME)
-        .catch(logError);
-    }
+      this.references = sanitize.string(mail.references, null)?.split(" ");
+
+      // Body
+      this.text = mail.text;
+      let html = sanitize.string(mail.html, null);
+      if (html) {
+        this.html = html;
+      }
+
+      // Attachments
+      let fallbackID = 0;
+      this.attachments.clear();
+      this.attachments.addAll(mail.attachments.map(a => {
+        try {
+          let attachment = new Attachment();
+          attachment.contentID = sanitize.nonemptystring(a.contentId, "" + ++fallbackID);
+          attachment.mimeType = sanitize.nonemptystring(a.mimeType, "application/octet-stream");
+          attachment.filename = sanitize.nonemptystring(a.filename, "attachment-" + fallbackID + "." + fileExtensionForMIMEType(attachment.mimeType));
+          attachment.disposition = sanitize.translate(a.disposition, {
+            attachment: ContentDisposition.attachment,
+            inline: ContentDisposition.inline,
+          }, ContentDisposition.unknown);
+          attachment.related = sanitize.boolean(a.related, false);
+          attachment.content = new File([a.content], attachment.filename, { type: attachment.mimeType });
+          attachment.size = sanitize.integer(attachment.content.size, -1);
+          return attachment;
+        } catch (ex) {
+          this.folder.account.errorCallback(ex);
+          return null;
+        }
+      }).filter(attachment => !!attachment));
+
+      // Run processors, filters, calendar invitations, SML, etc.
+      for (let processor of EMailProcessorList.processors) {
+        if (processor.runOn != ProcessingStartOn.Parse) {
+          continue;
+        }
+        processor.process(this, postalMIME)
+          .catch(logError);
+      }
+    });
   }
 
   /**
@@ -373,23 +377,26 @@ export class EMail extends Message {
     await this.loadMIME();
   }
 
+  readonly loadMIMERunOnce = new RunOnce<void>();
   async loadMIME() {
     if (this.mime) {
       return;
     }
-    if (this.dbID) {
-      try {
-        await this.storage.readMessage(this);
-        await this.folder.account.contentStorage.first.read(this);
-        if (this.mime) {
-          await this.parseMIME();
-          return;
+    await this.loadMIMERunOnce.runOnce(async () => {
+      if (this.dbID) {
+        try {
+          await this.storage.readMessage(this);
+          await this.folder.account.contentStorage.first.read(this);
+          if (this.mime) {
+            await this.parseMIME();
+            return;
+          }
+        } catch (ex) {
+          console.error(ex);
         }
-      } catch (ex) {
-        console.error(ex);
       }
-    }
-    await this.download();
+      await this.download();
+    });
   }
 
   async loadAttachments() {


### PR DESCRIPTION
- `loadEvent` and `loadForDisplay` both call `loadMIME` or `parseMIME` in parallel
- Changing the `loadedBody` property causes an extra call in parallel also
- This wraps `loadMIME` and `parseMIME` in runOnce to prevent extra calls in parallel
- This also fixes: 
> For some reason the code even after the existing .migrate() runs more than once in parallel so I had to wrap it in a runOnce.

from: https://github.com/mustang-im/mustang/pull/1074#issuecomment-4035113601
With extra call and I also see the database is being opened multiple times in parallel in the backend.