### PR TITLE
Hide account selector from filter criteria #1018

### DIFF
--- a/app/frontend/Mail/Search/SearchCriteria.svelte
+++ b/app/frontend/Mail/Search/SearchCriteria.svelte
@@ -74,7 +74,7 @@
       <TagSelector tags={availableTags} selectedTags={search.tags} canAdd={false} />
     </vbox>
   {/if}
-  {#if appGlobal.emailAccounts.length > 1}
+  {#if showAccount && appGlobal.emailAccounts.length > 1}
     <Checkbox bind:checked={hasAccount} allowFalse={false} allowIndetermined={true}
       on:change={updateAccount}
       label={$t`${search.account?.name} account only`}>
@@ -131,6 +131,7 @@
   export let search: SearchEMail;
 
   export let showSearchTerm = true;
+  export let showAccount = true;
   export let searchMessages: Collection<EMail> = null;
 
   // enable/disable fine-grained controls

--- a/app/frontend/Settings/Mail/Rules.svelte
+++ b/app/frontend/Settings/Mail/Rules.svelte
@@ -54,7 +54,7 @@
             <HeaderGroupBox>
               <hbox slot="header">{$t`Criteria`}</hbox>
               <vbox class="content">
-                <SearchCriteria search={rule.criteria} />
+                <SearchCriteria search={rule.criteria} showAccount={false} />
               </vbox>
             </HeaderGroupBox>
 

--- a/app/logic/Mail/FilterRules/FilterRuleAction.ts
+++ b/app/logic/Mail/FilterRules/FilterRuleAction.ts
@@ -49,10 +49,10 @@ export class FilterRuleAction extends Observable {
 
   constructor(account: MailAccount, criteria?: SearchEMail) {
     super();
-    this.account = account;
     if (criteria) {
       this.criteria = criteria;
     }
+    this.criteria.account = this.account = account;
   }
 
   /** Checks for a match, and runs the filter action, as needed. */
@@ -101,6 +101,7 @@ export class FilterRuleAction extends Observable {
     this.name = sanitize.nonemptystring(json.name, "-");
     this.when = sanitize.enum<FilterMoment>(json.when, Object.values(FilterMoment));
     this.criteria.fromJSON(json.criteria);
+    this.criteria.account = this.account;
     function boolean(value: boolean | undefined): boolean | undefined {
       return typeof (value) == "boolean" ? value : undefined;
     }


### PR DESCRIPTION
I forced the rule to specify the criteria account because the UI needs an account to be able to offer the folders; the alternative would be something like `<SearchCriteria search={rule.criteria} forceAccount={rule.account} />`.