### PR TITLE
Routing: Replace navigate(-1) with goBack #1084

### DIFF
--- a/app/frontend/AppsBar/AppMenuM/AppMenu.svelte
+++ b/app/frontend/AppsBar/AppMenuM/AppMenu.svelte
@@ -44,10 +44,10 @@
   import BottomAppMenu from "./BottomAppMenu.svelte";
   import AppMenuBarM from "./AppMenuBarM.svelte";
   import RecentPersons from "./RecentPersons.svelte";
-  import { navigate } from "svelte-navigator";
+  import { goBack } from "../selectedApp";
 
   function onClose() {
-    navigate(-1);
+    goBack();
   }
 </script>
 

--- a/app/frontend/AppsBar/AppMenuM/AppMenuBarM.svelte
+++ b/app/frontend/AppsBar/AppMenuM/AppMenuBarM.svelte
@@ -27,15 +27,14 @@
 
 <script lang="ts">
   import { settingsMustangApp } from "../../Settings/Window/SettingsMustangApp";
-  import { goTo } from "../selectedApp";
+  import { goBack, goTo } from "../selectedApp";
   import AppBarM from "../../AppsBar/AppBarM.svelte";
   import AppMenuButton from "../../AppsBar/AppMenuM/AppMenuButton.svelte";
   import Button from "../../Shared/Button.svelte";
-  import { navigate } from "svelte-navigator";
   import { t } from "../../../l10n/l10n";
 
   function onClose() {
-    navigate(-1);
+    goBack();
   }
 </script>
 

--- a/app/frontend/Contacts/PersonPage/NameBoxM.svelte
+++ b/app/frontend/Contacts/PersonPage/NameBoxM.svelte
@@ -5,7 +5,7 @@
         <RoundButton
           icon={BackIcon}
           label={$t`Back to list of persons`}
-          onClick={() => navigate(-1)}
+          onClick={() => goBack()}
           classes="back" />
       {/if}
       {#if isEditing}
@@ -117,7 +117,7 @@
   import { getUILocale, t } from "../../../l10n/l10n";
   import Button from "../../Shared/Button.svelte";
   import GroupBox from "./GroupBox.svelte";
-  import { navigate } from "svelte-navigator";
+  import { goBack } from "../../AppsBar/selectedApp";
 
   export let person: Person;
   /** in/out */

--- a/app/frontend/Mail/Composer/MailComposer.svelte
+++ b/app/frontend/Mail/Composer/MailComposer.svelte
@@ -215,7 +215,7 @@
   import SpellCheckIcon from "lucide-svelte/icons/square-check-big";
   import { t, gt } from "../../../l10n/l10n";
   import { tick } from "svelte";
-  import { navigate } from "svelte-navigator";
+  import { goBack } from "../../AppsBar/selectedApp";
   import type { Editor } from '@tiptap/core';
 
   export let mail: EMail;
@@ -365,7 +365,7 @@
 
     let me = mailMustangApp.subApps.find(app => app instanceof WriteMailMustangApp && app.windowParams.mail == mail);
     mailMustangApp.subApps.remove(me);
-    navigate(-1);
+    goBack();
   }
 
   let showSMLAdd = false;

--- a/app/frontend/MainWindow/NavigationM.svelte
+++ b/app/frontend/MainWindow/NavigationM.svelte
@@ -4,13 +4,13 @@
   import { showError } from "../Util/error";
   import { App } from "@capacitor/app";
   import { gestures } from "@composi/gestures";
-  import { navigate } from "svelte-navigator";
+  import { goBack } from "../AppsBar/selectedApp";
 
   gestures();
 
   App.addListener("backButton", ({canGoBack}) => {
     if (canGoBack) {
-      navigate(-1);
+      goBack();
     } else {
       App.minimizeApp();
     }


### PR DESCRIPTION
- Replace navigate(-1) with goBack so it uses the same history object in `selectedApp.ts`