### PR TITLE
S/MIME: Using node-forge

### DIFF
--- a/app/frontend/Contacts/PersonPage/EncryptionKey.svelte
+++ b/app/frontend/Contacts/PersonPage/EncryptionKey.svelte
@@ -120,7 +120,7 @@
         </hbox>
         <hbox>
           <hbox class="label">{$t`ID`}</hbox>
-          <hbox class="value">{key.id}</hbox>
+          <hbox class="value">{key.id.slice(-16)}</hbox>
         </hbox>
         {#if key.cipher}
           <hbox>

--- a/app/frontend/Contacts/PersonPage/EncryptionKey.svelte
+++ b/app/frontend/Contacts/PersonPage/EncryptionKey.svelte
@@ -119,7 +119,7 @@
         </hbox>
         <hbox>
           <hbox class="label">{$t`ID`}</hbox>
-          <hbox class="value">{key.id}</hbox>
+          <hbox class="value">{key.id.slice(-16)}</hbox>
         </hbox>
         {#if key.cipher}
           <hbox>

--- a/app/frontend/Settings/Mail/Account/Encryption.svelte
+++ b/app/frontend/Settings/Mail/Account/Encryption.svelte
@@ -15,7 +15,7 @@
   <hbox class="subtitle font-small">{$t`Private keys allow you to send encrypted emails, and to sign your own emails.`}</hbox>
   <vbox class="keys">
     {#if showCreate || showCreateOverride}
-      <EncryptionImport {identity} bind:isOpen={showCreateOverride} />
+      <EncryptionImport {identity} bind:isOpen={showCreateOverride} bind:showObsolete />
     {/if}
     {#each $keys.filterObservable(key => !key.obsolete).sortBy(key => key.sortOrder).each as key}
       <EncryptionKey {key} {identity} />

--- a/app/frontend/Settings/Mail/Account/EncryptionImport.svelte
+++ b/app/frontend/Settings/Mail/Account/EncryptionImport.svelte
@@ -95,6 +95,7 @@
   export let identity: MailIdentity;
   /** in/out */
   export let isOpen: boolean;
+  export let showObsolete: boolean;
 
   let showPassword = false;
   let passphrase: string;
@@ -104,7 +105,7 @@
   }
 
   let fileSelector: FileSelector;
-  const acceptFileTypes = [ "application/pgp-secret-keys", ".asc", "application/pkcs8", "application/x-pem-file", "text/plain" ];
+  const acceptFileTypes = [ "application/pgp-secret-keys", ".asc", "application/pkcs8", "application/x-pem-file", ".key", "text/plain" ];
   async function onImportFile(passphrase: string) {
     let file = await fileSelector.selectFile();
     if (!file) {
@@ -113,6 +114,9 @@
     let fileContent = await file.text();
     let key = await importPrivateKey(fileContent, passphrase);
     identity.encryptionPrivateKeys.add(key);
+    if (key.obsolete) {
+      showObsolete = true;
+    }
     isOpen = false;
     await identity.account.save();
   }

--- a/app/frontend/Settings/Mail/Account/EncryptionKey.svelte
+++ b/app/frontend/Settings/Mail/Account/EncryptionKey.svelte
@@ -74,7 +74,7 @@
       </hbox>
       <hbox>
         <hbox class="label">{$t`ID`}</hbox>
-        <hbox class="value">{key.id}</hbox>
+        <hbox class="value">{key.id.slice(-16)}</hbox>
       </hbox>
       {#if key.cipher}
         <hbox>
@@ -98,6 +98,29 @@
           {/each}
         </vbox>
       </hbox>
+      {#if chain}
+        <vbox>
+          <hbox class="label">{$t`Certificate chain *=> Any additional certificates that might be required to authenticate this key`}</hbox>
+          {#each $chain.each as certificate}
+            <hbox class="verification-code">
+              <pre wrap class="value">{certificate.fingerprintDisplay}</pre>
+              <vbox>
+                <RoundButton
+                  label={$t`Delete`}
+                  icon={DeleteIcon}
+                  onClick={() => onRemoveFromChain(certificate)}
+                  />
+              </vbox>
+            </hbox>
+          {/each}
+          <hbox>
+            <Button
+              label={$t`Add certificate… *=> Add the certificate for this private key, or an additional certificate in the chain`}
+              onClick={onFileCertificate}
+              />
+          </hbox>
+        </vbox>
+      {/if}
       <hbox>
         <hbox class="buttons">
           {#if !key.obsolete}
@@ -141,12 +164,16 @@
   {/if}
 </vbox>
 
+<FileSelector {acceptFileTypes} bind:this={fileSelector} />
+
 <script lang="ts">
   import type { PublicKey } from "../../../../logic/Mail/Encryption/PublicKey";
   import type { PrivateKey } from "../../../../logic/Mail/Encryption/PrivateKey";
+  import { SMIMEPublicKey } from "../../../../logic/Mail/Encryption/SMIME/SMIMEPublicKey";
   import { MailIdentity } from "../../../../logic/Mail/MailIdentity";
   import { saveBlobAsFile } from "../../../Util/util";
   import { appName } from "../../../../logic/build";
+  import FileSelector from "../../../Mail/Composer/Attachments/FileSelector.svelte";
   import Checkbox from "../../../Shared/Checkbox.svelte";
   import RoundButton from "../../../Shared/RoundButton.svelte";
   import Button from "../../../Shared/Button.svelte";
@@ -166,7 +193,9 @@
   export let key: PublicKey & PrivateKey;
   export let identity: MailIdentity;
 
-  let isExpanded = false;
+  $: chain = key instanceof SMIMEPublicKey ? key.chain : null;
+
+  let isExpanded = key.justCreated;
 
   let showSecretPassphrase = false;
   async function onExportPrivate() {
@@ -198,6 +227,21 @@
       }
     }
     identity.encryptionPrivateKeys.remove(key);
+    await identity.account.save();
+  }
+  let fileSelector: FileSelector;
+  const acceptFileTypes = [ "application/x-x509-email-cert", "application/x-x509-ca-cert", "application/pkix-cert", ".crt" ];
+  async function onFileCertificate() {
+    let file = await fileSelector.selectFile();
+    if (!file) {
+      return;
+    }
+    let fileContent = await file.text();
+    await (key as SMIMEPublicKey).addCertificate(fileContent);
+    await identity.account.save();
+  }
+  async function onRemoveFromChain(certificate) {
+    key.chain.remove(certificate);
     await identity.account.save();
   }
 </script>

--- a/app/logic/Mail/Encryption/KeyUtils.ts
+++ b/app/logic/Mail/Encryption/KeyUtils.ts
@@ -2,10 +2,12 @@ import type { PublicKey } from "./PublicKey";
 import type { PrivateKey } from "./PrivateKey";
 import type { Person } from "../../Abstract/Person";
 import type { PersonUID } from "../../Abstract/PersonUID";
+import type { EMail } from "../EMail";
 import { PGPPrivateKey } from "./PGP/PGPPrivateKey";
 import { PGPPublicKey } from "./PGP/PGPPublicKey";
 import { readAutoCryptKeys } from "./PGP/AutoCrypt";
-import type { EMail } from "../EMail";
+import { SMIMEPrivateKey } from "./SMIME/SMIMEPrivateKey";
+import { SMIMEPublicKey } from "./SMIME/SMIMEPublicKey";
 import { findAllIdentities, type MailIdentity } from "../MailIdentity";
 import { appGlobal } from "../../app";
 import { UserError, assert } from "../../util/util";
@@ -71,7 +73,10 @@ export async function importPrivateKey(fileContent: string, passphrase: string):
   assert(!fileContent.includes("PUBLIC KEY"), gt`This is a public key. If this is your key, you should also have the secret key in another file.`);
   if (fileContent.includes("-----BEGIN PGP PRIVATE KEY BLOCK-----")) {
     return await PGPPrivateKey.importPrivateKey(fileContent, passphrase);
-  } else if (fileContent.includes("-----BEGIN PRIVATE KEY BLOCK-----")) {
+  } else if (fileContent.includes("-----BEGIN PRIVATE KEY-----") ||
+    fileContent.includes("-----BEGIN ENCRYPTED PRIVATE KEY-----") ||
+    fileContent.includes("-----BEGIN RSA PRIVATE KEY-----")) {
+    return await SMIMEPrivateKey.importPrivateKey(fileContent, passphrase);
   }
   throw new UserError(gt`Could not find a key in this file`);
 }
@@ -81,7 +86,11 @@ export async function importPublicKey(fileContent: string): Promise<PublicKey> {
   assert(!fileContent.includes("PRIVATE KEY"), gt`This is a secret key. If this is your key, go to Settings | Mail | Identity | Encryption and import it there.`);
   if (fileContent.includes("-----BEGIN PGP PUBLIC KEY BLOCK-----")) {
     return await PGPPublicKey.importPublicKey(fileContent);
-  } else if (fileContent.includes("-----BEGIN PUBLIC KEY BLOCK-----")) {
+  } else if (fileContent.includes("-----BEGIN CERTIFICATE-----")) {
+    return await SMIMEPublicKey.importPublicKey(fileContent, false);
+  } else if (fileContent.includes("-----BEGIN TRUSTED CERTIFICATE-----")) {
+    // This is an OpenSSL certificate and may contain extra data.
+    return await SMIMEPublicKey.importPublicKey(fileContent);
   }
   throw new UserError(gt`Could not find a key in this file`);
 }

--- a/app/logic/Mail/Encryption/KeyUtils.ts
+++ b/app/logic/Mail/Encryption/KeyUtils.ts
@@ -4,6 +4,8 @@ import type { Person } from "../../Abstract/Person";
 import type { PersonUID } from "../../Abstract/PersonUID";
 import { PGPPrivateKey } from "./PGP/PGPPrivateKey";
 import { PGPPublicKey } from "./PGP/PGPPublicKey";
+import { SMIMEPrivateKey } from "./SMIME/SMIMEPrivateKey";
+import { SMIMEPublicKey } from "./SMIME/SMIMEPublicKey";
 import { findAllIdentities, type MailIdentity } from "../MailIdentity";
 import { appGlobal } from "../../app";
 import { UserError, assert } from "../../util/util";
@@ -55,7 +57,10 @@ export async function importPrivateKey(fileContent: string, passphrase: string):
   assert(!fileContent.includes("PUBLIC KEY"), gt`This is a public key. If this is your key, you should also have the secret key in another file.`);
   if (fileContent.includes("-----BEGIN PGP PRIVATE KEY BLOCK-----")) {
     return await PGPPrivateKey.importPrivateKey(fileContent, passphrase);
-  } else if (fileContent.includes("-----BEGIN PRIVATE KEY BLOCK-----")) {
+  } else if (fileContent.includes("-----BEGIN PRIVATE KEY-----") ||
+    fileContent.includes("-----BEGIN ENCRYPTED PRIVATE KEY-----") ||
+    fileContent.includes("-----BEGIN RSA PRIVATE KEY-----")) {
+    return await SMIMEPrivateKey.importPrivateKey(fileContent, passphrase);
   }
   throw new UserError(gt`Could not find a key in this file`);
 }
@@ -65,7 +70,11 @@ export async function importPublicKey(fileContent: string): Promise<PublicKey> {
   assert(!fileContent.includes("PRIVATE KEY"), gt`This is a secret key. If this is your key, go to Settings | Mail | Identity | Encryption and import it there.`);
   if (fileContent.includes("-----BEGIN PGP PUBLIC KEY BLOCK-----")) {
     return await PGPPublicKey.importPublicKey(fileContent);
-  } else if (fileContent.includes("-----BEGIN PUBLIC KEY BLOCK-----")) {
+  } else if (fileContent.includes("-----BEGIN CERTIFICATE-----")) {
+    return await SMIMEPublicKey.importPublicKey(fileContent, false);
+  } else if (fileContent.includes("-----BEGIN TRUSTED CERTIFICATE-----")) {
+    // This is an OpenSSL certificate and may contain extra data.
+    return await SMIMEPublicKey.importPublicKey(fileContent);
   }
   throw new UserError(gt`Could not find a key in this file`);
 }

--- a/app/logic/Mail/Encryption/PublicKey.ts
+++ b/app/logic/Mail/Encryption/PublicKey.ts
@@ -100,7 +100,7 @@ export class PublicKey extends Observable {
     json.name = this.name;
     json.id = this.id;
     json.fingerprint = this.fingerprint;
-    json.created = this.created.toISOString();
+    json.created = this.created?.toISOString();
     json.expires = this.expires?.toISOString();
     json.cipher = this.cipher;
     json.keyLengthInBits = this.keyLengthInBits;
@@ -117,8 +117,8 @@ export class PublicKey extends Observable {
     this.system = sanitize.enum<EncryptionSystem>(json.system, Object.values(EncryptionSystem));
     this.id = sanitize.alphanumdash(json.id);
     this.name = sanitize.label(json.name, this.id.substring(0, 4));
-    this.fingerprint = sanitize.alphanumdash(json.fingerprint);
-    this.created = sanitize.date(json.created);
+    this.fingerprint = sanitize.alphanumdash(json.fingerprint, "");
+    this.created = sanitize.date(json.created, null);
     this.expires = sanitize.date(json.expires, null);
     this.cipher = sanitize.nonemptylabel(json.cipher, null);
     this.keyLengthInBits = sanitize.integer(json.keyLengthInBits, null);

--- a/app/logic/Mail/Encryption/SMIME/SMIMEPrivateKey.ts
+++ b/app/logic/Mail/Encryption/SMIME/SMIMEPrivateKey.ts
@@ -1,5 +1,6 @@
 import { SMIMEPublicKey } from "./SMIMEPublicKey";
 import type { PrivateKey } from "../PrivateKey";
+import { SMIMEReadProcessor } from "./SMIMEReadProcessor";
 import { sanitize } from "../../../../../lib/util/sanitizeDatatypes";
 import { notifyChangedProperty } from "../../../util/Observable";
 
@@ -29,8 +30,31 @@ export class SMIMEPrivateKey extends SMIMEPublicKey implements PrivateKey {
     }
   }
 
+  async decryptKey() {
+    let forge = await import("node-forge");
+    return forge.pki.decryptRsaPrivateKey(this.privateKeyArmored, this.passphrase);
+  }
+
   privateKeyAsFile(): File {
     return this.keyAsFile(this.privateKeyArmored, "application/pkcs8", "SecretKey", "p8");
+  }
+
+  /**
+   * Reads an S/MIME private key from a file.
+   * Factory function.
+   * @param passphrase
+   *     Not yet supported.
+   */
+  static async importPrivateKey(privateKey: string, passphrase?: string): Promise<SMIMEPrivateKey> {
+    let key = new SMIMEPrivateKey();
+    key.privateKeyArmored = privateKey;
+    key.passphrase = passphrase;
+    let forge = await import("node-forge");
+    let rsa = forge.pki.decryptRsaPrivateKey(privateKey, passphrase);
+    key.id = rsa.n.toString(16);
+    key.keyLengthInBits = key.id.length * 4;
+    key.justCreated = true;
+    return key;
   }
 
   toJSON() {
@@ -49,3 +73,5 @@ export class SMIMEPrivateKey extends SMIMEPublicKey implements PrivateKey {
     this.passphrase = sanitize.string(json.passphrase, null);
   }
 }
+
+SMIMEReadProcessor.hookup();

--- a/app/logic/Mail/Encryption/SMIME/SMIMEPublicKey.ts
+++ b/app/logic/Mail/Encryption/SMIME/SMIMEPublicKey.ts
@@ -1,13 +1,92 @@
 import { PublicKey, EncryptionSystem } from "../PublicKey";
+import { sanitize } from "../../../../../lib/util/sanitizeDatatypes";
+import { ArrayColl } from "svelte-collections";
 
 export class SMIMEPublicKey extends PublicKey {
   system = EncryptionSystem.SMIME;
+  cipher = "RSA";
   /**
    * Armored (base64-encoded) public S/MIME certificate
    */
   declare publicKeyArmored: string;
 
+  chain = new ArrayColl<SMIMEPublicKey>();
+
+  constructor() {
+    super();
+    this.id = ""; // What is this field anyway?
+    this.obsolete = true;
+    this.fingerprint = "";
+  }
+
+  get certificate(): string {
+    return this.publicKeyArmored;
+  }
+
+  /**
+   * Parses the given certificate and sets it as the public key.
+   * Only set parseAllBytes to true if you know what you're doing.
+   */
+  async setCertificate(certificate: string, parseAllBytes = false) {
+    let forge = await import("node-forge");
+    let cert = forge.pki.certificateFromPem(certificate, true, { parseAllBytes });
+    let id = cert.publicKey.n.toString(16);
+    if (!this.id) {
+      this.id = id;
+      this.keyLengthInBits = id.length * 4;
+    } else if (id != this.id) {
+      throw new Error("Certificate does not match private key");
+    }
+    this.publicKeyArmored = forge.pki.certificateToPem(cert);
+    this.name = cert.subject.getField("E").value;
+    this.fingerprint = cert.md.digest().toHex();
+    this.created = cert.validity.notBefore;
+    this.expires = cert.validity.notAfter;
+    let now = new Date();
+    this.obsolete = now < this.created || now > this.expires;
+  }
+
+  async addCertificate(certificate: string) {
+    let forge = await import("node-forge");
+    let cert = forge.pki.certificateFromPem(certificate, false, { parseAllBytes: false });
+    let id = cert.publicKey.n.toString(16);
+    if (!this.id || this.id == id) {
+      await this.setCertificate(certificate);
+    } else {
+      let key = this.chain.find(key => key.id == id);
+      if (key) {
+        await key.setCertificate(certificate);
+      } else {
+        this.chain.add(await SMIMEPublicKey.importPublicKey(certificate));
+      }
+    }
+  }
+
+  /** Reads an S/MIME certificate from a file.
+   * maybeOpenSSL: True if this certificate might be an OpenSSL certificate
+   * Factory function. */
+  static async importPublicKey(publicKey: string, maybeOpenSSL = true): Promise<SMIMEPublicKey> {
+    let key = new SMIMEPublicKey();
+    await key.setCertificate(publicKey, !maybeOpenSSL);
+    return key;
+  }
+
   publicKeyAsFile(): File {
     return this.keyAsFile(this.publicKeyArmored, "application/pkix-cert", "PublicKey", "crt");
+  }
+
+  toJSON() {
+    let json = super.toJSON();
+    json.chain = this.chain.contents.map(key => key.toJSON());
+    return json;
+  }
+
+  fromJSON(json: any) {
+    super.fromJSON(json);
+    for (let certificate of sanitize.array(json.chain, [])) {
+      let key = new SMIMEPublicKey();
+      key.fromJSON(certificate);
+      this.chain.add(key);
+    }
   }
 }

--- a/app/logic/Mail/Encryption/SMIME/SMIMEReadProcessor.ts
+++ b/app/logic/Mail/Encryption/SMIME/SMIMEReadProcessor.ts
@@ -1,0 +1,81 @@
+import { EMailProcessor, ProcessingStartOn } from "../../EMailProcessor";
+import type { EMail } from "../../EMail";
+import { MailIdentity } from "../../MailIdentity";
+import { SMIMEPrivateKey } from "./SMIMEPrivateKey";
+import { parseMIMEDirectSubparts } from "../MIME";
+import { assert, blobToBase64 } from "../../../util/util";
+import { ArrayColl, Collection } from "svelte-collections";
+import type { Email as PostalEmail } from "postal-mime";
+
+export class SMIMEReadProcessor extends EMailProcessor {
+  runOn = ProcessingStartOn.Parse;
+  async process(email: EMail, postal: PostalEmail) {
+    // There is a direct accessor to the content type in the PostalMIME object
+    // itself, but we don't have that here. And to get the headers in the
+    // EMail object requires an extra parse, which seems wasteful. So
+    // let's fish the header out of the PostalEmail object...
+    let contentTypeHeader = postal.headers.find(header => header.key == "content-type")?.value ?? "";
+    let contentType = contentTypeHeader.split(";")[0].trim().toLowerCase();
+    if (contentType == "application/pkcs7-mime") {
+      // Encrypted messages only have a body part but fsr this is an attachment.
+      let encrypted = email.attachments.first;
+      let forge = await import("node-forge");
+      // PostalMIME has decoded the base64 for us but forge wants the base64...
+      let pem = "-----BEGIN PKCS7-----\r\n" + await blobToBase64(encrypted.content) + "\r\n-----END PKCS7-----\r\n";
+      let pkcs7 = forge.pkcs7.messageFromPem(pem);
+      // XXX what if you were BCC'd?
+      for (let recipient of email.allRecipients()) {
+        let identity = MailIdentity.findIdentity(new ArrayColl([recipient]), email.folder?.account)?.identity;
+        if (identity) {
+          for (let privateKey of identity.encryptionPrivateKeys) {
+            if (privateKey instanceof SMIMEPrivateKey) {
+              let cert = forge.pki.certificateFromPem(privateKey.certificate);
+              let recipient = pkcs7.findRecipient(cert);
+              if (recipient) {
+                let rsa = await privateKey.decryptKey();
+                pkcs7.decrypt(recipient, rsa);
+                let originalFrom = email.from.emailAddress.toLowerCase();
+                email.wasEncrypted = true;
+                email.downloadComplete = false;
+                email.mime = new TextEncoder().encode(pkcs7.content.toString());
+                email.resetProperties();
+                await email.parseMIME();
+                // Signature will have been checked recursively
+                if (email.from.emailAddress.toLowerCase() != originalFrom) {
+                  email.signed = null;
+                }
+                await email.saveCompleteMessage();
+                return;
+              }
+            }
+          }
+        }
+      }
+    } else if (contentType == "multipart/signed") {
+      let signed = email.attachments.last;
+      if (signed.mimeType.toLowerCase() == "application/pkcs7-signature") {
+        let parts = parseMIMEDirectSubparts(email.mime, contentTypeHeader);
+        assert(parts.length == 2, "multipart/signed must have exactly 2 subparts: cleartext and signature, but got " + parts.length);
+        let [clearText, signature] = parts;
+        let forge = await import("node-forge");
+        let pem = "-----BEGIN PKCS7-----\r\n" + signature.split("\r\n\r\n")[1] + "\r\n-----END PKCS7-----\r\n";
+        let pkcs7 = forge.pkcs7.messageFromPem(pem);
+        // forge hasn't implemented signature verification yet.
+        let oid = forge.asn1.derToOid(pkcs7.rawCapture.digestAlgorithm);
+        let digestAlgorithm = forge.md[forge.pki.oids[oid]];
+        let digest = digestAlgorithm.create().start().update(clearText).digest().bytes();
+        let messageDigest = pkcs7.rawCapture.authenticatedAttributes.find(attr => forge.asn1.derToOid(attr.value[0].value) == forge.pki.oids.messageDigest);
+        if (digest != messageDigest?.value?.[1]?.value?.[0]?.value) {
+          console.log("Ignoring signature as its digest does not match the message");
+          return;
+        }
+        let authenticatedAttributes = forge.asn1.toDer(forge.asn1.create(forge.asn1.Class.UNIVERSAL, forge.asn1.Type.SET, true, pkcs7.rawCapture.authenticatedAttributes)).getBytes();
+        let attributesDigest = digestAlgorithm.create().start().update(authenticatedAttributes).digest().bytes();
+        if (pkcs7.certificates[0].publicKey.verify(attributesDigest, pkcs7.rawCapture.signature)) {
+          email.signed = pkcs7.certificates[0].publicKey.n.toString(16);
+          // TODO: need to all user to save the certificate
+        }
+      }
+    }
+  }
+}

--- a/app/logic/Mail/Encryption/SMIME/SMIMESend.ts
+++ b/app/logic/Mail/Encryption/SMIME/SMIMESend.ts
@@ -1,6 +1,11 @@
 import { SendEncrypted } from "../SendEncrypted";
 import type { EMail } from "../../EMail";
+import { getMyPrivateKey, getPublicKeyForPerson } from "../KeyUtils";
 import { CreateMIME } from "../../SMTP/CreateMIME";
+import { SMIMEPublicKey } from "./SMIMEPublicKey";
+import { SMIMEPrivateKey } from "./SMIMEPrivateKey";
+import { NotReached, assert } from "../../../util/util";
+import { gt } from "../../../../l10n/l10n";
 
 export class SMIMESend {
   /**
@@ -14,8 +19,80 @@ export class SMIMESend {
    *   The original email is untouched.
    */
   static async encryptAndSign(mail: EMail): Promise<EMail> {
+    let privateKey = getMyPrivateKey(mail.identity, SMIMEPrivateKey);
+    assert(privateKey, gt`Please first set up S/MIME encryption for yourself, in Settings | Mail | Identity | Encryption`);
     let result = SendEncrypted.cloneEMail(mail);
-    let mime = CreateMIME.getMIME(mail);
+    let mime = await CreateMIME.getMIME(mail);
+    let mimeAsText = new TextDecoder().decode(mime);
+    let headers = mimeAsText.slice(0, mimeAsText.indexOf("\r\n\r\n")).split("\r\n");
+    let forge = await import("node-forge");
+    if (mail.signed) {
+      if (!mail.shouldEncrypt) {
+        // Some MTAs strip User-Agent headers on MIME parts.
+        mimeAsText = mimeAsText.replace(/^User-Agent: .+\r\n/m, "");
+      }
+      let pkcs7 = forge.pkcs7.createSignedData();
+      pkcs7.content = forge.util.createBuffer(mimeAsText, "utf8");
+      pkcs7.addCertificate(privateKey.certificate);
+      for (let key of privateKey.chain) {
+        pkcs7.addCertificate(key.certificate);
+      }
+      pkcs7.addSigner({
+        key: await privateKey.decryptKey(),
+        certificate: privateKey.certificate,
+        digestAlgorithm: forge.pki.oids.sha256,
+        authenticatedAttributes: [
+          { type: forge.pki.oids.contentType, value: forge.pki.oids.data },
+          { type: forge.pki.oids.messageDigest },
+          { type: forge.pki.oids.signingTime },
+        ],
+      });
+      pkcs7.sign({ detached: true });
+      let asn1 = pkcs7.toAsn1();
+      let der = forge.asn1.toDer(asn1);
+      let boundary = "----" + crypto.randomUUID().replace(/-/g, "");
+      mimeAsText = [
+        `Content-Type: multipart/signed; protocol="application/pkcs7-signature"; micalg=sha256; boundary ="${boundary}"`,
+        ... headers.filter(header => !/^Content-Type: /i.test(header)),
+        '',
+        `--${boundary}`,
+        mimeAsText,
+        `--${boundary}`,
+        'Content-Type: application/pkcs7-signature; name="smime.p7s"',
+        'Content-Transfer-Encoding: base64',
+        'Content-Disposition: attachment; filename="smime.p7s"',
+        '',
+        ... btoa(der.getBytes()).match(/.{1,76}/g),
+        `--${boundary}--`,
+        '',
+      ].join("\r\n");
+    }
+    if (mail.shouldEncrypt) {
+      let recipientKeys = mail.allRecipients().contents.flatMap(puid =>
+        getPublicKeyForPerson(puid.findPerson(), SMIMEPublicKey));
+      if (!recipientKeys.some(key => key.id == privateKey.id)) {
+        recipientKeys.push(privateKey);
+      }
+      let pkcs7 = forge.pkcs7.createEnvelopedData();
+      pkcs7.content = forge.util.createBuffer(mimeAsText, "utf8");
+      for (let recipientKey of recipientKeys) {
+        let cert = forge.pki.certificateFromPem(recipientKey.certificate);
+        pkcs7.addRecipient(cert);
+      }
+      pkcs7.encrypt();
+      let asn1 = pkcs7.toAsn1();
+      let der = forge.asn1.toDer(asn1);
+      mimeAsText = [
+        'Content-Type: application/pkcs7-mime; smime-type=enveloped-data; name="smime.p7m"',
+        'Content-Transfer-Encoding: base64',
+        `Content-Disposition: attachment; filename="smime.p7m"`,
+        ... headers.filter(header => !/^Content-Type: /i.test(header)),
+        '',
+        ... btoa(der.getBytes()).match(/.{1,76}/g),
+        '',
+      ].join("\r\n");
+    }
+    result.sendRawMIME = mimeAsText;
     return result;
   }
 }

--- a/app/package.json
+++ b/app/package.json
@@ -51,6 +51,7 @@
     "lucide-svelte": "^0.562.0",
     "markdown-it": "^14.1.0",
     "matrix-js-sdk": "^40.1.0-rc.0",
+    "node-forge": "^1.4.0",
     "openpgp": "^6.3.0",
     "password-salt": "^5.0.1",
     "pkce-challenge": "^5.0.1",

--- a/app/package.json
+++ b/app/package.json
@@ -52,6 +52,7 @@
     "lucide-svelte": "^0.562.0",
     "markdown-it": "^14.1.0",
     "matrix-js-sdk": "^40.1.0-rc.0",
+    "node-forge": "^1.4.0",
     "openpgp": "^6.3.0",
     "password-salt": "^5.0.1",
     "pkce-challenge": "^5.0.1",


### PR DESCRIPTION
Using the `node-forge` library. Functions:

- Import password-protected private key
- Import certificate(s) for private key
- Import public key
- Sign messages
- Encrypt messages
- Decrypt messages
- Verify signatures

Note: When Thunderbird encrypts a message, it only includes the Content-Type header in the encrypted message. Currently this code generates an encrypted message with all headers and expects that when decrypting.