### PR TITLE
Calendar: Fix 'Change Remainder' #1178

### DIFF
--- a/app/frontend/Calendar/EditEvent/DialogHeader.svelte
+++ b/app/frontend/Calendar/EditEvent/DialogHeader.svelte
@@ -257,8 +257,8 @@
     }
     await saveEvent(master);
     master.finishEditing();
-    event.parentEvent.cancelEditing();
     event.cancelEditing();
+    event.parentEvent.cancelEditing();
     await event.truncateRecurrence();
     onClose();
   }
@@ -292,8 +292,8 @@
   }
 
   async function onDeleteRemainder() {
-    event.parentEvent.cancelEditing();
     event.cancelEditing();
+    event.parentEvent.cancelEditing();
     await event.truncateRecurrence();
     $selectedEvent = null;
     onClose();


### PR DESCRIPTION
Cancelling editing while the editing screen is open restarts editing of the master, so cancel the master after cancelling the event. I didn't check to see whether deleting events was broken before this change but it works with it.