### PR TITLE
Electron: Create new Menu without Reload and Forced Reload

### DIFF
--- a/desktop/src/main/index.ts
+++ b/desktop/src/main/index.ts
@@ -1,5 +1,5 @@
 import { setMainWindow, startupBackend, shutdownBackend, startupArgs } from '../../backend/backend';
-import { app, shell, BrowserWindow, session } from 'electron'
+import { app, shell, BrowserWindow, session, Menu, MenuItemConstructorOptions } from 'electron'
 import { ipcMain } from 'electron/main';
 import { join } from 'path'
 import electronUpdater from 'electron-updater';
@@ -87,6 +87,30 @@ function createWindow(): void {
   }
 }
 
+function createMenu() {
+  // <copied from="https://github.com/electron/electron/blob/main/lib/browser/default-menu.ts#L48-L60">
+  const macAppMenu: MenuItemConstructorOptions = { role: 'appMenu' };
+  const menu = Menu.buildFromTemplate([
+    ...(process.platform === 'darwin' ? [macAppMenu] : []),
+    { role: 'fileMenu' },
+    { role: 'editMenu' },
+    {
+      label: 'View',
+      submenu: [
+        { role: 'toggleDevTools' },
+        { type: 'separator' },
+        { role: 'resetZoom' },
+        { role: 'zoomIn' },
+        { role: 'zoomOut' },
+        { type: 'separator' },
+        { role: 'togglefullscreen' }
+      ]
+    },
+    { role: 'windowMenu' },
+  ]);
+  Menu.setApplicationMenu(menu);
+}
+
 const gotLock = app.requestSingleInstanceLock();
 if (gotLock) {
   app.whenReady()
@@ -117,6 +141,7 @@ async function whenReady() {
     optimizer.watchWindowShortcuts(window)
   })
 
+  createMenu();
   createWindow();
 
   app.on('activate', function () {


### PR DESCRIPTION
- Create an new Menu from the default template
- For `viewMenu` rebuild it without reload and forced reload
- Disables the shortcut for reload and forced reload also
- Other menu items are needed for copy, paste, minimize, etc...