### PR TITLE
RunOnce: Keep the same successful result but throw different error stacks #1065

### DIFF
--- a/app/logic/util/flow/RunOnce.ts
+++ b/app/logic/util/flow/RunOnce.ts
@@ -38,9 +38,8 @@ export class RunOnce<Result> {
 }
 
 function copyError(oldError: Error, newError: Error) {
-  for (let key of Object.keys(oldError)) {
-    newError[key] = oldError[key];
-  }
+  newError = Object.assign(newError, oldError);
+
   newError.message = oldError.message;
   newError.stack = oldError.stack;
   if (oldError.stack) {

--- a/app/logic/util/flow/RunOnce.ts
+++ b/app/logic/util/flow/RunOnce.ts
@@ -23,8 +23,29 @@ export class RunOnce<Result> {
       // Return the same result if successful
       return await this.running;
     } catch (ex) {
-      // Rethrow error for a fresh stack
-      throw ex;
+      if (!ex.stack) {
+        throw ex;
+      }
+      // Join stack traces and rethrow
+      let newEx = new Error(ex.message);
+      // Get new stack before copying
+      let newStack = newEx.stack;
+      copyError(ex, newEx);
+      newEx.stack = `${ex.stack}\n${newStack.split('\n').slice(1).join('\n')}`;
+      throw newEx;
     }
   }
+}
+
+function copyError(oldError: Error, newError: Error) {
+  for (let key of Object.keys(oldError)) {
+    newError[key] = oldError[key];
+  }
+  newError.message = oldError.message;
+  newError.stack = oldError.stack;
+  if (oldError.stack) {
+    newError.stack = oldError.stack;
+  }
+
+  return newError;
 }

--- a/app/logic/util/flow/RunOnce.ts
+++ b/app/logic/util/flow/RunOnce.ts
@@ -23,7 +23,7 @@ export class RunOnce<Result> {
       // Return the same result if successful
       return await this.running;
     } catch (ex) {
-      if (!ex.stack) {
+      if (!ex?.stack) {
         throw ex;
       }
       // Join stack traces and rethrow

--- a/app/logic/util/flow/RunOnce.ts
+++ b/app/logic/util/flow/RunOnce.ts
@@ -31,6 +31,7 @@ export class RunOnce<Result> {
       // Get new stack before copying
       let newStack = newEx.stack;
       copyError(ex, newEx);
+      // Remove second Error header before joining
       newEx.stack = `${ex.stack}\n${newStack.split('\n').slice(1).join('\n')}`;
       throw newEx;
     }

--- a/app/logic/util/flow/RunOnce.ts
+++ b/app/logic/util/flow/RunOnce.ts
@@ -9,13 +9,22 @@ export class RunOnce<Result> {
   running: Promise<Result> | null = null;
 
   async runOnce(func: () => Promise<Result>): Promise<Result> {
+    if (!this.running) {
+      this.running = (async () => {
+        try {
+          return await func();
+        } finally {
+          this.running = null;
+        }
+      })();
+    }
+
     try {
-      if (!this.running) {
-        this.running = func();
-      }
+      // Return the same result if successful
       return await this.running;
-    } finally {
-      this.running = null;
+    } catch (ex) {
+      // Rethrow error for a fresh stack
+      throw ex;
     }
   }
 }

--- a/app/test/logic/util/flow/RunOnce.test.ts
+++ b/app/test/logic/util/flow/RunOnce.test.ts
@@ -1,5 +1,5 @@
 import { RunOnce } from "../../../../logic/util/flow/RunOnce";
-import { sleep } from '../../../../logic/util/util';
+import { sleep, UserError } from '../../../../logic/util/util';
 import { expect, test } from "vitest";
 
 class WithRunOnce {
@@ -26,7 +26,7 @@ class WithRunOnceError {
   async throwErr() {
     await sleep(Math.random());
     this.ran += 1;
-    throw new Error(`Err #${this.ran}`);
+    throw new UserError(`Err #${this.ran}`);
   }
 }
 
@@ -54,7 +54,7 @@ class WithoutRunOnceError {
   async throwErr() {
     await sleep(Math.random());
     this.ran += 1;
-    throw new Error(`Err #${this.ran}`);
+    throw new UserError(`Err #${this.ran}`);
   }
 }
 
@@ -84,8 +84,9 @@ test("RunOnce Error", async () => {
   let results = await Promise.allSettled(promises) as PromiseRejectedResult[];
   expect(a.ran).toBe(1);
   for (let i = 0; i < kCalls; i++) {
-    expect(!!results.find(r => (r.reason as Error).stack?.includes(`Promise.allSettled (index ${i})`))).toBe(true);
-    expect(!!results.find(r => (r.reason as Error).message.includes("Err #1"))).toBe(true);
+    expect(results[i].reason.isUserError).toBe(true);
+    expect(!!results.find(r => (r.reason as UserError).stack?.includes(`Promise.allSettled (index ${i})`))).toBe(true);
+    expect(!!results.find(r => (r.reason as UserError).message.includes("Err #1"))).toBe(true);
   }
 });
 
@@ -95,7 +96,8 @@ test("Without RunOnce Error", async () => {
   let results = await Promise.allSettled(promises) as PromiseRejectedResult[];
   expect(a.ran).toBe(kCalls);
   for (let i = 0; i < kCalls; i++) {
-    expect(!!results.find(r => (r.reason as Error).stack?.includes(`Promise.allSettled (index ${i})`))).toBe(true);
-    expect(!!results.find(r => (r.reason as Error).message.includes(`Err #${i + 1}`))).toBe(true);
+    expect(results[i].reason.isUserError).toBe(true);
+    expect(!!results.find(r => (r.reason as UserError).stack?.includes(`Promise.allSettled (index ${i})`))).toBe(true);
+    expect(!!results.find(r => (r.reason as UserError).message.includes(`Err #${i + 1}`))).toBe(true);
   }
 });

--- a/app/test/logic/util/flow/RunOnce.test.ts
+++ b/app/test/logic/util/flow/RunOnce.test.ts
@@ -1,0 +1,101 @@
+import { RunOnce } from "../../../../logic/util/flow/RunOnce";
+import { sleep } from '../../../../logic/util/util';
+import { expect, test } from "vitest";
+
+class WithRunOnce {
+  ran = 0;
+  runOnce = new RunOnce<string>();
+  async run() {
+    return await this.runOnce.runOnce(() => this.sayHi());
+  }
+
+  async sayHi() {
+    await sleep(Math.random());
+    this.ran += 1;
+    return `Hi #${this.ran}`;
+  }
+}
+
+class WithRunOnceError {
+  ran = 0;
+  runOnce = new RunOnce<void>();
+  async run() {
+    return await this.runOnce.runOnce(() => this.throwErr());
+  }
+
+  async throwErr() {
+    await sleep(Math.random());
+    this.ran += 1;
+    throw new Error(`Err #${this.ran}`);
+  }
+}
+
+class WithoutRunOnce {
+  ran = 0;
+  runOnce = new RunOnce<string>();
+  async run() {
+    return await this.sayHi();
+  }
+
+  async sayHi() {
+    await sleep(Math.random());
+    this.ran += 1;
+    return `Hi #${this.ran}`;
+  }
+}
+
+class WithoutRunOnceError {
+  ran = 0;
+  runOnce = new RunOnce<void>();
+  async run() {
+    return await this.throwErr();
+  }
+
+  async throwErr() {
+    await sleep(Math.random());
+    this.ran += 1;
+    throw new Error(`Err #${this.ran}`);
+  }
+}
+
+const kCalls = 5;
+
+test("RunOnce", async () => {
+  let a = new WithRunOnce();
+  let promises = Array.from({ length: kCalls }, () => a.run());
+  let results = await Promise.all(promises);
+  expect(a.ran).toBe(1);
+  expect(results.every(r => r == "Hi #1")).toBe(true);
+});
+
+test("Without RunOnce", async () => {
+  let a = new WithoutRunOnce();
+  let promises = Array.from({ length: kCalls }, () => a.run());
+  let results = await Promise.all(promises);
+  expect(a.ran).toBe(kCalls);
+  for (let i = 1; i <= kCalls; i++) {
+    expect(!!results.find(r => r == `Hi #${i}`)).toBe(true);
+  }
+});
+
+test("RunOnce Error", async () => {
+  let a = new WithRunOnceError();
+  let promises = Array.from({ length: kCalls }, () => a.run());
+  let results = await Promise.allSettled(promises) as PromiseRejectedResult[];
+  expect(a.ran).toBe(1);
+  for (let i = 0; i < kCalls; i++) {
+    expect(!!results.find(r => (r.reason as Error).stack?.includes(`Promise.allSettled (index ${i})`))).toBe(true);
+    expect(!!results.find(r => (r.reason as Error).message.includes("Err #1"))).toBe(true);
+  }
+});
+
+test("Without RunOnce Error", async () => {
+  let a = new WithoutRunOnceError();
+  let promises = Array.from({ length: kCalls }, () => a.run());
+  let results = await Promise.allSettled(promises) as PromiseRejectedResult[];
+  expect(a.ran).toBe(kCalls);
+  for (let i = 0; i < kCalls; i++) {
+    expect(!!results.find(r => (r.reason as Error).stack?.includes(`Promise.allSettled (index ${i})`))).toBe(true);
+    expect(!!results.find(r => (r.reason as Error).message.includes(`Err #${i + 1}`))).toBe(true);
+  }
+});


### PR DESCRIPTION
- If the result is successful keep the same result for all calls
- If the result was rejected re-throw the error with different error stacks for each call. We were using the same stack for all calls. And the single instance of the function call lived in the `RunOnce`.
- The only downside with this I see so far is that the `instanceof` will be different because we're rebuilding the error and possible any non enumerable properties.
- I've tried just reassigning the stack but it seems to be merging the stack for all calls for some reason and it becomes very messy
- I've tried using `Error.cause` but that nests the Errors and will cause some issues for our `try...catches` with `ex.message`
- Should fix: https://github.com/mustang-im/mustang/issues/1065#issuecomment-4079476021