### PR TITLE
Lazily load move/copy to folder #1018

### DIFF
--- a/app/logic/Mail/FilterRules/FilterRuleAction.ts
+++ b/app/logic/Mail/FilterRules/FilterRuleAction.ts
@@ -28,7 +28,7 @@ export class FilterRuleAction extends Observable {
   @notifyChangedProperty
   toFolderID: string | undefined;
   get toFolder(): Folder | null {
-    return this.toFolderID && (this._toFolder ??= this.account.findFolder(folder => folder.id == this.toFolderID)) || null;
+    return this.toFolderID && (this._toFolder ??= this.account.findFolder(folder => folder.id == this.toFolderID)) ?? null;
   }
   set toFolder(folder: Folder | null) {
     this._toFolder = folder;


### PR DESCRIPTION
Filters get loaded very early in account creation via `MailAccount.fromConfigJSON`. Unfortunately this is before the account has loaded its folders.

I don't know whether it's worth caching the `toFolder` but I can implement that if you like.