### PR TITLE
Only restore instances, exceptions and exclusions of unedited recurring masters

### DIFF
--- a/app/logic/Calendar/Event.ts
+++ b/app/logic/Calendar/Event.ts
@@ -367,9 +367,11 @@ export class Event extends Observable {
     this.recurrenceStartTime = original.recurrenceStartTime;
     this.recurrenceCase = original.recurrenceCase;
     this.recurrenceRule = original.recurrenceRule;
-    this.instances.replaceAll(original.instances);
-    this.exceptions.replaceAll(original.exceptions);
-    this.exclusions.replaceAll(original.exclusions);
+    if (this.recurrenceRule) {
+      this.instances.replaceAll(original.instances);
+      this.exceptions.replaceAll(original.exceptions);
+      this.exclusions.replaceAll(original.exclusions);
+    }
     this.parentEvent = original.parentEvent;
   }
 


### PR DESCRIPTION
Regression from #1128, which while it fixed editing events and recurring master events, broke cloning events, causing issue #1164. I checked and this change doesn't seem to regress #1128.