### PR TITLE
Fix actual bitrot to #984 from #1051

### DIFF
--- a/lib/jpc/obj.js
+++ b/lib/jpc/obj.js
@@ -300,7 +300,7 @@ export default class BaseProtocol {
     return /** @this {RemoteClass} */ async function() {
       // this == stub object
       let props = await self.callRemote("refresh", { obj: this._jpc_id });
-      await self.updateObjectProperties(this, props);
+      await self.updateObjectProperties(this, await self.mapIncomingObjects(props));
       return this;
     }
   }
@@ -502,11 +502,11 @@ export default class BaseProtocol {
       }
 
       if (typeof property.value != "function") {
-        props[propName] = this.mapOutgoingObjects(property.value);
+        props[propName] = property.value;
       }
     }
 
-    return props;
+    return this.mapOutgoingObjects(props);
   }
 
   /**


### PR DESCRIPTION
PR #1051 changed the way `updateObjectProperties` works which bitrotted PR #984. (Previously each property was mapped individually but this caused duplication so all of the properties are now mapped in a single call.)