### PR TITLE
Mail: Delete email from content storage

### DIFF
--- a/app/logic/Mail/EMail.ts
+++ b/app/logic/Mail/EMail.ts
@@ -191,6 +191,11 @@ export class EMail extends Message {
     this.isDeleted = true;
     this.folder.messages.remove(this);
     await this.storage.deleteMessage(this);
+    let contentDeletes = new PromiseAllDone();
+    for (let contentStorage of this.folder.account.contentStorage) {
+      contentDeletes.add(contentStorage.deleteIt(this));
+    }
+    await contentDeletes.wait();
   }
 
   async deleteMessageOnServer() {


### PR DESCRIPTION
- Delete email from content storage when deleting message locally
- Needs to be deleted to prevent DB being bloated with content of deleted emails