### PR TITLE
Lazily load filter criteria folder #1018

### DIFF
--- a/app/logic/Mail/Store/SearchEMail.ts
+++ b/app/logic/Mail/Store/SearchEMail.ts
@@ -90,7 +90,7 @@ export class SearchEMail extends Observable {
 
     this.includesPerson = findPerson(json.includesPersonEMail);
     this.account = appGlobal.emailAccounts.find(acc => acc.id == json.accountID);
-    this.folderID = json.folderID;
+    this.folderID = sanitize.nonemptystring(json.folderID, null);
     this._folder = null;
     this.tags.replaceAll(sanitize.array(json.tags, [])?.map(name => getTagByName(name)));
   }


### PR DESCRIPTION
Filters and their criteria get loaded very early in account creation via MailAccount.fromConfigJSON. Unfortunately this is before the account has loaded its folders.

I decided to cache the folder this time by comparison with #1086.
