### PR TITLE
WebView: Map Electron InputObject to Browser KeyboardEvent correctly #1154

### DIFF
--- a/app/frontend/Mail/Message/MessageKeyboard.ts
+++ b/app/frontend/Mail/Message/MessageKeyboard.ts
@@ -4,26 +4,6 @@ import { DeleteStrategy } from "../../../logic/Mail/MailAccount";
 import { selectedMessage, selectedMessages } from "../Selected";
 import { get } from "svelte/store";
 
-/**
- * Electron InputEvent uses shift / control / alt / meta, but
- * KeyboardEvent init needs shiftKey / ctrlKey / altKey / metaKey.
- * @see https://www.electronjs.org/docs/latest/api/web-contents#event-before-input-event
- * @see https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent
- */
-export function newElectronKeyboardEvent(event: any) {
-  return new KeyboardEvent("keydown", {
-    key: event.key,
-    code: event.code,
-    repeat: event.isAutoRepeat,
-    isComposing: event.isComposing,
-    shiftKey: event.shift,
-    ctrlKey: event.control,
-    altKey: event.alt,
-    metaKey: event.meta,
-    location: event.location,
-  });
-}
-
 // <https://developer.mozilla.org/en-US/docs/Web/API/UI_Events/Keyboard_event_key_values>
 
 export async function onKeyOnList(event: KeyboardEvent) {
@@ -175,4 +155,26 @@ function majority<T>(array: Array<T>, condition: (item: T) => boolean): boolean 
 
 function openComposer(mail: EMail) {
   mailMustangApp.writeMail(mail);
+}
+
+
+/**
+ * Electron InputEvent uses shift / control / alt / meta, but
+ * KeyboardEvent init needs shiftKey / ctrlKey / altKey / metaKey.
+ * Generic utility function
+ * @see https://www.electronjs.org/docs/latest/api/web-contents#event-before-input-event
+ * @see https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent
+ */
+export function newElectronKeyboardEvent(event: any) {
+  return new KeyboardEvent("keydown", {
+    key: event.key,
+    code: event.code,
+    repeat: event.isAutoRepeat,
+    isComposing: event.isComposing,
+    shiftKey: event.shift,
+    ctrlKey: event.control,
+    altKey: event.alt,
+    metaKey: event.meta,
+    location: event.location,
+  });
 }

--- a/app/frontend/Mail/Message/MessageKeyboard.ts
+++ b/app/frontend/Mail/Message/MessageKeyboard.ts
@@ -4,6 +4,26 @@ import { DeleteStrategy } from "../../../logic/Mail/MailAccount";
 import { selectedMessage, selectedMessages } from "../Selected";
 import { get } from "svelte/store";
 
+/**
+ * Electron InputEvent uses shift / control / alt / meta, but
+ * KeyboardEvent init needs shiftKey / ctrlKey / altKey / metaKey.
+ * @see https://www.electronjs.org/docs/latest/api/web-contents#event-before-input-event
+ * @see https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent
+ */
+export function newElectronKeyboardEvent(event: any) {
+  return new KeyboardEvent("keydown", {
+    key: event.key,
+    code: event.code,
+    repeat: event.isAutoRepeat,
+    isComposing: event.isComposing,
+    shiftKey: event.shift,
+    ctrlKey: event.control,
+    altKey: event.alt,
+    metaKey: event.meta,
+    location: event.location,
+  });
+}
+
 // <https://developer.mozilla.org/en-US/docs/Web/API/UI_Events/Keyboard_event_key_values>
 
 export async function onKeyOnList(event: KeyboardEvent) {

--- a/app/frontend/Shared/WebView.svelte
+++ b/app/frontend/Shared/WebView.svelte
@@ -152,7 +152,21 @@
       if (event.type == "mouseDown") {
         webviewE.click();
       } else if (event.type == "rawKeyDown") {
-        onKeyOnMessage(new KeyboardEvent("keydown", event));
+        // Electron InputEvent uses shift / control / alt / meta, but
+        // KeyboardEvent init needs shiftKey / ctrlKey / altKey / metaKey.
+        // see https://www.electronjs.org/docs/latest/api/web-contents#event-before-input-event
+        // see https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent
+        onKeyOnMessage(new KeyboardEvent("keydown", {
+          key: event.key,
+          code: event.code,
+          repeat: event.isAutoRepeat,
+          isComposing: event.isComposing,
+          shiftKey: event.shift,
+          ctrlKey: event.control,
+          altKey: event.alt,
+          metaKey: event.meta,
+          location: event.location,
+        }));
       }
     });
   }

--- a/app/frontend/Shared/WebView.svelte
+++ b/app/frontend/Shared/WebView.svelte
@@ -23,7 +23,7 @@
 <script lang="ts">
   // #if [!WEBMAIL]
   import { buildContextMenu, MenuItem, type ContextInfo } from "./ContextMenu";
-  import { onKeyOnMessage } from "../Mail/Message/MessageKeyboard";
+  import { newElectronKeyboardEvent, onKeyOnMessage } from "../Mail/Message/MessageKeyboard";
   import { appGlobal } from "../../logic/app";
   // import { Menu } from "@svelteuidev/core";
   // #endif
@@ -152,21 +152,7 @@
       if (event.type == "mouseDown") {
         webviewE.click();
       } else if (event.type == "rawKeyDown") {
-        // Electron InputEvent uses shift / control / alt / meta, but
-        // KeyboardEvent init needs shiftKey / ctrlKey / altKey / metaKey.
-        // see https://www.electronjs.org/docs/latest/api/web-contents#event-before-input-event
-        // see https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent
-        onKeyOnMessage(new KeyboardEvent("keydown", {
-          key: event.key,
-          code: event.code,
-          repeat: event.isAutoRepeat,
-          isComposing: event.isComposing,
-          shiftKey: event.shift,
-          ctrlKey: event.control,
-          altKey: event.alt,
-          metaKey: event.meta,
-          location: event.location,
-        }));
+        onKeyOnMessage(newElectronKeyboardEvent(event));
       }
     });
   }


### PR DESCRIPTION
- Electron and the Browser has different property names for the Keyboard event
- Electron uses the ones listed in [`before-input-event`](https://www.electronjs.org/docs/latest/api/web-contents#event-before-input-event) not the [`KeyboardInputEvent`](https://www.electronjs.org/docs/latest/api/structures/keyboard-input-event) or [`KeyboardEvent`](https://www.electronjs.org/docs/latest/api/structures/keyboard-event)
- The browser uses [`KeyboardEvent`](https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent)