### PR TITLE
Make it possible to edit and delete unedited instances again

### DIFF
--- a/app/frontend/Calendar/DisplayEvent/DialogHeader.svelte
+++ b/app/frontend/Calendar/DisplayEvent/DialogHeader.svelte
@@ -113,6 +113,7 @@
     if (event.seriesStatus == "only") {
       await event.parentEvent.deleteIt();
     } else {
+      event.parentEvent?.cancelEditing();
       await event.deleteIt();
     }
     $selectedEvent = null;

--- a/app/frontend/Calendar/EditEvent/DialogHeader.svelte
+++ b/app/frontend/Calendar/EditEvent/DialogHeader.svelte
@@ -217,6 +217,7 @@
   }
 
   async function onSave() {
+    event.parentEvent?.cancelEditing();
     await saveEvent(event);
     onClose();
   }
@@ -263,8 +264,8 @@
   }
 
   async function onSaveException() {
-    await saveEvent(event);
     event.parentEvent?.cancelEditing();
+    await saveEvent(event);
     onClose();
   }
 
@@ -273,6 +274,7 @@
     if (event.seriesStatus == "only") {
       await event.parentEvent.deleteIt();
     } else {
+      event.parentEvent?.cancelEditing();
       await event.deleteIt();
     }
     $selectedEvent = null;

--- a/app/logic/Calendar/Event.ts
+++ b/app/logic/Calendar/Event.ts
@@ -364,9 +364,12 @@ export class Event extends Observable {
    * copyEditableFieldsFrom and recurring events need extra care. */
   copyFrom(original: Event) {
     this.copyEditableFieldsFrom(original);
-    this.recurrenceStartTime = original.recurrenceStartTime ? new Date(original.recurrenceStartTime) : null;
+    this.recurrenceStartTime = original.recurrenceStartTime;
     this.recurrenceCase = original.recurrenceCase;
     this.recurrenceRule = original.recurrenceRule;
+    this.instances.replaceAll(original.instances);
+    this.exceptions.replaceAll(original.exceptions);
+    this.exclusions.replaceAll(original.exclusions);
     this.parentEvent = original.parentEvent;
   }
 
@@ -580,8 +583,10 @@ export class Event extends Observable {
    * Saves the event to the server and to the database.
    */
   async save() {
-    await this.saveLocally();
+    // Temporary to work around #1127 - save to server first,
+    // while the event's parent is still unedited.
     await this.saveToServer();
+    await this.saveLocally();
   }
 
   /**


### PR DESCRIPTION
While trying to test PR #1124 I found that editing and deleting unedited instances of recurring events was broken, because we weren't cancelling the master event's editing, so the instances were getting detached from their master.

Additionally, the code to edit and cancel editing for a master event wasn't working properly anyway, so instances were still getting detached from their master.

I also ran across issue #1127 but I don't know how to fix that properly so I just added a workaround for now so that editing actually works.