### PR TITLE
Properly handle participants with unknown availability #1150

### DIFF
--- a/app/frontend/Calendar/EditEvent/AvailabilityGrid.svelte
+++ b/app/frontend/Calendar/EditEvent/AvailabilityGrid.svelte
@@ -61,7 +61,7 @@
     to.setDate(to.getDate() + showDays);
     let availability = await calendar.arePersonsFree(participants.contents, from, to);
     console.log("availability", availability);
-    if (!availability?.length) { // || availability.filter(avp => avp.availability.length).length <= 1) {
+    if (!availability.some(avp => avp.availability)) {
       throw new UserError(gt`No way to know`);
     }
     for (let day = startDay; day <= startDay + showDays; day++) {
@@ -80,7 +80,7 @@
 
         let participantsInfo = availability.map(avp => ({
           participant: avp.participant,
-          free: avp.availability.find(av => av.from <= startTime && endTime <= av.to)?.free,
+          free: avp.availability?.every(av => av.to <= startTime || endTime <= av.from || av.free),
         }));
         let freeParticipants = participantsInfo.filter(avp => avp.free === true).map(avp => avp.participant);
         let busyParticipants = participantsInfo.filter(avp => avp.free === false).map(avp => avp.participant);
@@ -103,7 +103,7 @@
         let participantsStatus =
           (busyParticipants.length ? gt`Busy` + ": " + busyParticipants.map(p => p.name).join(", ") + "\n" : "") +
           (freeParticipants.length ? gt`Free` + ": " + freeParticipants.map(p => p.name).join(", ") + "\n" : "") +
-          (unknownParticipants ? gt`Unknown` + ": " + unknownParticipants.map(p => p.name).join(", ") : "");
+          (unknownParticipants.length ? gt`Unknown` + ": " + unknownParticipants.map(p => p.name).join(", ") : "");
         event.color =
           isFree ? "#CBF3E1" : // green
           isBusy ? "#FF7676" : // red

--- a/app/logic/Calendar/ActiveSync/ActiveSyncCalendar.ts
+++ b/app/logic/Calendar/ActiveSync/ActiveSyncCalendar.ts
@@ -43,7 +43,7 @@ export class ActiveSyncCalendar extends Calendar implements ActiveSyncPingable {
     return new ActiveSyncIncomingInvitation(this, message);
   }
 
-  async arePersonsFree(participants: Participant[], from: Date, to: Date): Promise<{ participant: Participant, availability: { from: Date, to: Date, free: boolean }[] }[]> {
+  async arePersonsFree(participants: Participant[], from: Date, to: Date): Promise<{ participant: Participant, availability?: { from: Date, to: Date, free: boolean }[] }[]> {
     return Promise.all(participants.map(async participant => {
       let request = {
         To: participant.emailAddress,
@@ -56,7 +56,8 @@ export class ActiveSyncCalendar extends Calendar implements ActiveSyncPingable {
       };
       let result = await this.account.callEAS("ResolveRecipients", request);
       if (result.Response.Status != "1") {
-        throw new ActiveSyncError("ResolveRecipients", result.Response.Status, this);
+        //throw new ActiveSyncError("ResolveRecipients", result.Response.Status, this);
+        return { participant };
       }
       let freebusy = sanitize.nonemptystring(result.Response.Recipient.Availability.MergedFreeBusy, "");
       let availability = freebusy.split("").map((c: string, i: number) => ({

--- a/app/logic/Calendar/CalDAV/CalDAVCalendar.ts
+++ b/app/logic/Calendar/CalDAV/CalDAVCalendar.ts
@@ -79,7 +79,7 @@ export class CalDAVCalendar extends Calendar {
     return davAB;
   };
 
-  async arePersonsFree(participants: Participant[], from: Date, to: Date): Promise<{ participant: Participant, availability: { from: Date, to: Date, free: boolean }[] }[]> {
+  async arePersonsFree(participants: Participant[], from: Date, to: Date): Promise<{ participant: Participant, availability?: { from: Date, to: Date, free: boolean }[] }[]> {
     return [];
   }
 

--- a/app/logic/Calendar/Calendar.ts
+++ b/app/logic/Calendar/Calendar.ts
@@ -73,8 +73,8 @@ export class Calendar extends Account {
     });
   }
 
-  async arePersonsFree(participants: Participant[], from: Date, to: Date): Promise<{ participant: Participant, availability: { from: Date, to: Date, free: boolean }[] }[]> {
-    return participants.map(participant => ({ participant, availability: [] }));
+  async arePersonsFree(participants: Participant[], from: Date, to: Date): Promise<{ participant: Participant, availability?: { from: Date, to: Date, free: boolean }[] }[]> {
+    return [];
   }
 
   async save(): Promise<void> {

--- a/app/logic/Calendar/EWS/EWSCalendar.ts
+++ b/app/logic/Calendar/EWS/EWSCalendar.ts
@@ -37,7 +37,7 @@ export class EWSCalendar extends Calendar {
     return new EWSIncomingInvitation(this, message);
   }
 
-  async arePersonsFree(participants: Participant[], from: Date, to: Date): Promise<{ participant: Participant, availability: { from: Date, to: Date, free: boolean }[] }[]> {
+  async arePersonsFree(participants: Participant[], from: Date, to: Date): Promise<{ participant: Participant, availability?: { from: Date, to: Date, free: boolean }[] }[]> {
     let request = {
       m$GetUserAvailabilityRequest: {
         m$MailboxDataArray: {
@@ -60,7 +60,7 @@ export class EWSCalendar extends Calendar {
     let results = await this.account.callEWS(request);
     return participants.map((participant, i) => ({
       participant,
-      availability: ensureArray(results[i].FreeBusyView.CalendarEventArray?.CalendarEvent).map(event => ({
+      availability: results[i].ResponseMessage.ResponseClass == "Error" ? undefined : ensureArray(results[i].FreeBusyView.CalendarEventArray?.CalendarEvent).map(event => ({
         from: sanitize.date(sanitize.nonemptystring(event.StartTime) + "Z"),
         to: sanitize.date(sanitize.nonemptystring(event.EndTime) + "Z"),
         free: event.BusyType == "Free",

--- a/app/logic/Calendar/JMAP/JMAPCalendar.ts
+++ b/app/logic/Calendar/JMAP/JMAPCalendar.ts
@@ -46,7 +46,8 @@ export class JMAPCalendar extends Calendar {
     return new JMAPIncomingInvitation(this, message);
   }
 
-  async arePersonsFree(participants: Participant[], from: Date, to: Date): Promise<{ participant: Participant, availability: { from: Date, to: Date, free: boolean }[] }[]> {
+  async arePersonsFree(participants: Participant[], from: Date, to: Date): Promise<{ participant: Participant, availability?: { from: Date, to: Date, free: boolean }[] }[]> {
+    return [];
   }
 
   async listEvents() {

--- a/app/logic/Calendar/OWA/OWACalendar.ts
+++ b/app/logic/Calendar/OWA/OWACalendar.ts
@@ -47,11 +47,11 @@ export class OWACalendar extends Calendar {
     return new OWAIncomingInvitation(this, message);
   }
 
-  async arePersonsFree(participants: Participant[], from: Date, to: Date): Promise<{ participant: Participant, availability: { from: Date, to: Date, free: boolean }[] }[]> {
+  async arePersonsFree(participants: Participant[], from: Date, to: Date): Promise<{ participant: Participant, availability?: { from: Date, to: Date, free: boolean }[] }[]> {
     let results = await this.callOWA(new OWAGetUserAvailabilityRequest(participants, from, to));
     return participants.map((participant, i) => ({
       participant,
-      availability: ensureArray(results.Responses[i].CalendarView.Items).map(event => ({
+      availability: results.Responses[i].ResponseMessage.ResponseClass == "Error" ? undefined : ensureArray(results.Responses[i].CalendarView.Items).map(event => ({
         from: new Date(event.Start + "Z"),
         to: new Date(event.End + "Z"),
         free: event.FreeBusyType == "Free",


### PR DESCRIPTION
`arePersonsFree` now returns:
- An empty array if the function is not supported
- An array of objects, one for each participant
- If the participant availability is unknown, then no availability array is returned
- If the participant availability is known, then an array with at least the time ranges that the participant is busy (an empty array means that the participant has no appointments at all in that time range)

I've also updated `AvailabilityGrid.svelte` to properly query the availability array.