### PR TITLE
Mobile: AppMenu: Stop click event propagation to stop navigating back #1197

### DIFF
--- a/app/frontend/AppsBar/AppMenuM/BasicButton.svelte
+++ b/app/frontend/AppsBar/AppMenuM/BasicButton.svelte
@@ -1,5 +1,5 @@
 <RoundButton
-  {label} {icon} {onClick}
+  {label} {icon} onClick={myOnClick}
   classes="plain {classes}"
   iconSize="24px"
   padding="12px"
@@ -19,6 +19,11 @@
   export let params = {};
 
   export let classes = "";
+
+  async function myOnClick(event: Event) {
+    event.stopPropagation();
+    await onClick();
+  }
 
   function onClickPage() {
     goTo(page, params);


### PR DESCRIPTION
- Stop click event propagation to stop navigating back after navigating to the desired page, that's why here was a flash