### PR TITLE
Hotmail: Send DefaultAnchorMailbox in the backend #1105

### DIFF
--- a/app/logic/Mail/ActiveSync/ActiveSyncAccount.ts
+++ b/app/logic/Mail/ActiveSync/ActiveSyncAccount.ts
@@ -162,7 +162,7 @@ export class ActiveSyncAccount extends MailAccount {
   async verifyLogin(): Promise<void> {
     let options: any = {
       headers: {
-        Cookie: `DefaultAnchorMailbox=${encodeURI(this.emailAddress)}`, // required for v14.0
+        DefaultAnchorMailbox: encodeURI(this.emailAddress), // required for Hotmail
       },
       method: "OPTIONS",
     };
@@ -247,7 +247,7 @@ export class ActiveSyncAccount extends MailAccount {
       headers: {
         "Content-Type": "application/vnd.ms-sync.wbxml",
         "MS-ASProtocolVersion": this.protocolVersion == "16.1" && !aOptions.allowV16 ? "14.1" : this.protocolVersion,
-        Cookie: `DefaultAnchorMailbox=${encodeURI(this.emailAddress)}`, // required for 14.0
+        DefaultAnchorMailbox: encodeURI(this.emailAddress), // required for Hotmail
       },
       method: "POST",
       signal: AbortSignal.timeout(heartbeat * 1000 + 25000), // extra timeout for Ping commands

--- a/app/logic/Mail/ActiveSync/ActiveSyncAccount.ts
+++ b/app/logic/Mail/ActiveSync/ActiveSyncAccount.ts
@@ -162,7 +162,7 @@ export class ActiveSyncAccount extends MailAccount {
   async verifyLogin(): Promise<void> {
     let options: any = {
       headers: {
-        DefaultAnchorMailbox: encodeURI(this.emailAddress), // required for Hotmail
+        "Cookie-Bypass": `DefaultAnchorMailbox=${encodeURI(this.emailAddress)}`, // required for Hotmail
       },
       method: "OPTIONS",
     };
@@ -247,7 +247,7 @@ export class ActiveSyncAccount extends MailAccount {
       headers: {
         "Content-Type": "application/vnd.ms-sync.wbxml",
         "MS-ASProtocolVersion": this.protocolVersion == "16.1" && !aOptions.allowV16 ? "14.1" : this.protocolVersion,
-        DefaultAnchorMailbox: encodeURI(this.emailAddress), // required for Hotmail
+        "Cookie-Bypass": `DefaultAnchorMailbox=${encodeURI(this.emailAddress)}`, // required for Hotmail
       },
       method: "POST",
       signal: AbortSignal.timeout(heartbeat * 1000 + 25000), // extra timeout for Ping commands

--- a/desktop/src/main/index.ts
+++ b/desktop/src/main/index.ts
@@ -217,9 +217,10 @@ function allowCrossDomainRequestsFromFrontend() {
         case "referer":
           delete requestHeaders[name];
           break;
-        case "defaultanchormailbox":
+        case "cookie-bypass":
           // Fake out the Cookie on all ActiveSync requests, because Hotmail.
-          requestHeaders.Cookie = name + "=" + requestHeaders[name];
+          requestHeaders.Cookie = requestHeaders[name];
+          delete requestHeaders[name];
           break;
         case "user-agent":
           // Fake out the User-Agent on all ActiveSync requests, because Office.

--- a/desktop/src/main/index.ts
+++ b/desktop/src/main/index.ts
@@ -217,6 +217,10 @@ function allowCrossDomainRequestsFromFrontend() {
         case "referer":
           delete requestHeaders[name];
           break;
+        case "defaultanchormailbox":
+          // Fake out the Cookie on all ActiveSync requests, because Hotmail.
+          requestHeaders.Cookie = name + "=" + requestHeaders[name];
+          break;
         case "user-agent":
           // Fake out the User-Agent on all ActiveSync requests, because Office.
           if (details.url.toLowerCase().includes("/microsoft-server-activesync")) {


### PR DESCRIPTION
`Cookie` is a banned CORS header, so we can't `fetch` it without some major shenanigans.

@jermy-c If you try to add your `@outlook.com` account with this change, does it now say that 16.1 isn't supported? If that's the case, we could drop support for 14.x which would massively simplify PR #1124.