### PR TITLE
Exchange permissions: Check another email address case-insensitively #1120

### DIFF
--- a/app/logic/Mail/EWS/EWSFolder.ts
+++ b/app/logic/Mail/EWS/EWSFolder.ts
@@ -687,7 +687,9 @@ export class ExchangePermission {
 }
 
 export function getSharedPersons(permissions: ExchangeUser[], thisUser: string): ArrayColl<PersonUID> {
-  return new ArrayColl(permissions.filter(permission => !permission.UserId.DistinguishedUser && permission.UserId.PrimarySmtpAddress != thisUser).map(permission => new PersonUID(permission.UserId.PrimarySmtpAddress, permission.UserId.DisplayName)));
+  return new ArrayColl(permissions
+    .filter(permission => !permission.UserId.DistinguishedUser && permission.UserId.PrimarySmtpAddress.toLowerCase() != thisUser.toLowerCase())
+    .map(permission => new PersonUID(permission.UserId.PrimarySmtpAddress, permission.UserId.DisplayName)));
 }
 
 export async function deleteExchangePermissions(target: { getPermissions(): Promise<ExchangePermission[]>, setPermissions(permission: ExchangePermission[]): Promise<void> }, otherPerson: PersonUID) {


### PR DESCRIPTION
This is for `getSharedPersons` to correctly exclude the current user even when their email address on the server is only a case-insensitive match for the one they used to create the account.