### PR TITLE
Throw if attempting to get capabilities before login

### DIFF
--- a/app/logic/Mail/IMAP/IMAPAccount.ts
+++ b/app/logic/Mail/IMAP/IMAPAccount.ts
@@ -66,7 +66,6 @@ export class IMAPAccount extends MailAccount {
   }
 
   async startup() {
-    this.namespaces = await this.getNamespaces();
     await super.startup();
     this.notifyObservers();
     (this.inbox as IMAPFolder).startPolling();
@@ -157,6 +156,8 @@ export class IMAPAccount extends MailAccount {
       this.connections.set(purpose, connection);
       this.connectionLock.set(connection, new Lock());
       if (purpose == ConnectionPurpose.Main) {
+        // Get namespaces and refresh connection early to avoid race condition.
+        this.namespaces = await this.getNamespaces();
         this.notifyObservers();
       }
       this.log(null, connection, "connected");

--- a/app/logic/Mail/IMAP/IMAPAccount.ts
+++ b/app/logic/Mail/IMAP/IMAPAccount.ts
@@ -50,8 +50,7 @@ export class IMAPAccount extends MailAccount {
   }
 
   get isLoggedIn(): boolean {
-    // return !!this.connectionMain?.authenticated; TODO authenticated is always false
-    return !!this.connections.get(ConnectionPurpose.Main) || this.oAuth2?.isLoggedIn;
+    return !!this.connections.get(ConnectionPurpose.Main)?.authenticated;
   }
 
   async login(interactive: boolean): Promise<void> {
@@ -258,6 +257,9 @@ export class IMAPAccount extends MailAccount {
   }
 
   async hasCapability(capa: string): Promise<boolean> {
+    if (!this.isLoggedIn) {
+      throw new LoginError(null, gt`Please login`);
+    }
     let conn = await this.connection();
     // conn.capabilities was automatically updated via `getNamespaces`
     return await conn.capabilities.has(capa);

--- a/app/logic/Mail/IMAP/IMAPAccount.ts
+++ b/app/logic/Mail/IMAP/IMAPAccount.ts
@@ -66,6 +66,7 @@ export class IMAPAccount extends MailAccount {
   }
 
   async startup() {
+    this.namespaces = await this.getNamespaces();
     await super.startup();
     this.notifyObservers();
     (this.inbox as IMAPFolder).startPolling();
@@ -156,8 +157,6 @@ export class IMAPAccount extends MailAccount {
       this.connections.set(purpose, connection);
       this.connectionLock.set(connection, new Lock());
       if (purpose == ConnectionPurpose.Main) {
-        // Get namespaces and refresh connection early to avoid race condition.
-        this.namespaces = await this.getNamespaces();
         this.notifyObservers();
       }
       this.log(null, connection, "connected");

--- a/lib/jpc/obj.js
+++ b/lib/jpc/obj.js
@@ -300,7 +300,7 @@ export default class BaseProtocol {
     return /** @this {RemoteClass} */ async function() {
       // this == stub object
       let props = await self.callRemote("refresh", { obj: this._jpc_id });
-      await self.updateObjectProperties(this, props);
+      await self.updateObjectProperties(this, await self.mapIncomingObjects(props));
       return this;
     }
   }
@@ -502,11 +502,11 @@ export default class BaseProtocol {
       }
 
       if (typeof property.value != "function") {
-        props[propName] = this.mapOutgoingObjects(property.value);
+        props[propName] = property.value;
       }
     }
 
-    return props;
+    return this.mapOutgoingObjects(props);
   }
 
   /**


### PR DESCRIPTION
Drafting because this depends on PR #1193.

The race condition happens because startup code (e.g. `loadFolder`) can try to access `IMAPAccount.hasCapability` before `IMAPAccount.startup` has refreshed it.

This also allows `this.connections.get(ConnectionPurpose.Main)?.authenticated` to work (see comment in `isLoggedIn`).