### PR TITLE
Electron: Don't open new windows for other windows of the app

### DIFF
--- a/desktop/src/main/index.ts
+++ b/desktop/src/main/index.ts
@@ -165,7 +165,6 @@ async function whenReady() {
   }
 }
 
-// Reject opening new windows initially. It can be overriden to allow later.
 app.on('web-contents-created', (event, webContents) => setWindowOpenHandler(webContents));
 
 // Quit when all windows are closed, except on macOS. There, it's common

--- a/desktop/src/main/index.ts
+++ b/desktop/src/main/index.ts
@@ -1,5 +1,5 @@
 import { setMainWindow, startupBackend, shutdownBackend, startupArgs } from '../../backend/backend';
-import { app, shell, BrowserWindow, session, Menu, MenuItemConstructorOptions } from 'electron'
+import { app, shell, BrowserWindow, session, Menu, MenuItemConstructorOptions, type WebContents } from 'electron'
 import { ipcMain } from 'electron/main';
 import { join } from 'path'
 import electronUpdater from 'electron-updater';
@@ -165,6 +165,9 @@ async function whenReady() {
   }
 }
 
+// Reject opening new windows initially. It can be overriden to allow later.
+app.on('web-contents-created', (event, webContents) => setWindowOpenHandler(webContents));
+
 // Quit when all windows are closed, except on macOS. There, it's common
 // for applications and their menu bar to stay active until the user quits
 // explicitly with Cmd + Q.
@@ -250,6 +253,12 @@ function allowCrossDomainRequestsFromFrontend() {
       callback({ responseHeaders, statusLine });
     }
   );
+}
+
+function setWindowOpenHandler(webContents: WebContents) {
+  webContents.setWindowOpenHandler((details) => {
+    return { action: 'deny' };
+  });
 }
 
 // In this file you can include the rest of your app"s specific main process


### PR DESCRIPTION
- When you Ctrl/Cmd+Click it opens the link in a new Electron Window along with in the System Browser
- We don't set the windowHandler for all child or later created windows
- This sets the windowHandler to prevent open all windows that's not the main window from opening new Electron windows
- You have to check if the windows is destroyed before checking the web contents otherwise it will throw an error