### PR TITLE
Support recurring events in other time zones #1135

### DIFF
--- a/app/frontend/Calendar/DisplayEvent/DetailsGrid.svelte
+++ b/app/frontend/Calendar/DisplayEvent/DetailsGrid.svelte
@@ -6,7 +6,7 @@
 
   {#if $event.recurrenceCase == RecurrenceCase.Master}
     <hbox />
-    <hbox class="recurrence">{ruleAsLabel($event.recurrenceRule, $event.startTime)}</hbox>
+    <hbox class="recurrence">{ruleAsLabel($event.recurrenceRule}</hbox>
   {/if}
 
   {#if $participants?.hasItems}

--- a/app/frontend/Calendar/EditEvent/RepeatBox.svelte
+++ b/app/frontend/Calendar/EditEvent/RepeatBox.svelte
@@ -108,21 +108,24 @@
   let yearWeekOptions: RadioOption[];
 
   $: startTime = $event.startTime.getTime();
+  $: timezone = $event.timezone;
   $: duration = $event.duration;
-  $: startTime, duration, updateDateUI();
+  $: startTime, timezone, duration, updateDateUI();
   function updateDateUI() {
     master.startEditing();
     master.startTime = event.startTime;
+    master.timezone = event.timezone;
     master.duration = event.duration;
     master.newRecurrenceRule(frequency, interval, week, weekdays);
+    let localStartTime = master.recurrenceRule.seriesStartTime;
     week = master.recurrenceRule.week;
-    weekdays = master.recurrenceRule.weekdays?.slice() ?? [$event.startTime.getDay()];
+    weekdays = master.recurrenceRule.weekdays?.slice() ?? [localStartTime.getUTCDay()];
 
-    yearWeekOptions = [{ label: $t`On ${event.startTime.toLocaleDateString(getDateTimeLocale(), { day: "numeric", month: "long" })}`, value: 0 }];
-    monthWeekOptions = [{ label: $t`On ${event.startTime.toLocaleDateString(getDateTimeLocale(), { day: "numeric" })}. of every month`, value: 0 }];
+    yearWeekOptions = [{ label: $t`On ${localStartTime.toLocaleDateString(getDateTimeLocale(), { day: "numeric", month: "long", timeZone: "UTC" })}`, value: 0 }];
+    monthWeekOptions = [{ label: $t`On ${localStartTime.toLocaleDateString(getDateTimeLocale(), { day: "numeric", timeZone: "UTC" })}. of every month`, value: 0 }];
 
-    let weekday = event.startTime.toLocaleDateString(getDateTimeLocale(), { weekday: "long" });
-    let weekno = Math.ceil(event.startTime.getDate() / 7);
+    let weekday = localStartTime.toLocaleDateString(getDateTimeLocale(), { weekday: "long", timeZone: "UTC" });
+    let weekno = Math.ceil(localStartTime.getUTCDay() / 7);
     if (weekno < 5) {
       let weekname = [
         $t`first *=> as in: On the first Wednesday in July`,
@@ -130,19 +133,19 @@
         $t`third *=> as in: On the third Wednesday in July`,
         $t`fourth *=> as in: On the fourth Wednesday in July`,
       ][weekno - 1];
-      yearWeekOptions.push({ label: $t`On the ${weekname} ${weekday} in ${event.startTime.toLocaleDateString(getDateTimeLocale(), { month: "long" })} *=> On the third Wednesday in September`, value: weekno });
+      yearWeekOptions.push({ label: $t`On the ${weekname} ${weekday} in ${localStartTime.toLocaleDateString(getDateTimeLocale(), { month: "long", timeZone: "UTC" })} *=> On the third Wednesday in September`, value: weekno });
       monthWeekOptions.push({ label: $t`On the ${weekname} ${weekday} *=> On the third Wednesday of each month`, value: weekno });
     }
 
-    if (isLastWeekOfMonth(event.startTime)) {
+    if (isLastWeekOfMonth(localStartTime)) {
       let weekname = $t`last *=> as in: On the last Wednesday in July`;
-      yearWeekOptions.push({ label: $t`On the ${weekname} ${weekday} in ${event.startTime.toLocaleDateString(getDateTimeLocale(), { month: "long" })} *=> On the third Wednesday in September`, value: 5 });
+      yearWeekOptions.push({ label: $t`On the ${weekname} ${weekday} in ${localStartTime.toLocaleDateString(getDateTimeLocale(), { month: "long", timeZone: "UTC" })} *=> On the third Wednesday in September`, value: 5 });
       monthWeekOptions.push({ label: $t`On the ${weekname} ${weekday} *=> On the third Wednesday of each month`, value: 5 });
     }
 
     weekdayOptions = kAllWeekdays.map(weekday => ({
       value: weekday,
-      disabled: weekday == event.startTime.getDay(),
+      disabled: weekday == localStartTime.getUTCDay(),
       label: weekdayLabel(weekday, "narrow"),
       tooltip: weekdayLabel(weekday, "long"),
     }));
@@ -158,8 +161,8 @@
 
   function isLastWeekOfMonth(date: Date) {
     date = new Date(date);
-    date.setDate(date.getDate() + 7);
-    return date.getDate() < 8;
+    date.setUTCDate(date.getUTCDate() + 7);
+    return date.getUTCDate() < 8;
   }
 
   function onDailyOptionChanged() {

--- a/app/logic/Calendar/ActiveSync/ActiveSyncEvent.ts
+++ b/app/logic/Calendar/ActiveSync/ActiveSyncEvent.ts
@@ -94,6 +94,7 @@ export class ActiveSyncEvent extends Event {
 
   protected newRecurrenceRuleFromWBXML(wbxmljs: any): RecurrenceRule {
     let masterDuration = this.duration;
+    let timezone = this.timezone;
     let seriesStartTime = this.startTime;
     let seriesEndTime = wbxmljs.Until ? fromCompact(sanitize.nonemptystring(wbxmljs.Until)) : null;
     let count = sanitize.integer(wbxmljs.Occurrences, Infinity);
@@ -102,7 +103,7 @@ export class ActiveSyncEvent extends Event {
     let weekdays = extractWeekdays(sanitize.integer(wbxmljs.DayOfWeek, 0));
     let week = sanitize.integer(wbxmljs.WeekOfMonth, 0);
     let first = sanitize.integer(wbxmljs.FirstDayOfWeek, Weekday.Monday);
-    return new RecurrenceRule({ masterDuration, seriesStartTime, seriesEndTime, count, frequency, interval, weekdays, week, first });
+    return new RecurrenceRule({ masterDuration, timezone, seriesStartTime, seriesEndTime, count, frequency, interval, weekdays, week, first });
   }
 
   toFields(exceptions: { Exception: any } | { Exception: any }[] = []): any {
@@ -123,10 +124,10 @@ export class ActiveSyncEvent extends Event {
         Occurrences: this.recurrenceRule.count < Infinity ? String(this.recurrenceRule.count) : [],
         Interval: String(this.recurrenceRule.interval),
         WeekOfMonth: this.recurrenceRule.week ? String(this.recurrenceRule.week) : [],
-        DayOfWeek: this.recurrenceRule.weekdays ? String(this.recurrenceRule.weekdays.reduce((bitmask, day) => bitmask | 1 << day, 0)) : this.recurrenceRule.week ? String(1 << this.recurrenceRule.seriesStartTime.getDay()) : [],
-        MonthOfYear: this.recurrenceRule.frequency == Frequency.Yearly ? String(this.recurrenceRule.seriesStartTime.getMonth() + 1) : [],
+        DayOfWeek: this.recurrenceRule.weekdays ? String(this.recurrenceRule.weekdays.reduce((bitmask, day) => bitmask | 1 << day, 0)) : this.recurrenceRule.week ? String(1 << this.recurrenceRule.seriesStartTime.getUTCDay()) : [],
+        MonthOfYear: this.recurrenceRule.frequency == Frequency.Yearly ? String(this.recurrenceRule.seriesStartTime.getUTCMonth() + 1) : [],
         Until: toCompact(this.recurrenceRule.seriesEndTime) || [],
-        DayOfMonth: [Frequency.Monthly, Frequency.Yearly].includes(this.recurrenceRule.frequency) && !this.recurrenceRule.week ? String(this.recurrenceRule.seriesStartTime.getDate()) : [],
+        DayOfMonth: [Frequency.Monthly, Frequency.Yearly].includes(this.recurrenceRule.frequency) && !this.recurrenceRule.week ? String(this.recurrenceRule.seriesStartTime.getUTCDate()) : [],
         FirstDayOfWeek: this.calendar.account.protocolVersion == "14.0" ? [] : this.recurrenceRule.frequency == Frequency.Weekly ? String(this.recurrenceRule.first) : [],
       } : [],
       Subject: this.title,

--- a/app/logic/Calendar/EWS/EWSEvent.ts
+++ b/app/logic/Calendar/EWS/EWSEvent.ts
@@ -124,6 +124,7 @@ export class EWSEvent extends Event {
 
   protected newRecurrenceRuleFromXML(xmljs: any): RecurrenceRule {
     let masterDuration = this.duration;
+    let timezone = this.timezone;
     let seriesStartTime = this.startTime;
     let seriesEndTime: Date | null = null;
     if (xmljs.EndDateRecurrence) {
@@ -144,7 +145,7 @@ export class EWSEvent extends Event {
     let weekdays = extractWeekdays(sanitize.nonemptystring(pattern.DaysOfWeek, null));
     let week = sanitize.integer(WeekOfMonth[pattern.DayOfWeekIndex], 0);
     let first = sanitize.integer(Weekday[pattern.FirstDayOfWeek], Weekday.Monday);
-    return new RecurrenceRule({ masterDuration, seriesStartTime, seriesEndTime, count, frequency, interval, weekdays, week, first });
+    return new RecurrenceRule({ masterDuration, timezone, seriesStartTime, seriesEndTime, count, frequency, interval, weekdays, week, first });
   }
 
   get outgoingInvitation() {
@@ -269,7 +270,7 @@ export class EWSEvent extends Event {
       pattern.t$Interval = rule.interval;
     }
     if (/^Relative|^Weekly/.test(recurrenceType)) {
-      let weekdays = rule.weekdays || [rule.seriesStartTime.getDay()];
+      let weekdays = rule.weekdays || [rule.seriesStartTime.getUTCDay()];
       pattern.t$DaysOfWeek = weekdays.map(day => Weekday[day]).join(" ");
     }
     if (rule.frequency == Frequency.Weekly) {
@@ -279,26 +280,26 @@ export class EWSEvent extends Event {
       pattern.t$DayOfWeekIndex = WeekOfMonth[rule.week];
     }
     if (/Absolute/.test(recurrenceType)) {
-      pattern.t$DayOfMonth = rule.seriesStartTime.getDate();
+      pattern.t$DayOfMonth = rule.seriesStartTime.getUTCDate();
     }
     if (rule.frequency == Frequency.Yearly) {
-      pattern.t$Month = rule.seriesStartTime.toLocaleDateString("en", { month: "long" });
+      pattern.t$Month = rule.seriesStartTime.toLocaleDateString("en", { month: "long", timeZone: "UTC" });
     }
     let recurrence: any = {};
     recurrence[`t$${recurrenceType}Recurrence`] = pattern;
     if (rule.count < Infinity) {
       recurrence.t$NumberedRecurrence = {
-        t$StartDate: this.dateString(rule.seriesStartTime, true),
+        t$StartDate: this.dateString(this.startTime, true),
         t$NumberOfOccurrences: rule.count,
       };
     } else if (rule.seriesEndTime) {
       recurrence.t$EndDateRecurrence = {
-        t$StartDate: this.dateString(rule.seriesStartTime, true),
+        t$StartDate: this.dateString(this.startTime, true),
         t$EndDate: this.dateString(rule.seriesEndTime, true),
       };
     } else {
       recurrence.t$NoEndRecurrence = {
-        t$StartDate: this.dateString(rule.seriesStartTime, true),
+        t$StartDate: this.dateString(this.startTime, true),
       };
     }
     return recurrence;

--- a/app/logic/Calendar/Event.ts
+++ b/app/logic/Calendar/Event.ts
@@ -343,19 +343,17 @@ export class Event extends Observable {
   newRecurrenceRule(frequency: Frequency, interval = 1, week = 0, weekdays?: number[]): void {
     let init: RecurrenceInit = {
       masterDuration: this.duration,
+      timezone: this.timezone,
       seriesStartTime: this.startTime,
       frequency,
       interval,
     };
     if (frequency == Frequency.Weekly) {
-      init.weekdays = weekdays?.includes(this.startTime.getDay()) ? weekdays : [...weekdays?.length > 1 ? weekdays : [], this.startTime.getDay()]; // e.g. Monday and Thursday
+      init.weekdays = weekdays;
     } else if (frequency == Frequency.Monthly || frequency == Frequency.Yearly) {
-      if (week) {
-        init.week = week == 5 && isLastWeekOfMonth(this.startTime) ? 5 : Math.ceil(this.startTime.getDate() / 7);
-        init.weekdays = [this.startTime.getDay()]; // e.g. 3rd Wednesday of month
-      }
+      init.week = week;
     }
-    this.recurrenceRule = new RecurrenceRule(init);
+    this.recurrenceRule = new RecurrenceRule(init, true);
   }
 
   /** Create a new instance of the same event.
@@ -797,8 +795,9 @@ export class Event extends Observable {
    */
   async setRecurrenceCount(count: number) {
     assert(this.recurrenceRule, "Need to have a rule to set its count");
-    let { masterDuration, seriesStartTime, frequency, interval, weekdays, week, first } = this.recurrenceRule;
-    this.recurrenceRule = new RecurrenceRule({ masterDuration, seriesStartTime, count, frequency, interval, weekdays, week, first });
+    let seriesStartTime = this.startTime;
+    let { masterDuration, timezone, frequency, interval, weekdays, week, first } = this.recurrenceRule;
+    this.recurrenceRule = new RecurrenceRule({ masterDuration, timezone, seriesStartTime, count, frequency, interval, weekdays, week, first });
     await this.trimExceptionsAndExclusions(this.recurrenceRule.getOccurrenceByIndex(count - 1));
   }
 
@@ -807,8 +806,9 @@ export class Event extends Observable {
    */
   async setRecurrenceEndTime(seriesEndTime: Date) {
     assert(this.recurrenceRule, "Need to have a rule to set its end time");
-    let { masterDuration, seriesStartTime, frequency, interval, weekdays, week, first } = this.recurrenceRule;
-    this.recurrenceRule = new RecurrenceRule({ masterDuration, seriesStartTime, seriesEndTime, frequency, interval, weekdays, week, first });
+    let seriesStartTime = this.startTime;
+    let { masterDuration, timezone, frequency, interval, weekdays, week, first } = this.recurrenceRule;
+    this.recurrenceRule = new RecurrenceRule({ masterDuration, timezone, seriesStartTime, seriesEndTime, frequency, interval, weekdays, week, first });
     await this.trimExceptionsAndExclusions(seriesEndTime);
   }
 
@@ -867,10 +867,4 @@ export enum RecurrenceCase {
    * Like an instance, but at a different time or with modified properties.
    * Overrides a specific instance. */
   Exception = "exception",
-}
-
-function isLastWeekOfMonth(date: Date) {
-  date = new Date(date);
-  date.setDate(date.getDate() + 7);
-  return date.getDate() < 8;
 }

--- a/app/logic/Calendar/ICal/ICalToEvent.ts
+++ b/app/logic/Calendar/ICal/ICalToEvent.ts
@@ -98,7 +98,7 @@ export function convertICalContainerToEvent(vevent: ICalContainer, event: Event)
     event.allDay = true;
   }
   if (vevent.entries.rrule) {
-    event.recurrenceRule = RecurrenceRule.fromCalString(event.duration, event.startTime, vevent.entries.rrule[0].line);
+    event.recurrenceRule = RecurrenceRule.fromCalString(event.duration, event.timezone, event.startTime, vevent.entries.rrule[0].line);
   } else {
     event.recurrenceRule = null;
   }

--- a/app/logic/Calendar/JMAP/JSCalendarEvent.ts
+++ b/app/logic/Calendar/JMAP/JSCalendarEvent.ts
@@ -37,6 +37,7 @@ export class JSCalendarEvent {
       let r = jmap.recurrenceRule;
       let rrinit: RecurrenceInit = {
         masterDuration: event.duration,
+        timezone: event.timezone,
         seriesStartTime: event.startTime,
         seriesEndTime: this.toDate(r.until, jmap, null),
         count: sanitize.integer(r.count, Infinity),

--- a/app/logic/Calendar/OWA/OWAEvent.ts
+++ b/app/logic/Calendar/OWA/OWAEvent.ts
@@ -121,6 +121,7 @@ export class OWAEvent extends Event {
 
   protected newRecurrenceRuleFromJSON(json: any): RecurrenceRule {
     let masterDuration = this.duration;
+    let timezone = this.timezone;
     let seriesStartTime = this.startTime;
     let seriesEndTime: Date | null = null;
     if (json.RecurrenceRange.EndDate) {
@@ -140,7 +141,7 @@ export class OWAEvent extends Event {
     let weekdays = extractWeekdays(pattern.DaysOfWeek);
     let week = sanitize.integer(WeekOfMonth[pattern.DayOfWeekIndex], 0);
     let first = sanitize.integer(Weekday[pattern.FirstDayOfWeek], Weekday.Monday);
-    return new RecurrenceRule({ masterDuration, seriesStartTime, seriesEndTime, count, frequency, interval, weekdays, week, first });
+    return new RecurrenceRule({ masterDuration, timezone, seriesStartTime, seriesEndTime, count, frequency, interval, weekdays, week, first });
   }
 
   get outgoingInvitation() {
@@ -317,7 +318,7 @@ export class OWAEvent extends Event {
       recurrence.RecurrencePattern.Interval = rule.interval;
     }
     if (/^Relative|^Weekly/.test(recurrenceType)) {
-      let weekdays = rule.weekdays || [rule.seriesStartTime.getDay()];
+      let weekdays = rule.weekdays || [rule.seriesStartTime.getUTCDay()];
       recurrence.RecurrencePattern.DaysOfWeek = weekdays.map(day => Weekday[day]).join(" ");
     }
     if (rule.frequency == Frequency.Weekly) {
@@ -327,12 +328,12 @@ export class OWAEvent extends Event {
       recurrence.RecurrencePattern.DayOfWeekIndex = WeekOfMonth[rule.week];
     }
     if (/Absolute/.test(recurrenceType)) {
-      recurrence.RecurrencePattern.DayOfMonth = rule.seriesStartTime.getDate();
+      recurrence.RecurrencePattern.DayOfMonth = rule.seriesStartTime.getUTCDate();
     }
     if (rule.frequency == Frequency.Yearly) {
-      recurrence.RecurrencePattern.Month = rule.seriesStartTime.toLocaleDateString("en", { month: "long" });
+      recurrence.RecurrencePattern.Month = rule.seriesStartTime.toLocaleDateString("en", { month: "long", timeZone: "UTC" });
     }
-    recurrence.RecurrenceRange.StartDate = this.dateString(rule.seriesStartTime, true);
+    recurrence.RecurrenceRange.StartDate = this.dateString(this.startTime, true);
     if (rule.count < Infinity) {
       recurrence.RecurrenceRange.__type = "NumberedRecurrence:#Exchange";
       recurrence.RecurrenceRange.NumberOfOccurrences = rule.count;

--- a/app/logic/Calendar/RecurrenceRule.ts
+++ b/app/logic/Calendar/RecurrenceRule.ts
@@ -36,8 +36,15 @@ export enum iCalWeekday {
   SA = 6,
 }
 
+/**
+ * Used to initialise a RecurrenceRule.
+ * The `Date`s in a RecurrenceInit use actual time.
+ * The rule itself holds seriesStartTime in a different format,
+ * so that it can easily extract the local time fields.
+ */
 export interface RecurrenceInit {
   masterDuration: number;
+  timezone?: string;
   seriesStartTime: Date;
   seriesEndTime?: Date;
   count?: number;
@@ -46,6 +53,18 @@ export interface RecurrenceInit {
   weekdays?: Weekday[];
   week?: number;
   first?: Weekday;
+}
+
+interface ZonedDate {
+  getTime(): number;
+  getUTCDay(): number;
+  getUTCFullYear(): number;
+  getUTCMonth(): number;
+  getUTCDate(): number;
+  getUTCHours(): number;
+  getUTCMinutes(): number;
+  getUTCSeconds(): number;
+  toLocaleDateString(locale: string, options: Intl.DateTimeFormatOptions): string;
 }
 
 /**
@@ -57,21 +76,29 @@ export interface RecurrenceInit {
  * The Outlook Web Access UI does allow a daily recurrence on specific weekdays,
  * but this is just a weekly recurrence with an interval of 1.
  */
-export class RecurrenceRule implements Readonly<RecurrenceInit> {
+export class RecurrenceRule implements Readonly<Omit<RecurrenceInit, "seriesStartTime">> {
   /**
    * The duration of the master event.
    *
    * Used by `timesMatch()` to see whether the time changes.
-   * Given that master.startTime == seriesStartTime and
+   * Given that master.startTime ~ seriesStartTime and
    * the master.endTime == masterStartTime + masterDuration,
    * we can detect changes in the master start and end time.
    */
-  masterDuration: number;
+  readonly masterDuration: number;
   /**
-   * The time of the first occurrence in the series.
-   * The same as the master event date.
+   * The time zone of the master event.
+   * Used to ensure that events recur on the correct day of the week.
+   * Defaults to the user's time zone.
    */
-  readonly seriesStartTime!: Date;
+  readonly timezone: string | undefined;
+  /**
+   * A date object whose UTC fields give the local time of
+   * the first occurrence in the series. This allows callers to
+   * easily determine the local date parts without needing a
+   * Temporal.ZonedDateTime object.
+   */
+  readonly seriesStartTime!: ZonedDate;
   /**
    * The date beyond which the recurrence stops.
    * If you also provide the count, the earlier is used.
@@ -120,19 +147,41 @@ export class RecurrenceRule implements Readonly<RecurrenceInit> {
   minutes: number;
   seconds: number;
 
-  constructor(data: RecurrenceInit) {
+  constructor(data: RecurrenceInit, additionalChecks?: boolean) {
     Object.assign(this, data);
+    // Callers like to pass in null but toLocaleString wants undefined
+    this.timezone ??= undefined;
     // EditEvent mutates the start time, so clone it to be safe.
-    let start = this.seriesStartTime = new Date(this.seriesStartTime);
-    this.occurrences.push(start);
-    this.weekday = start.getDay();
-    this.year = start.getFullYear();
-    this.month = start.getMonth();
-    this.day = start.getDate();
-    this.hours = start.getHours();
-    this.minutes = start.getMinutes();
-    this.seconds = start.getSeconds();
+    this.occurrences.push(new Date(data.seriesStartTime));
+    // Convert from the given time zone to get the right date parts.
+    let start = this.seriesStartTime = new Date(data.seriesStartTime.toLocaleString("lt", { timeZone: this.timezone }).replace(" ", "T") + "Z");
+    this.weekday = start.getUTCDay();
+    this.year = start.getUTCFullYear();
+    this.month = start.getUTCMonth();
+    this.day = start.getUTCDate();
+    this.hours = start.getUTCHours();
+    this.minutes = start.getUTCMinutes();
+    this.seconds = start.getUTCSeconds();
     // this.fillOccurrences(this.count, this.seriesEndTime || new Date(Date.now() + 1e11));
+    if (additionalChecks) {
+      if (this.frequency == Frequency.Weekly) {
+        if (!this.weekdays?.includes(this.weekday)) {
+          if (!(this.weekdays?.length > 1)) {
+            this.weekdays = [];
+          }
+          this.weekdays.push(this.weekday);
+        }
+      } else if (this.frequency == Frequency.Monthly || this.frequency == Frequency.Yearly) {
+        if (this.week) {
+          let nextWeek = new Date(start);
+          nextWeek.setUTCDate(this.day + 7);
+          if (nextWeek.getUTCDate() > 7 || this.week < 5) {
+            this.week = Math.ceil(this.day / 7);
+          }
+          this.weekdays = [this.weekday]; // e.g. 3rd Wednesday of month
+        }
+      }
+    }
   }
 
   static ensureFrequency(frequency: string): asserts frequency is Frequency {
@@ -141,13 +190,13 @@ export class RecurrenceRule implements Readonly<RecurrenceInit> {
     }
   }
 
-  static fromCalString(masterDuration: number, seriesStartTime: Date, calString: string): RecurrenceRule {
+  static fromCalString(masterDuration: number, timezone: string, seriesStartTime: Date, calString: string): RecurrenceRule {
     if (!/^RRULE:/i.test(sanitize.string(calString))) {
       throw new Error("Malformed recurrence rule string missing RRULE:");
     }
     let { FREQ: frequency, UNTIL: seriesEndTime, COUNT: count, INTERVAL: interval, BYDAY: byday, WKST: first } = Object.fromEntries(calString.slice(6).toUpperCase().split(";").map(part => part.split("="))) as Record<string, string>;
     this.ensureFrequency(frequency);
-    let data: RecurrenceInit = { masterDuration, seriesStartTime, frequency };
+    let data: RecurrenceInit = { masterDuration, timezone, seriesStartTime, frequency };
     if (seriesEndTime) {
       data.seriesEndTime = sanitizeCalDate(seriesEndTime);
       if (data.seriesEndTime < data.seriesStartTime) {
@@ -214,6 +263,7 @@ export class RecurrenceRule implements Readonly<RecurrenceInit> {
     let thisWeekdays = this.weekdays || kAllWeekdays;
     let ruleWeekdays = rule.weekdays || kAllWeekdays;
     return rule.masterDuration == this.masterDuration &&
+      rule.timezone == this.timezone &&
       rule.seriesStartTime.getTime() == this.seriesStartTime.getTime() &&
       rule.frequency == this.frequency &&
       rule.interval == this.interval &&
@@ -317,28 +367,35 @@ export class RecurrenceRule implements Readonly<RecurrenceInit> {
         }
         break;
       }
-      let occurrence = new Date(this.year, this.month, this.day, this.hours, this.minutes, this.seconds);
-      if (this.week == 5 && occurrence.getDate() != this.day) {
+      let utc = new Date(Date.UTC(this.year, this.month, this.day, this.hours, this.minutes, this.seconds));
+      if (this.week == 5 && utc.getUTCDate() != this.day) {
         // Month ran out of days. Advance to the next month/year.
         if (this.frequency == Frequency.Yearly) {
           this.year += this.interval;
         } else {
           this.month += this.interval;
         }
-        occurrence.setFullYear(this.year);
-        occurrence.setMonth(this.month);
+        utc.setUTCFullYear(this.year);
+        utc.setUTCMonth(this.month);
         // Temporarily advance to the next month.
-        occurrence.setDate(32);
+        utc.setUTCDate(32);
         // Rewind to the last week of the month.
-        occurrence.setDate(-6);
-        this.day = occurrence.getDate();
+        utc.setUTCDate(-6);
+        this.day = utc.getUTCDate();
       }
-      if (this.weekdays && !this.weekdays.includes(occurrence.getDay())) {
+      if (this.weekdays && !this.weekdays.includes(utc.getUTCDay())) {
         continue;
       }
-      if ((this.frequency == Frequency.Yearly || this.frequency == Frequency.Monthly) && occurrence.getDate() != this.day) {
+      if ((this.frequency == Frequency.Yearly || this.frequency == Frequency.Monthly) && utc.getUTCDate() != this.day) {
         // Ran out of days in the month, so rewind to the last day in the month.
-        occurrence.setDate(0);
+        utc.setUTCDate(0);
+      }
+      // Now convert the occurrence to the given time zone.
+      let offset = new Date(utc.toLocaleString("lt", { timeZone: this.timezone }).replace(" ", "T") + "Z").getTime() - utc.getTime();
+      let occurrence = new Date(utc.getTime() - offset);
+      offset = new Date(occurrence.toLocaleString("lt", { timeZone: this.timezone }).replace(" ", "T") + "Z").getTime() - utc.getTime();
+      if (offset) {
+        occurrence = new Date(occurrence.getTime() - offset);
       }
       // Don't allow more occurrences than the series wants
       if (this.seriesEndTime && occurrence > this.seriesEndTime) {
@@ -362,7 +419,7 @@ function sanitizeCalDate(dateStr: string) {
  * @returns A human-readable, translated description of the recurrence.
  * E.g. "Every month, on the third Wednesday of the month"
  */
-export function ruleAsLabel(r: RecurrenceRule, startTime: Date): string {
+export function ruleAsLabel(r: RecurrenceRule): string {
   let label = "";
   if (r.frequency == Frequency.Daily) {
     label += r.interval == 1
@@ -382,9 +439,9 @@ export function ruleAsLabel(r: RecurrenceRule, startTime: Date): string {
       : gt`Every ${r.interval} months`;
     label += `, `;
     if (r.week) {
-      label += gt`on the ${weekName(r.week)} ${weekdayLabel(r.weekday, "long")} *=> as in: on the third Wednesday of the month`;
+      label += gt`on the ${weekName(r.week)} ${r.seriesStartTime.toLocaleDateString(getDateTimeLocale(), { weekday: "long", timeZone: "UTC" })} *=> as in: on the third Wednesday of the month`;
     } else {
-      label += gt`on the ${startTime.toLocaleDateString(getDateTimeLocale(), { day: "numeric" })}th *=> as in: on the 5th of the month`;
+      label += gt`on the ${r.seriesStartTime.toLocaleDateString(getDateTimeLocale(), { day: "numeric", timeZone: "UTC" })}th *=> as in: on the 5th of the month`;
     }
   } else if (r.frequency == Frequency.Yearly) {
     label += r.interval == 1
@@ -392,9 +449,9 @@ export function ruleAsLabel(r: RecurrenceRule, startTime: Date): string {
       : gt`Every ${r.interval} years`;
     label += `, `;
     if (r.week) {
-      label += gt`on the ${weekName(r.week)} ${weekdayLabel(r.weekday, "long")} in ${startTime.toLocaleDateString(getDateTimeLocale(), { month: "long" })} *=> as in: on the third Wednesday in September`;
+      label += gt`on the ${weekName(r.week)} ${r.seriesStartTime.toLocaleDateString(getDateTimeLocale(), { weekday: "long", timeZone: "UTC" })} in ${r.seriesStartTime.toLocaleDateString(getDateTimeLocale(), { month: "long", timeZone: "UTC" })} *=> as in: on the third Wednesday in September`;
     } else {
-      label += gt`on ${startTime.toLocaleDateString(getDateTimeLocale(), { day: "numeric", month: "long" })} *=> as in: on the 5th July`;
+      label += gt`on ${r.seriesStartTime.toLocaleDateString(getDateTimeLocale(), { day: "numeric", month: "long", timeZone: "UTC" })} *=> as in: on the 5th July`;
     }
   }
   return label;

--- a/app/logic/Calendar/SQL/SQLEvent.ts
+++ b/app/logic/Calendar/SQL/SQLEvent.ts
@@ -178,7 +178,7 @@ export class SQLEvent extends Event {
       }
     }
     if (row.recurrenceRule) {
-      event.recurrenceRule = RecurrenceRule.fromCalString(event.duration, event.startTime, row.recurrenceRule);
+      event.recurrenceRule = RecurrenceRule.fromCalString(event.duration, event.timezone, event.startTime, row.recurrenceRule);
       await SQLEvent.readExclusions(event);
       event.generateRecurringInstances(); // TODO the exclusion should keep the parent in sync automatically
     }


### PR DESCRIPTION
The major changes are:
- `timezone` field added to `RecurrenceRule` and `RecurrenceInit`
- `RecurrenceRule.seriesStartTime` is no longer a true date

Ideally we would use a `Temporal.ZonedDateTime` to store the series start time, but they're not available yet. Instead, I'm using a regular `Date`, but using the `UTC` fields to store the series start time for the given time zone.

Let's take an example. A recurring event's start time is 2026-03-31T22:00:00 in zone America/New_York. This is 2026-04-01T02:00:00Z or 2026-04-01T04:00:00 in your time zone Europe/Berlin. When you're viewing that event, you will see it listed in Wednesday April 1 (or should I say Mittwoch?) in your calendar (because for you that's where it is), but for the creator of the event, it's in Tuesday March 31. In particular, if it's a weekly recurring event, their recurrence pattern will say "Every Tuesday", but in your calendar you want it to appear on Wednesdays.

To handle this, the `RecurrenceRule` will store the start date as 2026-03-31T22:00:00Z. As you can see, if I format that date in zone UTC, I will get the same result as if I format the original date in zone America/New_York: "10PM on March 31st 2026". Additionally, I can use functions such as `getUTCDay()` which will tell me that the day of the week is Tuesday.

The `RecurrenceRule` object will then use this to generate occurrences every week on Tuesday, still in the notional America/New_York zone but using the UTC fields, before converting to true time to save the actual occurrence dates, which due to the time zone difference will end up on Wednesdays as required, despite the rule being an "Every Tuesday" rule.

I've had to tweak the UI to show the recurrence as given by the event's time zone. In the case of calls to `toLocaleDateString`, this is done by using the `seriesStartTime` and passing a `timeZone` of "UTC"; I could have used `event.startTime` and `event.timezone` but I felt this was clearer since `seriesStartTime` had to be used for the other calls (e.g. to find the day of the week or week of the month) anyway.

For most of the rest of the callers it's just necessary to a) pass in the time zone when creating the `RecurrenceRule` b) using the `UTC` series of functions on the `recurrenceRule.seriesStartDate` c) where the UTC date is needed, switching back to `event.startDate`. To ensure `recurrenceRule.seriesStartDate` is used correctly I've given it its own interface, so that you get a TypeScript error if you try to use regular `Date` functions on it.

The one tricky caller was `newRecurrenceRule` where it's tricky to validate the `init` object before we know the day of week and/or month of the date in the event's time zone.