### PR TITLE
MailWindow: Change theme after the backend is loaded

### DIFF
--- a/app/frontend/MainWindow/MainWindow.svelte
+++ b/app/frontend/MainWindow/MainWindow.svelte
@@ -107,11 +107,11 @@
   async function onLoad() {
     loadMustangApps();
     openApp(mailMustangApp, {});
-    changeTheme($themeSetting.value);
     // #if [MOBILE]
     SplashScreen.hide();
     // #endif
     await startup();
+    changeTheme($themeSetting.value);
   }
 
   async function startup() {


### PR DESCRIPTION
- Changing the theme before the backend started had no effect
- Change the theme after the backend is loaded, there might be a split second of the system theme because we also setup and login to the accounts in `startup()` even placing it after `getStartObjects()` you still see a split second of the system theme
- This at least loads the theme saved in local storage