### PR TITLE
EWS, OWA: Subaccounts: Make double startups less likely

### DIFF
--- a/app/logic/Abstract/Account.ts
+++ b/app/logic/Abstract/Account.ts
@@ -277,6 +277,7 @@ export function setMainAccounts(): void {
     let mainID = account._mainAccountID;
     if (mainID && !account.mainAccount) {
       account.mainAccount = accounts.find(acc => acc.id == mainID);
+      account.notifyObservers();
     }
   }
 }

--- a/app/logic/Abstract/Account.ts
+++ b/app/logic/Abstract/Account.ts
@@ -36,6 +36,7 @@ export class Account extends Observable {
   @notifyChangedProperty
   realname: string = appGlobal.me?.name;
   /** @see `mainAccount` */
+  @notifyChangedProperty
   _mainAccount: Account | null = null;
   /** Internal. Used only during load. */
   _mainAccountID: string | null = null;
@@ -277,7 +278,6 @@ export function setMainAccounts(): void {
     let mainID = account._mainAccountID;
     if (mainID && !account.mainAccount) {
       account.mainAccount = accounts.find(acc => acc.id == mainID);
-      account.notifyObservers();
     }
   }
 }

--- a/app/logic/Mail/ActiveSync/ActiveSyncAccount.ts
+++ b/app/logic/Mail/ActiveSync/ActiveSyncAccount.ts
@@ -139,9 +139,7 @@ export class ActiveSyncAccount extends MailAccount {
 
   notifyObserversOfSubaccounts() {
     for (let account of this.dependentAccounts()) {
-      if (account.mainAccount == this) {
-        account.notifyObservers();
-      }
+      account.notifyObservers();
     }
   }
 

--- a/app/logic/Mail/ActiveSync/ActiveSyncAccount.ts
+++ b/app/logic/Mail/ActiveSync/ActiveSyncAccount.ts
@@ -102,9 +102,9 @@ export class ActiveSyncAccount extends MailAccount {
           throw new ActiveSyncError("Settings", response.DeviceInformation.Status, this);
         }
       }
-    });
 
-    await this.startup();
+      await this.startup();
+    });
   }
 
   async startup() {

--- a/app/logic/Mail/ActiveSync/ActiveSyncAccount.ts
+++ b/app/logic/Mail/ActiveSync/ActiveSyncAccount.ts
@@ -85,7 +85,10 @@ export class ActiveSyncAccount extends MailAccount {
       if (this.authMethod == AuthMethod.OAuth2) {
         this.oAuth2 ??= getOAuth2BuiltIn(this);
         assert(this.oAuth2, gt`Could not find OAuth2 config for ${this.hostname}`);
-        this.oAuth2.subscribe(() => this.notifyObservers());
+        this.oAuth2.subscribe(() => {
+          this.notifyObservers();
+          this.notifyObserversOfSubaccounts();
+        });
         await this.oAuth2.login(interactive);
       }
       this.protocolVersion = this.getStorageItem("protocolVersion");
@@ -131,6 +134,14 @@ export class ActiveSyncAccount extends MailAccount {
     let galAB = appGlobal.searchOnlyAddressbooks.find(ab => ab.mainAccount == this);
     if (galAB) {
       appGlobal.searchOnlyAddressbooks.remove(galAB);
+    }
+  }
+
+  notifyObserversOfSubaccounts() {
+    for (let account of this.dependentAccounts()) {
+      if (account.mainAccount == this) {
+        account.notifyObservers();
+      }
     }
   }
 

--- a/app/logic/Mail/EWS/EWSAccount.ts
+++ b/app/logic/Mail/EWS/EWSAccount.ts
@@ -129,7 +129,7 @@ export class EWSAccount extends MailAccount implements EWSSubscribable {
   }
 
   async logout(): Promise<void> {
-    if (this.mainAccount) {
+    if (this.isDependentAccount) {
       await this.mainAccount.logout();
       return;
     }
@@ -151,9 +151,7 @@ export class EWSAccount extends MailAccount implements EWSSubscribable {
 
   notifyObserversOfSubaccounts() {
     for (let account of this.dependentAccounts()) {
-      if (account.mainAccount == this) {
-        account.notifyObservers();
-      }
+      account.notifyObservers();
     }
   }
 

--- a/app/logic/Mail/EWS/EWSAccount.ts
+++ b/app/logic/Mail/EWS/EWSAccount.ts
@@ -90,7 +90,7 @@ export class EWSAccount extends MailAccount implements EWSSubscribable {
     if (this.authMethod == AuthMethod.OAuth2) {
       this.oAuth2 ??= getOAuth2BuiltIn(this);
       assert(this.oAuth2, gt`Could not find OAuth2 config for ${this.hostname}`);
-      this.oAuth2.subscribe(() => this.notifyObservers());
+      this.oAuth2.subscribe(() => this.notifyObserversIncludingSubaccounts());
       await this.oAuth2.login(interactive);
     }
   }
@@ -104,9 +104,9 @@ export class EWSAccount extends MailAccount implements EWSSubscribable {
       await ensureLicensed(); // Not in generic `Account`, to keep license code in the proprietary parts
       await super.login(interactive);
       await this.loginCommon(interactive);
-    });
 
-    await this.startup();
+      await this.startup();
+    });
   }
 
   async startup() {
@@ -125,6 +125,14 @@ export class EWSAccount extends MailAccount implements EWSSubscribable {
     });
   }
 
+  async logout(): Promise<void> {
+    if (this.mainAccount) {
+      await this.mainAccount.logout();
+      return;
+    }
+    await super.logout();
+  }
+
   async disconnect(): Promise<void> {
     if (this.mainAccount) {
       await (this.mainAccount as EWSAccount).unsubscribeNotifications(this);
@@ -135,6 +143,15 @@ export class EWSAccount extends MailAccount implements EWSSubscribable {
     let galAB = appGlobal.searchOnlyAddressbooks.find(ab => ab.mainAccount == this);
     if (galAB) {
       appGlobal.searchOnlyAddressbooks.remove(galAB);
+    }
+  }
+
+  notifyObserversIncludingSubaccounts() {
+    this.notifyObservers();
+    for (let account of appGlobal.emailAccounts) {
+      if (account.mainAccount == this) {
+        account.notifyObservers();
+      }
     }
   }
 

--- a/app/logic/Mail/EWS/EWSAccount.ts
+++ b/app/logic/Mail/EWS/EWSAccount.ts
@@ -90,7 +90,10 @@ export class EWSAccount extends MailAccount implements EWSSubscribable {
     if (this.authMethod == AuthMethod.OAuth2) {
       this.oAuth2 ??= getOAuth2BuiltIn(this);
       assert(this.oAuth2, gt`Could not find OAuth2 config for ${this.hostname}`);
-      this.oAuth2.subscribe(() => this.notifyObserversIncludingSubaccounts());
+      this.oAuth2.subscribe(() => {
+        this.notifyObservers();
+        this.notifyObserversOfSubaccounts();
+      });
       await this.oAuth2.login(interactive);
     }
   }
@@ -146,9 +149,8 @@ export class EWSAccount extends MailAccount implements EWSSubscribable {
     }
   }
 
-  notifyObserversIncludingSubaccounts() {
-    this.notifyObservers();
-    for (let account of appGlobal.emailAccounts) {
+  notifyObserversOfSubaccounts() {
+    for (let account of this.dependentAccounts()) {
       if (account.mainAccount == this) {
         account.notifyObservers();
       }

--- a/app/logic/Mail/OWA/OWAAccount.ts
+++ b/app/logic/Mail/OWA/OWAAccount.ts
@@ -217,7 +217,7 @@ export class OWAAccount extends MailAccount {
   }
 
   async logout(): Promise<void> {
-    if (this.mainAccount) { // TODO Why?
+    if (this.isDependentAccount) {
       await this.mainAccount.logout();
       return;
     }
@@ -238,9 +238,7 @@ export class OWAAccount extends MailAccount {
 
   notifyObserversOfSubaccounts() {
     for (let account of this.dependentAccounts()) {
-      if (account.mainAccount == this) {
-        account.notifyObservers();
-      }
+      account.notifyObservers();
     }
   }
 

--- a/app/logic/Mail/OWA/OWAAccount.ts
+++ b/app/logic/Mail/OWA/OWAAccount.ts
@@ -179,9 +179,10 @@ export class OWAAccount extends MailAccount {
       await this.loginCommon(interactive);
       this.authorizationHeader = await appGlobal.remoteApp.OWA.getAnyScrapedAuth(this.partition);
       this.hasLoggedIn = true;
-    });
+      this.notifyObserversOfSubaccounts();
 
-    await this.startup();
+      await this.startup();
+    });
   }
 
   async startup() {
@@ -221,6 +222,7 @@ export class OWAAccount extends MailAccount {
       return;
     }
     this.hasLoggedIn = false;
+    this.notifyObserversOfSubaccounts();
     await super.logout();
     if (!this.oAuth2) {
       await appGlobal.remoteApp.OWA.clearStorageData(this.partition);
@@ -231,6 +233,14 @@ export class OWAAccount extends MailAccount {
     let galAB = appGlobal.searchOnlyAddressbooks.find(ab => ab.mainAccount == this);
     if (galAB) {
       appGlobal.searchOnlyAddressbooks.remove(galAB);
+    }
+  }
+
+  notifyObserversOfSubaccounts() {
+    for (let account of appGlobal.emailAccounts) {
+      if (account.mainAccount == this) {
+        account.notifyObservers();
+      }
     }
   }
 

--- a/app/logic/Mail/OWA/OWAAccount.ts
+++ b/app/logic/Mail/OWA/OWAAccount.ts
@@ -237,7 +237,7 @@ export class OWAAccount extends MailAccount {
   }
 
   notifyObserversOfSubaccounts() {
-    for (let account of appGlobal.emailAccounts) {
+    for (let account of this.dependentAccounts()) {
       if (account.mainAccount == this) {
         account.notifyObservers();
       }


### PR DESCRIPTION
As commented in PR #1115, there is a login bug where subaccounts can try to startup twice. Additionally, there are some problems with the UI for subaccounts:
- the UI does not always show the correct login status on startup
- the UI does not update the login status after login/logout

While I was here I fixed a regression from PR #1115 which prevented logging out from the UI for an EWS subaccount.