### PR TITLE
Build: Use single Vite version

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -94,6 +94,9 @@
     "vite-plugin-node-polyfills": "^0.24.0",
     "vitest": "^4.0.16"
   },
+  "resolutions": {
+    "vite": "^7.3.1"
+  },
   "repository": {
     "type": "git",
     "url": "git+https://github.com/mustang-im/mustang.git"


### PR DESCRIPTION
- There might be a variation between what version of Vite we use and Vitest expects
- The solution is to force a single version of Vite
- Also we we're using version `^7.3.1` which Yarn might not be handling well
- Related issue: https://github.com/yarnpkg/yarn/issues/6285#issue-352138193 