### PR TITLE
UI: Clickable: Wrap all elements that don't need on:click or on:dblclick to be propagated #1200

### DIFF
--- a/app/frontend/AppsBar/AppMenuM/AppMenu.svelte
+++ b/app/frontend/AppsBar/AppMenuM/AppMenu.svelte
@@ -1,34 +1,36 @@
-<vbox class="app-menu" on:click={onClose} flex>
-  <hbox class="top">
-    <vbox class="left" flex>
-      <!--<WorkspaceDropDown />-->
-    </vbox>
-    <vbox class="center" flex>
-      <hbox class="date font-small">
-        {getFormattedDateString(new Date(), { weekday: "short", day: "2-digit", month: "short" })}
-      </hbox>
-      <hbox class="time">
-        {getTimeString(new Date())}
-      </hbox>
-    </vbox>
-    <vbox class="right" flex />
-  </hbox>
-  <hbox flex />
-  <!--<RecentPersons />-->
-  <hbox flex />
-  <grid class="apps">
-    <!-- each app must add exactly 5 elements -->
-    <TopAppMenu />
-    <!--<WebAppsAppMenu />-->
-    <FilesAppMenu />
-    <CalendarAppMenu />
-    <MeetAppMenu />
-    <ChatAppMenu />
-    <MailAppMenu />
-    <ContactsAppMenu />
-    <BottomAppMenu />
-  </grid>
-</vbox>
+<Clickable onClick={onClose}>
+  <vbox class="app-menu" flex>
+    <hbox class="top">
+      <vbox class="left" flex>
+        <!--<WorkspaceDropDown />-->
+      </vbox>
+      <vbox class="center" flex>
+        <hbox class="date font-small">
+          {getFormattedDateString(new Date(), { weekday: "short", day: "2-digit", month: "short" })}
+        </hbox>
+        <hbox class="time">
+          {getTimeString(new Date())}
+        </hbox>
+      </vbox>
+      <vbox class="right" flex />
+    </hbox>
+    <hbox flex />
+    <!--<RecentPersons />-->
+    <hbox flex />
+    <grid class="apps">
+      <!-- each app must add exactly 5 elements -->
+      <TopAppMenu />
+      <!--<WebAppsAppMenu />-->
+      <FilesAppMenu />
+      <CalendarAppMenu />
+      <MeetAppMenu />
+      <ChatAppMenu />
+      <MailAppMenu />
+      <ContactsAppMenu />
+      <BottomAppMenu />
+    </grid>
+  </vbox>
+</Clickable>
 <AppMenuBarM />
 
 <script lang="ts">
@@ -44,6 +46,7 @@
   import BottomAppMenu from "./BottomAppMenu.svelte";
   import AppMenuBarM from "./AppMenuBarM.svelte";
   import RecentPersons from "./RecentPersons.svelte";
+  import Clickable from "../../Shared/Clickable.svelte";
   import { goBack } from "../selectedApp";
 
   function onClose() {

--- a/app/frontend/Calendar/DayView/AllDayEvent.svelte
+++ b/app/frontend/Calendar/DayView/AllDayEvent.svelte
@@ -1,12 +1,15 @@
-<hbox class="event font-small" on:click on:click={onSelect} on:dblclick={onOpen}
-  title={eventAsText}
-  style="--account-color: {event.calendar?.color}"
-  class:selected={$selectedEvent == event}>
-  <hbox class="title">{event.title}</hbox>
-</hbox>
+<Clickable onClick={onSelect} onDoubleClick={onOpen}>
+  <hbox class="event font-small"
+    title={eventAsText}
+    style="--account-color: {event.calendar?.color}"
+    class:selected={$selectedEvent == event}>
+    <hbox class="title">{event.title}</hbox>
+  </hbox>
+</Clickable>
 
 <script lang="ts">
   import type { Event } from "../../../logic/Calendar/Event";
+  import Clickable from "../../Shared/Clickable.svelte";
   import { openEventFromOtherApp } from "../open";
   import { selectedEvent } from "../selected";
 

--- a/app/frontend/Calendar/DayView/EventContent.svelte
+++ b/app/frontend/Calendar/DayView/EventContent.svelte
@@ -1,23 +1,23 @@
-<hbox class="event font-small" flex
-  on:click
-  on:click={onSelect}
-  on:dblclick={onOpen}
-  title={eventAsText}>
-  {#if showTime}
-    <!--{event.startTime.toLocaleTimeString(getDateTimeLocale(), { hour: "numeric", minute: "numeric" })}-->
-    <hbox class="time">{startTime}</hbox>
-  {:else if forceShowText}
-    <hbox class="time">…</hbox>
-  {/if}
-  {#if showTitle}
-    <hbox class="title">{$event.title}</hbox>
-  {/if}
-</hbox>
+<Clickable onClick={onSelect} onDoubleClick={onSelect}>
+  <hbox class="event font-small" flex
+    title={eventAsText}>
+    {#if showTime}
+      <!--{event.startTime.toLocaleTimeString(getDateTimeLocale(), { hour: "numeric", minute: "numeric" })}-->
+      <hbox class="time">{startTime}</hbox>
+    {:else if forceShowText}
+      <hbox class="time">…</hbox>
+    {/if}
+    {#if showTitle}
+      <hbox class="title">{$event.title}</hbox>
+    {/if}
+  </hbox>
+</Clickable>
 
 <script lang="ts">
   import type { Event } from "../../../logic/Calendar/Event";
   import { openEventFromOtherApp } from "../open";
   import { selectedEvent } from "../selected";
+  import Clickable from "../../Shared/Clickable.svelte";
   import { getDurationString } from "../../Util/date";
   import { getDateTimeLocale } from "../../../l10n/l10n";
 
@@ -34,12 +34,10 @@
   $: showTitle = showTime || forceShowText;
 
   function onSelect(ev: MouseEvent) {
-    ev.stopPropagation();
     $selectedEvent = event;
   }
 
   function onOpen(ev: MouseEvent) {
-    ev.stopPropagation();
     $selectedEvent = event;
     openEventFromOtherApp(event, true);
   }

--- a/app/frontend/Calendar/DayView/TimeCell.svelte
+++ b/app/frontend/Calendar/DayView/TimeCell.svelte
@@ -1,36 +1,38 @@
-<vbox flex class="events"
-  on:dblclick={onDoubleClick}
-  on:pointerenter={() => hovering = true}
-  on:pointerleave={() => hovering = false}
-  >
-  {#if $displayEvents?.hasItems}
-    {#each $displayEvents.each as event (event.id)}
-      <EventContainer {event} {start} {end} {conflicts}>
-        <EventContent {event} {start} {end} forceShowText={conflicts.length > 1} />
-      </EventContainer>
-    {/each}
-  {/if}
+<Clickable {onDoubleClick}>
+  <vbox flex class="events"
+    on:pointerenter={() => hovering = true}
+    on:pointerleave={() => hovering = false}
+    >
+    {#if $displayEvents?.hasItems}
+      {#each $displayEvents.each as event (event.id)}
+        <EventContainer {event} {start} {end} {conflicts}>
+          <EventContent {event} {start} {end} forceShowText={conflicts.length > 1} />
+        </EventContainer>
+      {/each}
+    {/if}
 
-  {#if $displayOverlayEvents.hasItems}
-    {#each $displayOverlayEvents.each as event}
-      <EventContainer {event} {start} {end} {conflicts}>
-        <slot name="event-overlay" start={event.startTime} {end} {event} events={displayEvents} />
-      </EventContainer>
-    {/each}
-  {/if}
+    {#if $displayOverlayEvents.hasItems}
+      {#each $displayOverlayEvents.each as event}
+        <EventContainer {event} {start} {end} {conflicts}>
+          <slot name="event-overlay" start={event.startTime} {end} {event} events={displayEvents} />
+        </EventContainer>
+      {/each}
+    {/if}
 
-  {#if hovering}
-    <slot name="event-hover"
-      {start} {end}
-      empty={!$displayEvents?.hasItems && !$displayOverlayEvents.hasItems}
-      events={displayEvents}
-      />
-  {/if}
-</vbox>
+    {#if hovering}
+      <slot name="event-hover"
+        {start} {end}
+        empty={!$displayEvents?.hasItems && !$displayOverlayEvents.hasItems}
+        events={displayEvents}
+        />
+    {/if}
+  </vbox>
+</Clickable>
 
 <script lang="ts">
   import type { Event } from "../../../logic/Calendar/Event";
   import EventContainer from "./EventContainer.svelte";
+  import Clickable from "../../Shared/Clickable.svelte";
   import { ArrayColl, Collection } from "svelte-collections";
   import EventContent from "./EventContent.svelte";
   import { createEventDispatcher } from 'svelte';

--- a/app/frontend/Calendar/DisplayEvent/ParticipantDisplay.svelte
+++ b/app/frontend/Calendar/DisplayEvent/ParticipantDisplay.svelte
@@ -1,12 +1,13 @@
-<hbox class="participant-name"
-  on:click={() => catchErrors(() => onOpenParticipant(participant))}>
-  {participant.name}
-</hbox>
+<Clickable onClick={() => onOpenParticipant(participant)}>
+  <hbox class="participant-name">
+    {participant.name}
+  </hbox>
+</Clickable>
 
 <script lang="ts">
   import { Participant } from "../../../logic/Calendar/Participant";
   import { openPersonFromOtherApp } from "../../Contacts/open";
-  import { catchErrors } from "../../Util/error";
+  import Clickable from "../../Shared/Clickable.svelte";
 
   export let participant: Participant;
 

--- a/app/frontend/Calendar/ListView/ListViewLine.svelte
+++ b/app/frontend/Calendar/ListView/ListViewLine.svelte
@@ -6,22 +6,22 @@
     {startTime}
   {/if}
 </hbox>
-<Clickable onClick={onSelect} onDoubleClick={onOpen}>
-  <hbox class="event title"
-    title={eventAsText}
-    style="--color: {event.color ?? event.calendar?.color}"
-    class:all-day={$event.allDay}
-    class:selected={$selectedEvent == event}
-    >
-    {$event.title}
-  </hbox>
-</Clickable>
+<hbox class="event title"
+  on:click
+  on:click={onSelect}
+  on:dblclick={onOpen}
+  title={eventAsText}
+  style="--color: {event.color ?? event.calendar?.color}"
+  class:all-day={$event.allDay}
+  class:selected={$selectedEvent == event}
+  >
+  {$event.title}
+</hbox>
 
 <script lang="ts">
   import type { Event } from "../../../logic/Calendar/Event";
   import { selectedEvent } from "../selected";
   import { openEventFromOtherApp } from "../open";
-  import Clickable from "../../Shared/Clickable.svelte";
   import { getDurationString } from "../../Util/date";
   import { getDateTimeLocale } from "../../../l10n/l10n";
 

--- a/app/frontend/Calendar/ListView/ListViewLine.svelte
+++ b/app/frontend/Calendar/ListView/ListViewLine.svelte
@@ -6,22 +6,22 @@
     {startTime}
   {/if}
 </hbox>
-<hbox class="event title"
-  on:click
-  on:click={onSelect}
-  on:dblclick={onOpen}
-  title={eventAsText}
-  style="--color: {event.color ?? event.calendar?.color}"
-  class:all-day={$event.allDay}
-  class:selected={$selectedEvent == event}
-  >
-  {$event.title}
-</hbox>
+<Clickable onClick={onSelect} onDoubleClick={onOpen}>
+  <hbox class="event title"
+    title={eventAsText}
+    style="--color: {event.color ?? event.calendar?.color}"
+    class:all-day={$event.allDay}
+    class:selected={$selectedEvent == event}
+    >
+    {$event.title}
+  </hbox>
+</Clickable>
 
 <script lang="ts">
   import type { Event } from "../../../logic/Calendar/Event";
   import { selectedEvent } from "../selected";
   import { openEventFromOtherApp } from "../open";
+  import Clickable from "../../Shared/Clickable.svelte";
   import { getDurationString } from "../../Util/date";
   import { getDateTimeLocale } from "../../../l10n/l10n";
 

--- a/app/frontend/Calendar/MonthView/DayLabel.svelte
+++ b/app/frontend/Calendar/MonthView/DayLabel.svelte
@@ -1,21 +1,24 @@
-<hbox class="day font-small" on:click={selectDay} on:dblclick={changeToDay} class:today={day.getTime() == today.getTime()}>
-  <hbox class="date-number">
-    {day.toLocaleDateString(getDateTimeLocale(), { day: "numeric" })}
-  </hbox>
-  {#if withMonthOnFirst && day.getDate() == 1 ||
-          withMonthOnMonday && day.getDay() == 1 }
-    <hbox class="month">
-      {day.toLocaleDateString(getDateTimeLocale(), { month: "short" })}
+<Clickable onClick={selectDay} onDoubleClick={changeToDay}>
+  <hbox class="day font-small" class:today={day.getTime() == today.getTime()}>
+    <hbox class="date-number">
+      {day.toLocaleDateString(getDateTimeLocale(), { day: "numeric" })}
     </hbox>
-  {/if}
-  <hbox class="today-icon" flex>
-    <TodayIcon size={14} />
+    {#if withMonthOnFirst && day.getDate() == 1 ||
+            withMonthOnMonday && day.getDay() == 1 }
+      <hbox class="month">
+        {day.toLocaleDateString(getDateTimeLocale(), { month: "short" })}
+      </hbox>
+    {/if}
+    <hbox class="today-icon" flex>
+      <TodayIcon size={14} />
+    </hbox>
   </hbox>
-</hbox>
+</Clickable>
 
 <script lang="ts">
   import { selectedDate, selectedDateInterval } from "../selected";
   import { getToday } from "../../Util/date";
+  import Clickable from "../../Shared/Clickable.svelte";
   import TodayIcon from "lucide-svelte/icons/home";
   import { getDateTimeLocale } from "../../../l10n/l10n";
 

--- a/app/frontend/Calendar/SML/Shared/DisplayList.svelte
+++ b/app/frontend/Calendar/SML/Shared/DisplayList.svelte
@@ -8,29 +8,32 @@
       </hbox>
     {/if}
 
-    <hbox class="option added" class:showEndTime on:click={() => dispatchEvent("optionclick", option)}>
-      <hbox class="start-time">
-        {getTimeString(option)}
+    <Clickable onClick={() => dispatchEvent("optionclick", option)}>
+      <hbox class="option added" class:showEndTime>
+        <hbox class="start-time">
+          {getTimeString(option)}
+        </hbox>
+        {#if showEndTime}
+          <hbox class="end-separator">
+            -
+          </hbox>
+          <hbox class="end-time">
+            {end = new Date(option), end.setMinutes(end.getMinutes() + duration), getTimeString(end)}
+          </hbox>
+        {/if}
+        <hbox flex />
+        <slot name="center" {option} />
+        <hbox flex />
+        <slot name="right" {option} />
       </hbox>
-      {#if showEndTime}
-        <hbox class="end-separator">
-          -
-        </hbox>
-        <hbox class="end-time">
-          {end = new Date(option), end.setMinutes(end.getMinutes() + duration), getTimeString(end)}
-        </hbox>
-      {/if}
-      <hbox flex />
-      <slot name="center" {option} />
-      <hbox flex />
-      <slot name="right" {option} />
-    </hbox>
+    </Clickable>
   {/each}
 </vbox>
 
 <script lang="ts">
   import { getDateString, getTimeString } from "../../../Util/date";
   import { Collection } from "svelte-collections";
+  import Clickable from "../../../Shared/Clickable.svelte";
   import { createEventDispatcher } from 'svelte';
   const dispatchEvent = createEventDispatcher<{ optionclick: Date }>();
 

--- a/app/frontend/Contacts/History/ChatLog.svelte
+++ b/app/frontend/Contacts/History/ChatLog.svelte
@@ -1,17 +1,19 @@
-<vbox on:click={() => catchErrors(onOpen)}>
-  {#if message.subject}
-    <div class="subject">
-      {message.subject}
+<Clickable onClick={onOpen}>
+  <vbox>
+    {#if message.subject}
+      <div class="subject">
+        {message.subject}
+      </div>
+    {/if}
+    <div class="body">
+      {message.text?.substring(0, 120)}
     </div>
-  {/if}
-  <div class="body">
-    {message.text?.substring(0, 120)}
-  </div>
-</vbox>
+  </vbox>
+</Clickable>
 
 <script lang="ts">
   import type { ChatMessage } from "../../../logic/Chat/Message";
-  import { catchErrors } from "../../Util/error";
+  import Clickable from "../../Shared/Clickable.svelte";
 
   export let message: ChatMessage;
 

--- a/app/frontend/Contacts/History/EMailLog.svelte
+++ b/app/frontend/Contacts/History/EMailLog.svelte
@@ -1,19 +1,20 @@
-<vbox class="email" flex
-  title={message.subject + "\n\n" + (message.text?.substring(0, 300) ?? "")}
-  on:click={() => catchErrors(onOpen)}>
-  <div class="subject">
-    {message.subject}
-  </div>
-  <div class="body">
-    {message.text?.substring(0, 240) ?? ""}
-  </div>
-</vbox>
+<Clickable onClick={onOpen}>
+  <vbox class="email" flex
+    title={message.subject + "\n\n" + (message.text?.substring(0, 300) ?? "")}>
+    <div class="subject">
+      {message.subject}
+    </div>
+    <div class="body">
+      {message.text?.substring(0, 240) ?? ""}
+    </div>
+  </vbox>
+</Clickable>
 
 <script lang="ts">
   import type { EMail } from "../../../logic/Mail/EMail";
   import { openEMailMessage } from "../../Mail/open";
   import { SearchView } from "../../Mail/LeftPane/SearchSwitcher.svelte";
-  import { catchErrors } from "../../Util/error";
+  import Clickable from "../../Shared/Clickable.svelte";
 
   export let message: EMail;
 

--- a/app/frontend/Contacts/History/EventLog.svelte
+++ b/app/frontend/Contacts/History/EventLog.svelte
@@ -1,14 +1,15 @@
-<vbox class="event" flex
-  on:click={() => catchErrors(onOpen)}>
-  <div class="title">
-    {event.title}
-  </div>
-</vbox>
+<Clickable onClick={onOpen}>
+  <vbox class="event" flex>
+    <div class="title">
+      {event.title}
+    </div>
+  </vbox>
+</Clickable>
 
 <script lang="ts">
   import type { Event } from "../../../logic/Calendar/Event";
   import { openEventFromOtherApp } from "../../Calendar/open";
-  import { catchErrors } from "../../Util/error";
+  import Clickable from "../../Shared/Clickable.svelte";
 
   export let event: Event;
 

--- a/app/frontend/Contacts/History/FileLog.svelte
+++ b/app/frontend/Contacts/History/FileLog.svelte
@@ -1,16 +1,17 @@
-<vbox class="file" flex
-  title={(file.name ?? "") + "\n" + fileSize(file.size)}
-  on:click={() => catchErrors(onOpen)}>
-  <div class="name">
-    {file.name?.substring(0, 200) ?? ""}
-  </div>
-</vbox>
+<Clickable onClick={onOpen}>
+  <vbox class="file" flex
+    title={(file.name ?? "") + "\n" + fileSize(file.size)}>
+    <div class="name">
+      {file.name?.substring(0, 200) ?? ""}
+    </div>
+  </vbox>
+</Clickable>
 
 <script lang="ts">
   import { File } from "../../../logic/Files/File";
   import { fileSize } from "../../Files/fileSize";
-  import { catchErrors } from "../../Util/error";
   import { openFileFromOtherApp } from "../../Files/open";
+  import Clickable from "../../Shared/Clickable.svelte";
 
   export let file: File;
 

--- a/app/frontend/Contacts/PersonAutocomplete/PersonEntry.svelte
+++ b/app/frontend/Contacts/PersonAutocomplete/PersonEntry.svelte
@@ -1,18 +1,19 @@
-<hbox class="person"
-  class:selected={popupOpen}
-  class:no-pic={!$person.person?.picture}
-  title={person.name + "\n" + person.emailAddress}
-  bind:this={popupAnchor}
-  on:click={onPopupToggle}>
-  <slot name="before-avatar" />
-  {#if $person.person?.picture}
-    <PersonPicture person={$person.person} size={24} />
-  {/if}
-  <vbox flex class="right">
-    <hbox flex class="name">{$person.name || $person.emailAddress}</hbox>
-  </vbox>
-  <slot name="after-name" />
-</hbox>
+<Clickable onClick={onPopupToggle}>
+  <hbox class="person"
+    class:selected={popupOpen}
+    class:no-pic={!$person.person?.picture}
+    title={person.name + "\n" + person.emailAddress}
+    bind:this={popupAnchor}>
+    <slot name="before-avatar" />
+    {#if $person.person?.picture}
+      <PersonPicture person={$person.person} size={24} />
+    {/if}
+    <vbox flex class="right">
+      <hbox flex class="name">{$person.name || $person.emailAddress}</hbox>
+    </vbox>
+    <slot name="after-name" />
+  </hbox>
+</Clickable>
 <Popup bind:popupOpen {popupAnchor} placement="bottom-start" boundaryElSel=".mail-composer-window">
   <PersonPopup personUID={person}
     {onRemovePerson}
@@ -32,6 +33,7 @@
   import PersonPopup from "./PersonPopup.svelte";
   import PersonPicture from "../Person/PersonPicture.svelte";
   import Popup from "../../Shared/Popup.svelte";
+  import Clickable from "../../Shared/Clickable.svelte";
   import { createEventDispatcher, onMount } from 'svelte';
   const dispatchEvent = createEventDispatcher<{ focusNext: void }>();
 
@@ -52,7 +54,6 @@
 
   function onPopupToggle(event: MouseEvent) {
     popupOpen = !popupOpen;
-    event.stopPropagation();
   }
 
   function onPopupClose() {

--- a/app/frontend/Contacts/PersonAutocomplete/PersonPopup.svelte
+++ b/app/frontend/Contacts/PersonAutocomplete/PersonPopup.svelte
@@ -54,10 +54,12 @@
       <vbox class="other-email-addresses">
         {#each person.emailAddresses.each as altContactEntry}
           {#if contactEntry != altContactEntry}
-            <hbox class="other-email-address font-small" on:click={() => catchErrors(() => useOtherEmailAddress(altContactEntry.value))}>
-              <MailIcon size={12} />
-              {altContactEntry.value}
-            </hbox>
+            <Clickable onClick={() => useOtherEmailAddress(altContactEntry.value)}>
+              <hbox class="other-email-address font-small">
+                <MailIcon size={12} />
+                {altContactEntry.value}
+              </hbox>
+            </Clickable>
           {/if}
         {/each}
       </vbox>
@@ -85,12 +87,13 @@
   import PersonPicture from "../Person/PersonPicture.svelte";
   import Button from "../../Shared/Button.svelte";
   import RoundButton from "../../Shared/RoundButton.svelte";
+  import Clickable from "../../Shared/Clickable.svelte";
   import AvatarFallbackIcon from "lucide-svelte/icons/user";
   import EditIcon from "lucide-svelte/icons/pencil";
   import CheckIcon from "lucide-svelte/icons/check";
   import MailIcon from "lucide-svelte/icons/mail";
   import { createIsSame, onKeyEnter } from "../../Util/util";
-  import { backgroundError, catchErrors } from "../../Util/error";
+  import { backgroundError } from "../../Util/error";
   import { t } from "../../../l10n/l10n";
   import { createEventDispatcher, onMount } from 'svelte';
   const dispatch = createEventDispatcher<{ close: void }>();

--- a/app/frontend/Contacts/PersonPage/ContactEntryUI.svelte
+++ b/app/frontend/Contacts/PersonPage/ContactEntryUI.svelte
@@ -45,17 +45,23 @@
   </hbox>
 {:else}
   {#if protocolLabels}
-    <hbox class="protocol display" on:click={startEditing}>
-      {displayProtocol(entry.protocol)}
-    </hbox>
+    <Clickable onClick={startEditing}>
+      <hbox class="protocol display">
+        {displayProtocol(entry.protocol)}
+      </hbox>
+    </Clickable>
   {:else}
-    <hbox class="purpose display" on:click={startEditing}>
-      {displayPurpose(entry.purpose)}
-    </hbox>
+    <Clickable onClick={startEditing}>
+      <hbox class="purpose display">
+        {displayPurpose(entry.purpose)}
+      </hbox>
+    </Clickable>
   {/if}
-  <hbox class="value" on:click={startEditing}>
-    <slot name="display" />
-  </hbox>
+  <Clickable onClick={startEditing}>
+    <hbox class="value">
+      <slot name="display" />
+    </hbox>
+  </Clickable>
   <hbox class="actions contact-entry">
     {#if !appGlobal.isMobile}
       {#if copied}
@@ -83,6 +89,7 @@
   import { selectedContactEntry } from "../Person/Selected";
   import { appGlobal } from "../../../logic/app";
   import Button from "../../Shared/Button.svelte";
+  import Clickable from "../../Shared/Clickable.svelte";
   import PencilIcon from "lucide-svelte/icons/pencil";
   import CopyIcon from "lucide-svelte/icons/copy";
   import OKIcon from "lucide-svelte/icons/check";

--- a/app/frontend/Contacts/PersonPage/ContactEntryUI.svelte
+++ b/app/frontend/Contacts/PersonPage/ContactEntryUI.svelte
@@ -44,20 +44,16 @@
       label={$t`Delete this information`} />
   </hbox>
 {:else}
-  {#if protocolLabels}
-    <Clickable onClick={startEditing}>
+  <Clickable onClick={startEditing}>
+    {#if protocolLabels}
       <hbox class="protocol display">
         {displayProtocol(entry.protocol)}
       </hbox>
-    </Clickable>
-  {:else}
-    <Clickable onClick={startEditing}>
+    {:else}
       <hbox class="purpose display">
         {displayPurpose(entry.purpose)}
       </hbox>
-    </Clickable>
-  {/if}
-  <Clickable onClick={startEditing}>
+    {/if}
     <hbox class="value">
       <slot name="display" />
     </hbox>

--- a/app/frontend/Contacts/PersonPage/EditableSimpleText.svelte
+++ b/app/frontend/Contacts/PersonPage/EditableSimpleText.svelte
@@ -13,9 +13,11 @@
     </hbox>
   {/if}
 {:else}
-  <div class="value" on:dblclick={startEditing}>
-    {value}
-  </div>
+  <Clickable onDoubleClick={startEditing}>
+    <div class="value">
+      {value}
+    </div>
+  </Clickable>
   {#if !appGlobal.isMobile}
     <hbox class="actions value">
       <Button
@@ -31,6 +33,7 @@
 <script lang="ts">
   import { appGlobal } from "../../../logic/app";
   import Button from "../../Shared/Button.svelte";
+  import Clickable from "../../Shared/Clickable.svelte";
   import PencilIcon from "lucide-svelte/icons/pencil";
   import OKIcon from "lucide-svelte/icons/check";
   import { onKeyEnter } from "../../Util/util";

--- a/app/frontend/Contacts/PersonPage/Encryption.svelte
+++ b/app/frontend/Contacts/PersonPage/Encryption.svelte
@@ -17,26 +17,27 @@
         <EncryptionKey {key} {person} />
       {/each}
       {#if $keys.filterObservable(key => key.obsolete).hasItems}
-        <vbox class="expired-header"
-          class:expanded={showObsolete}
-          on:click={() => showObsolete = !showObsolete}>
-          <hbox class="first-row">
-            <hbox class="label font-smallest" flex>
-              {$t`Expired *=> No longer valid`}
+        <Clickable onClick={() => showObsolete = !showObsolete}>
+          <vbox class="expired-header"
+            class:expanded={showObsolete}>
+            <hbox class="first-row">
+              <hbox class="label font-smallest" flex>
+                {$t`Expired *=> No longer valid`}
+              </hbox>
+              <RoundButton
+                label={showObsolete ? $t`Collapse` : $t`Expand`}
+                icon={showObsolete ? ChevronUp : ChevronDown}
+                border={false}
+                classes="plain"
+                />
             </hbox>
-            <RoundButton
-              label={showObsolete ? $t`Collapse` : $t`Expand`}
-              icon={showObsolete ? ChevronUp : ChevronDown}
-              border={false}
-              classes="plain"
-              />
-          </hbox>
-          {#if showObsolete}
-            <hbox class="subtitle font-smallest" flex>
-              {$t`These below are certificates that are expired, revoked, or obsolete. They will not be used for new emails. They are still necessary to validate the signatures of previous emails that you have received and stored.`}
-            </hbox>
-          {/if}
-        </vbox>
+            {#if showObsolete}
+              <hbox class="subtitle font-smallest" flex>
+                {$t`These below are certificates that are expired, revoked, or obsolete. They will not be used for new emails. They are still necessary to validate the signatures of previous emails that you have received and stored.`}
+              </hbox>
+            {/if}
+          </vbox>
+        </Clickable>
       {/if}
       {#if showObsolete}
         {#each keys.filterObservable(key => key.obsolete).each as key}
@@ -54,6 +55,7 @@
   import EncryptionImport from "./EncryptionImport.svelte";
   import GroupBox from "./GroupBox.svelte";
   import RoundButton from "../../Shared/RoundButton.svelte";
+  import Clickable from "../../Shared/Clickable.svelte";
   import EcryptionIcon from "lucide-svelte/icons/lock";
   import InfoIcon from "lucide-svelte/icons/info";
   import ChevronUp from "lucide-svelte/icons/chevron-up";

--- a/app/frontend/Contacts/PersonPage/EncryptionKey.svelte
+++ b/app/frontend/Contacts/PersonPage/EncryptionKey.svelte
@@ -1,35 +1,36 @@
 <vbox class="key" class:obsolete={$key.obsolete} class:short>
-  <hbox class="main-row"
-    on:click={() => isExpanded = !isExpanded}>
-    {#if showIcon}
-      <hbox class="usage-icon"
-        style:background-color={trustColor[$key.trustLevel] ?? "grey"}
-        style:color={trustColorFG[$key.trustLevel] ?? "black"}>
-        {#if $key.trustLevel == TrustLevel.Distrusted}
-          <DistrustIcon title={$t`Untrusted`} size="16px" />
-        {:else if $key.encryptByDefault}
-          <EncryptIcon title={$t`Use for encryption and checking signatures`} size="16px" />
-        {:else}
-          <SignIcon title={$t`Use only for checking signatures`} size="16px" />
-        {/if}
+  <Clickable onClick={() => isExpanded = !isExpanded}>
+    <hbox class="main-row">
+      {#if showIcon}
+        <hbox class="usage-icon"
+          style:background-color={trustColor[$key.trustLevel] ?? "grey"}
+          style:color={trustColorFG[$key.trustLevel] ?? "black"}>
+          {#if $key.trustLevel == TrustLevel.Distrusted}
+            <DistrustIcon title={$t`Untrusted`} size="16px" />
+          {:else if $key.encryptByDefault}
+            <EncryptIcon title={$t`Use for encryption and checking signatures`} size="16px" />
+          {:else}
+            <SignIcon title={$t`Use only for checking signatures`} size="16px" />
+          {/if}
+        </hbox>
+      {/if}
+      <hbox class="name">{$key.name}</hbox>
+      {#if isExpanded}
+        <hbox class="keytype" flex>{$t`Certificate`}</hbox>
+      {:else}
+        <hbox flex />
+      {/if}
+      <hbox class="system font-small">
+        {key.system}
       </hbox>
-    {/if}
-    <hbox class="name">{$key.name}</hbox>
-    {#if isExpanded}
-      <hbox class="keytype" flex>{$t`Certificate`}</hbox>
-    {:else}
-      <hbox flex />
-    {/if}
-    <hbox class="system font-small">
-      {key.system}
+      <RoundButton
+        label={isExpanded ? $t`Collapse` : $t`Expand`}
+        icon={isExpanded ? ChevronUp : ChevronDown}
+        border={false}
+        classes="plain"
+        />
     </hbox>
-    <RoundButton
-      label={isExpanded ? $t`Collapse` : $t`Expand`}
-      icon={isExpanded ? ChevronUp : ChevronDown}
-      border={false}
-      classes="plain"
-      />
-  </hbox>
+  </Clickable>
   {#if isExpanded}
     <vbox class="details">
       <hbox class="acceptance">
@@ -174,6 +175,7 @@
   import Checkbox from "../../Shared/Checkbox.svelte";
   import RoundButton from "../../Shared/RoundButton.svelte";
   import Button from "../../Shared/Button.svelte";
+  import Clickable from "../../Shared/Clickable.svelte";
   import SignIcon from "lucide-svelte/icons/signature";
   import EncryptIcon from "lucide-svelte/icons/lock";
   import DistrustIcon from "lucide-svelte/icons/octagon-x";

--- a/app/frontend/Contacts/PersonPage/SameName.svelte
+++ b/app/frontend/Contacts/PersonPage/SameName.svelte
@@ -7,12 +7,14 @@
       {/if}
       <grid class="other-person">
         {#each $sameName.each as other}
-          <hbox on:click={() => catchErrors(() => openPerson(other))} class="linked-object">
-            {#if other?.picture}
-              <PersonPicture person={other} size={24} />
-            {/if}
-            <hbox class="name">{other.name}</hbox>
-          </hbox>
+          <Clickable onClick={() => openPerson(other)}>
+            <hbox class="linked-object">
+              {#if other?.picture}
+                <PersonPicture person={other} size={24} />
+              {/if}
+              <hbox class="name">{other.name}</hbox>
+            </hbox>
+          </Clickable>
           <hbox class="email-address">{other.emailAddresses.first?.value ?? ""}</hbox>
           <hbox class="addressbook-icon"
             style="color: {other.addressbook?.color ?? "black"}"
@@ -44,6 +46,7 @@
   import PersonPicture from "../Person/PersonPicture.svelte";
   import Button from "../../Shared/Button.svelte";
   import Icon from "../../Shared/Icon.svelte";
+  import Clickable from "../../Shared/Clickable.svelte";
   import MergeIcon from "lucide-svelte/icons/combine";
   import PersonsIcon from "lucide-svelte/icons/users";
   import AccountIcon from "lucide-svelte/icons/book-user";

--- a/app/frontend/Files/FilesList/DirectoryLine.svelte
+++ b/app/frontend/Files/FilesList/DirectoryLine.svelte
@@ -1,34 +1,34 @@
-<hbox class="directory line"
-  class:selected={dir == $selectedFile}
-  on:click={() => catchErrors(toggleOpen)}
-  >
-  <hbox class="firstColumn">
-    {#each {length: indent} as _}
-      <hbox class="indention" />
-    {/each}
-    <button class="icon">
-      {#if open}
-        <FolderOpenIcon size="16" />
-      {:else}
-        <FolderClosedIcon size="16" />
+<Clickable onClick={toggleOpen}>
+  <hbox class="directory line"
+    class:selected={dir == $selectedFile}>
+    <hbox class="firstColumn">
+      {#each {length: indent} as _}
+        <hbox class="indention" />
+      {/each}
+      <button class="icon">
+        {#if open}
+          <FolderOpenIcon size="16" />
+        {:else}
+          <FolderClosedIcon size="16" />
+        {/if}
+      </button>
+      <hbox class="name">
+        {dir?.name}
+      </hbox>
+    </hbox>
+    <hbox class="type">
+      {$t`Folder`}
+    </hbox>
+    <hbox class="size">
+      {#if $subDirs.hasItems || $files.hasItems}
+        {$t`${$subDirs?.length + $files?.length} entries`}
       {/if}
-    </button>
-    <hbox class="name">
-      {dir?.name}
+    </hbox>
+    <hbox class="time">
+      {dir?.lastMod ? getDateTimeString(dir.lastMod) : ""}
     </hbox>
   </hbox>
-  <hbox class="type">
-    {$t`Folder`}
-  </hbox>
-  <hbox class="size">
-    {#if $subDirs.hasItems || $files.hasItems}
-      {$t`${$subDirs?.length + $files?.length} entries`}
-    {/if}
-  </hbox>
-  <hbox class="time">
-    {dir?.lastMod ? getDateTimeString(dir.lastMod) : ""}
-  </hbox>
-</hbox>
+</Clickable>
 
 {#if open}
   <FileOrDirLines {files} dirs={subDirs} indent={indent + 1} />
@@ -39,6 +39,7 @@
   import { selectedFile } from "../selected";
   import { getDateTimeString } from "../../Util/date";
   import FileOrDirLines from "./FileOrDirLines.svelte";
+  import Clickable from "../../Shared/Clickable.svelte";
   import FolderClosedIcon from "lucide-svelte/icons/folder";
   import FolderOpenIcon from "lucide-svelte/icons/folder-open";
   import { catchErrors } from "../../Util/error";

--- a/app/frontend/Files/FilesList/FileLine.svelte
+++ b/app/frontend/Files/FilesList/FileLine.svelte
@@ -1,36 +1,36 @@
-<hbox class="file line"
-  class:selected={file == $selectedFile}
-  on:click={() => catchErrors(openFile)}
-  >
-  <hbox class="firstColumn">
-    {#each {length: indent} as _}
-      <hbox class="indention" />
-    {/each}
-    <button class="icon">
-      <FileIcon ext={file.ext} localFilePath={file.path} />
-    </button>
-    <hbox class="name">
-      {file.nameWithoutExt}
+<Clickable onClick={openFile}>
+  <hbox class="file line"
+    class:selected={file == $selectedFile}>
+    <hbox class="firstColumn">
+      {#each {length: indent} as _}
+        <hbox class="indention" />
+      {/each}
+      <button class="icon">
+        <FileIcon ext={file.ext} localFilePath={file.path} />
+      </button>
+      <hbox class="name">
+        {file.nameWithoutExt}
+      </hbox>
+    </hbox>
+    <hbox class="type">
+      {file.ext}
+    </hbox>
+    <hbox class="size">
+      {fileSize(file.size)}
+    </hbox>
+    <hbox class="time">
+      {getDateTimeString(file.lastMod)}
     </hbox>
   </hbox>
-  <hbox class="type">
-    {file.ext}
-  </hbox>
-  <hbox class="size">
-    {fileSize(file.size)}
-  </hbox>
-  <hbox class="time">
-    {getDateTimeString(file.lastMod)}
-  </hbox>
-</hbox>
+</Clickable>
 
 <script lang="ts">
   import { File } from "../../../logic/Files/File";
   import { fileSize } from "../fileSize";
   import { selectedFile } from "../selected";
   import { getDateTimeString } from "../../Util/date";
+  import Clickable from "../../Shared/Clickable.svelte";
   import FileIcon from "../Thumbnail/FileIcon.svelte";
-  import { catchErrors } from "../../Util/error";
   import { assert } from "../../../logic/util/util";
 
   export let file: File;

--- a/app/frontend/Files/Gallery/DirectoryTile.svelte
+++ b/app/frontend/Files/Gallery/DirectoryTile.svelte
@@ -1,36 +1,37 @@
-<vbox class="directory box"
-  class:selected={dir == $selectedFile}
-  on:click={() => catchErrors(toggleOpen)}
-  >
-  <vbox class="tile">
-    <button class="icon">
-      {#if open}
-        <FolderOpenIcon size="48" />
-      {:else}
-        <FolderClosedIcon size="48" />
-      {/if}
-    </button>
-  </vbox>
-  <vbox class="info">
-    <hbox class="name">
-      {dir?.name}
-    </hbox>
-    <hbox class="second">
-      <hbox flex />
-      <hbox class="time font-smallest">
-        {dir?.lastMod ? getDateTimeString(dir.lastMod) : ""}
+<Clickable onClick={toggleOpen}>
+  <vbox class="directory box"
+    class:selected={dir == $selectedFile}>
+    <vbox class="tile">
+      <button class="icon">
+        {#if open}
+          <FolderOpenIcon size="48" />
+        {:else}
+          <FolderClosedIcon size="48" />
+        {/if}
+      </button>
+    </vbox>
+    <vbox class="info">
+      <hbox class="name">
+        {dir?.name}
       </hbox>
-    </hbox>
-  </vbox>
-</vbox>
+      <hbox class="second">
+        <hbox flex />
+        <hbox class="time font-smallest">
+          {dir?.lastMod ? getDateTimeString(dir.lastMod) : ""}
+        </hbox>
+      </hbox>
+    </vbox>
+  </vbox>`
+
+</Clickable>
 
 <script lang="ts">
   import { Directory } from "../../../logic/Files/Directory";
   import { selectedFolder, selectedFile } from "../selected";
+  import Clickable from "../../Shared/Clickable.svelte";
   import FolderClosedIcon from "lucide-svelte/icons/folder";
   import FolderOpenIcon from "lucide-svelte/icons/folder-open";
   import { getDateTimeString } from "../../Util/date";
-  import { catchErrors } from "../../Util/error";
 
   export let dir: Directory;
 

--- a/app/frontend/Files/Gallery/FileTile.svelte
+++ b/app/frontend/Files/Gallery/FileTile.svelte
@@ -1,43 +1,43 @@
-<vbox class="file box"
-  class:selected={file == $selectedFile}
-  on:click={() => catchErrors(openFile)}
-  >
-  <vbox class="tile">
-    <button class="icon">
-      <FileIcon ext={file.ext} localFilePath={file.path} size={48} />
-      <!--
-      {#if $file.isDownloaded}
-        <Thumbnail {file} size={48} />
-      {:else}
-        {#await $file.download()}
-          <FileIcon ext={file.ext} localFilePath={file.path} size={48} />
-        {:catch ex}
-          {ex?.message + ex + ""}
-        {/await}
-      {/if}
-      -->
-    </button>
-  </vbox>
-  <vbox class="info">
-    <hbox class="name">
-      {file?.name}
-    </hbox>
-    <hbox class="second">
-      <hbox flex />
-      <hbox class="time font-smallest">
-        {file?.lastMod ? getDateTimeString(file.lastMod) : ""}
+<Clickable onClick={openFile}>
+  <vbox class="file box"
+    class:selected={file == $selectedFile}>
+    <vbox class="tile">
+      <button class="icon">
+        <FileIcon ext={file.ext} localFilePath={file.path} size={48} />
+        <!--
+        {#if $file.isDownloaded}
+          <Thumbnail {file} size={48} />
+        {:else}
+          {#await $file.download()}
+            <FileIcon ext={file.ext} localFilePath={file.path} size={48} />
+          {:catch ex}
+            {ex?.message + ex + ""}
+          {/await}
+        {/if}
+        -->
+      </button>
+    </vbox>
+    <vbox class="info">
+      <hbox class="name">
+        {file?.name}
       </hbox>
-    </hbox>
+      <hbox class="second">
+        <hbox flex />
+        <hbox class="time font-smallest">
+          {file?.lastMod ? getDateTimeString(file.lastMod) : ""}
+        </hbox>
+      </hbox>
+    </vbox>
   </vbox>
-</vbox>
+</Clickable>
 
 <script lang="ts">
   import { File } from "../../../logic/Files/File";
   import { selectedFile } from "../selected";
+  import Clickable from "../../Shared/Clickable.svelte";
   import FileIcon from "../Thumbnail/FileIcon.svelte";
   import Thumbnail from "../Thumbnail/Thumbnail.svelte";
   import { getDateTimeString } from "../../Util/date";
-  import { catchErrors } from "../../Util/error";
   import { assert } from "../../../logic/util/util";
 
   export let file: File;

--- a/app/frontend/Files/RightPane/FilesHeader.svelte
+++ b/app/frontend/Files/RightPane/FilesHeader.svelte
@@ -11,9 +11,11 @@
 
   <hbox class="parent-dirs font-small">
     {#each parentDirs as parent, i}
-      <hbox class="parent-dir" on:click={changeTo(parent)}>
-        {parent.name}
-      </hbox>
+      <Clickable onClick={() => changeTo(parent)}>
+        <hbox class="parent-dir">
+          {parent.name}
+        </hbox>
+      </Clickable>
       {#if i < parentDirs.length}
         <hbox class="dir-separator">
           <SubIcon size="16px" />
@@ -47,6 +49,7 @@
   import { selectedFolder } from "../selected";
   import { NotImplemented } from "../../../logic/util/util";
   import RoundButton from "../../Shared/RoundButton.svelte";
+  import Clickable from "../../Shared/Clickable.svelte";
   import RightViewSwitcher from "./RightViewSwitcher.svelte";
   import PlusIcon from "lucide-svelte/icons/plus";
   import BackIcon from "lucide-svelte/icons/chevron-left";

--- a/app/frontend/Mail/LeftPane/FolderFooter.svelte
+++ b/app/frontend/Mail/LeftPane/FolderFooter.svelte
@@ -59,7 +59,9 @@
         {/if}
       </hbox>
     {:else if !appGlobal.isMobile}
-      <hbox flex class="no-search" on:click={toggleShowSearchField} />
+      <Clickable onClick={toggleShowSearchField}>
+        <hbox flex class="no-search" />
+      </Clickable>
       <FolderMsgCount {folder} {searchMessages} />
     {/if}
   </hbox>
@@ -75,6 +77,7 @@
   import SearchField from '../../Shared/SearchField.svelte';
   import GetMailButton from './GetMailButton.svelte';
   import RoundButton from '../../Shared/RoundButton.svelte';
+  import Clickable from "../../Shared/Clickable.svelte";
   import SearchIcon from "lucide-svelte/icons/search";
   import StarIcon from "lucide-svelte/icons/star";
   import CircleIcon from "lucide-svelte/icons/circle";

--- a/app/frontend/Mail/Message/AttachmentUI.svelte
+++ b/app/frontend/Mail/Message/AttachmentUI.svelte
@@ -1,26 +1,27 @@
-<hbox class="attachment"
-  draggable="true"
-  on:dragstart={onDragStart}
-  on:click={() => catchErrors(onOpen)}
-  >
-  <hbox bind:this={iconEl}>
-    <hbox class="icon">
-      <FileIcon ext={$attachment.ext} localFilePath={$attachment.filepathLocal} size={24} />
-    </hbox>
-    <vbox class="info">
-      <hbox title={$attachment.filename} class="filename top-row font-normal">
-        {$attachment.filename}
+<Clickable onClick={onOpen}>
+  <hbox class="attachment"
+    draggable="true"
+    on:dragstart={onDragStart}
+    >
+    <hbox bind:this={iconEl}>
+      <hbox class="icon">
+        <FileIcon ext={$attachment.ext} localFilePath={$attachment.filepathLocal} size={24} />
       </hbox>
-      <hbox class="bottom-row font-smallest">
-        <hbox class="size">
-          {$attachment.size ? fileSize($attachment.size) : $t`Not downloaded`}
+      <vbox class="info">
+        <hbox title={$attachment.filename} class="filename top-row font-normal">
+          {$attachment.filename}
         </hbox>
-        <hbox flex />
-        <AttachmentMenu {attachment} />
-      </hbox>
-    </vbox>
+        <hbox class="bottom-row font-smallest">
+          <hbox class="size">
+            {$attachment.size ? fileSize($attachment.size) : $t`Not downloaded`}
+          </hbox>
+          <hbox flex />
+          <AttachmentMenu {attachment} />
+        </hbox>
+      </vbox>
+    </hbox>
   </hbox>
-</hbox>
+</Clickable>
 
 <script lang="ts">
   import type { Attachment } from "../../../logic/Abstract/Attachment";
@@ -30,7 +31,7 @@
   import { assert } from "../../../logic/util/util";
   import AttachmentMenu from "./AttachmentMenu.svelte";
   import FileIcon from "../../Files/Thumbnail/FileIcon.svelte";
-  import { catchErrors } from "../../Util/error";
+  import Clickable from "../../Shared/Clickable.svelte";
   import { t } from "../../../l10n/l10n";
 
   export let attachment: Attachment;

--- a/app/frontend/Mail/Message/EncryptionDetails.svelte
+++ b/app/frontend/Mail/Message/EncryptionDetails.svelte
@@ -2,7 +2,7 @@
   <vbox class="font-small">
     {#if signed || encrypted}
       <vbox class="signed key-{trustLevel} plain">
-        <hbox on:click={() => isExpanded = false}>
+        <Clickable onClick={() => isExpanded = false}>
           <RoundButton
             label={title}
             icon={encrypted && signed ? EncryptedIcon : signed ? SignedIcon : EncryptedUnsignedIcon}
@@ -11,7 +11,7 @@
             border={false}
             />
           <div class="title">{title}</div>
-        </hbox>
+        </Clickable>
         <div class="msg">{msg}</div>
       </vbox>
     {/if}
@@ -32,6 +32,7 @@
   import { findIdentityForEMailAddress } from "../../../logic/Mail/MailIdentity";
   import EncryptionKey from "../../Contacts/PersonPage/EncryptionKey.svelte";
   import RoundButton from "../../Shared/RoundButton.svelte";
+  import Clickable from "../../Shared/Clickable.svelte";
   import SignedIcon from "lucide-svelte/icons/signature";
   import EncryptedIcon from "lucide-svelte/icons/lock";
   import EncryptedUnsignedIcon from "lucide-svelte/icons/shield-question-mark";

--- a/app/frontend/Mail/Message/Recipient.svelte
+++ b/app/frontend/Mail/Message/Recipient.svelte
@@ -1,21 +1,22 @@
-<hbox class="recipient"
-  on:click={(event) => catchErrors(() => onOpen(event))}
-  bind:this={anchor}
-  class:is-contact={recipient.findPerson()}
-  >
-  <div class="name" title={recipient.name + "\n" + recipient.emailAddress}>
-    {personDisplayName(recipient)}
-  </div>
-  {#if !recipient.findPerson()}
-    {#if recipient.emailAddress}
-      <div class="domain" title={recipient.emailAddress}>
-        @{getBaseDomainFromHost(getDomainForEmailAddress(recipient.emailAddress))}
-      </div>
-    {:else}
-      <hbox class="invalid">{$t`Invalid address`}</hbox>
+<Clickable onClick={onOpen}>
+  <hbox class="recipient"
+    bind:this={anchor}
+    class:is-contact={recipient.findPerson()}
+    >
+    <div class="name" title={recipient.name + "\n" + recipient.emailAddress}>
+      {personDisplayName(recipient)}
+    </div>
+    {#if !recipient.findPerson()}
+      {#if recipient.emailAddress}
+        <div class="domain" title={recipient.emailAddress}>
+          @{getBaseDomainFromHost(getDomainForEmailAddress(recipient.emailAddress))}
+        </div>
+      {:else}
+        <hbox class="invalid">{$t`Invalid address`}</hbox>
+      {/if}
     {/if}
-  {/if}
-</hbox>
+  </hbox>
+</Clickable>
 
 <Menu bind:isMenuOpen={isPopupOpen} {anchor} placement="bottom-start">
   {#if existingPersons?.hasItems}
@@ -50,7 +51,7 @@
   import Menu from "../../Shared/Menu/Menu.svelte";
   import MenuItem from "../../Shared/Menu/MenuItem.svelte";
   import MenuLabel from "../../Shared/Menu/MenuLabel.svelte";
-  import { catchErrors } from "../../Util/error";
+  import Clickable from "../../Shared/Clickable.svelte";
   import { ArrayColl } from "svelte-collections";
   import { t } from "../../../l10n/l10n";
 
@@ -61,7 +62,6 @@
   let existingPersons: ArrayColl<Person>;
 
   function onOpen(event: Event) {
-    event.stopPropagation();
     let person = recipient.findPerson(); // based on email address
     if (person) {
       openPersonFromOtherApp(person);

--- a/app/frontend/MainWindow/WorkspaceDropDown.svelte
+++ b/app/frontend/MainWindow/WorkspaceDropDown.svelte
@@ -1,22 +1,24 @@
 <vbox class="workspace-selector">
   {#each [null, ...appGlobal.workspaces.each] as workspace}
-    <hbox class="workspace"
-      on:click={event => onWorkspaceSelected(workspace, event)}
-      style="--workspace-color: {workspace?.color ?? "black"}"
-      class:selected={workspace == $selectedWorkspace}
-      >
-      <!--
-      <input type="radio"
-        checked={workspace == $selectedWorkspace}
-        value={workspace}
-        name="workspace"
-        on:input={event => onWorkspaceSelected(workspace, event)}
-        />
-      -->
-      <!--<Icon data={workspace?.icon} />-->
-      <hbox class="button" />
-      <label for="workspace" class="name">{workspace?.name ?? "All"}</label>
-    </hbox>
+    <Clickable onClick={() => onWorkspaceSelected(workspace)}>
+      <hbox class="workspace"
+        style="--workspace-color: {workspace?.color ?? "black"}"
+        class:selected={workspace == $selectedWorkspace}
+        >
+        <!--
+        <input type="radio"
+          checked={workspace == $selectedWorkspace}
+          value={workspace}
+          name="workspace"
+          on:input={event => onWorkspaceSelected(workspace, event)}
+          />
+        -->
+        <!--<Icon data={workspace?.icon} />-->
+        <hbox class="button" />
+        <label for="workspace" class="name">{workspace?.name ?? "All"}</label>
+      </hbox>
+
+    </Clickable>
   {/each}
 </vbox>
 
@@ -24,11 +26,11 @@
   import { Workspace } from "../../logic/Abstract/Workspace";
   import { selectedWorkspace } from "./Selected";
   import { appGlobal } from "../../logic/app";
+  import Clickable from "../Shared/Clickable.svelte";
 
   export let open: boolean;
 
-  function onWorkspaceSelected(workspace: Workspace, event: Event) {
-    event.stopPropagation();
+  function onWorkspaceSelected(workspace: Workspace) {
     open = false;
     $selectedWorkspace = workspace;
   }

--- a/app/frontend/MainWindow/WorkspaceDropDown.svelte
+++ b/app/frontend/MainWindow/WorkspaceDropDown.svelte
@@ -1,6 +1,6 @@
 <vbox class="workspace-selector">
   {#each [null, ...appGlobal.workspaces.each] as workspace}
-    <Clickable onClick={() => onWorkspaceSelected(workspace)}>
+    <Clickable onClick={event => onWorkspaceSelected(workspace, event)}>
       <hbox class="workspace"
         style="--workspace-color: {workspace?.color ?? "black"}"
         class:selected={workspace == $selectedWorkspace}
@@ -30,7 +30,7 @@
 
   export let open: boolean;
 
-  function onWorkspaceSelected(workspace: Workspace) {
+  function onWorkspaceSelected(workspace: Workspace, event: Event) {
     open = false;
     $selectedWorkspace = workspace;
   }

--- a/app/frontend/MainWindow/WorkspaceHeader.svelte
+++ b/app/frontend/MainWindow/WorkspaceHeader.svelte
@@ -1,22 +1,23 @@
-<hbox class="workspace" bind:this={workspaceE}
-  class:in-settings={$selectedApp == settingsMustangApp}
-  class:in-settings-workspaces={$selectedApp == settingsMustangApp && $selectedCategory?.id == "global-workspaces"}
-  style="--workspace-color: {$selectedWorkspace?.color ?? "inherit" }"
-  class:is-workspace-selected={$selectedWorkspace}
-  on:click={onWorkspaceToggle}>
-  {#if $selectedWorkspace}
-    <hbox class="dot" />
-    <hbox class="label">
-      {$selectedWorkspace.name}
-    </hbox>
-  {:else}
-    <RoundButton label={$t`Workspace`} icon={WorkspaceIcon}
-      iconSize="12px" filled={false} border={false} padding="0px" classes="workspace" />
-  {/if}
-  <Popup bind:popupOpen={showWorkspaceDropdown} popupAnchor={workspaceE} placement="bottom-start" boundaryElSel="body">
-    <WorkspaceDropDown bind:open={showWorkspaceDropdown} />
-  </Popup>
-</hbox>
+<Clickable onClick={onWorkspaceToggle}>
+  <hbox class="workspace" bind:this={workspaceE}
+    class:in-settings={$selectedApp == settingsMustangApp}
+    class:in-settings-workspaces={$selectedApp == settingsMustangApp && $selectedCategory?.id == "global-workspaces"}
+    style="--workspace-color: {$selectedWorkspace?.color ?? "inherit" }"
+    class:is-workspace-selected={$selectedWorkspace}>
+    {#if $selectedWorkspace}
+      <hbox class="dot" />
+      <hbox class="label">
+        {$selectedWorkspace.name}
+      </hbox>
+    {:else}
+      <RoundButton label={$t`Workspace`} icon={WorkspaceIcon}
+        iconSize="12px" filled={false} border={false} padding="0px" classes="workspace" />
+    {/if}
+    <Popup bind:popupOpen={showWorkspaceDropdown} popupAnchor={workspaceE} placement="bottom-start" boundaryElSel="body">
+      <WorkspaceDropDown bind:open={showWorkspaceDropdown} />
+    </Popup>
+  </hbox>
+</Clickable>
 
 <script lang="ts">
   import { selectedWorkspace } from "./Selected";
@@ -26,6 +27,7 @@
   import WorkspaceDropDown from "./WorkspaceDropDown.svelte";
   import Popup from "../Shared/Popup.svelte";
   import RoundButton from "../Shared/RoundButton.svelte";
+  import Clickable from "../Shared/Clickable.svelte";
   import WorkspaceIcon from 'lucide-svelte/icons/circle';
   import { t } from "../../l10n/l10n";
 

--- a/app/frontend/Meet/SelectScreenShare.svelte
+++ b/app/frontend/Meet/SelectScreenShare.svelte
@@ -10,14 +10,16 @@
       <Scroll>
         <hbox class="screens">
           {#each $screens.each as screen}
-            <vbox class="screen" on:click={() => onSelect(screen)}>
-              <img src={screen.thumbnailURL}
-                width={kThumbnailWidth} height={kThumbnailHeight}
-                alt="" />
-              <hbox class="name" style="--thumbnail-width: {kThumbnailWidth}px">
-                {screen.name}
-              </hbox>
-            </vbox>
+            <Clickable onClick={() => onSelect(screen)}>
+              <vbox class="screen">
+                <img src={screen.thumbnailURL}
+                  width={kThumbnailWidth} height={kThumbnailHeight}
+                  alt="" />
+                <hbox class="name" style="--thumbnail-width: {kThumbnailWidth}px">
+                  {screen.name}
+                </hbox>
+              </vbox>
+            </Clickable>
           {/each}
         </hbox>
       </Scroll>
@@ -51,6 +53,7 @@
   import { appGlobal } from "../../logic/app";
   import Popup from "../Shared/Popup.svelte";
   import Scroll from "../Shared/Scroll.svelte";
+  import Clickable from "../Shared/Clickable.svelte";
   import { t } from "../../l10n/l10n";
   import { onDestroy } from "svelte";
   import { ArrayColl } from "svelte-collections";

--- a/app/frontend/Meet/Start/MeetingList.svelte
+++ b/app/frontend/Meet/Start/MeetingList.svelte
@@ -2,9 +2,11 @@
   <Scroll>
     <grid>
       {#each $meetings.each as meeting}
-        <hbox class="time" on:click={ev => myOnClick(ev, meeting)}>
-          {getDateTimeString(meeting.startTime)}
-        </hbox>
+        <Clickable onClick={ev => myOnClick(ev, meeting)} {errorCallback}>
+          <hbox class="time">
+            {getDateTimeString(meeting.startTime)}
+          </hbox>
+        </Clickable>
         <hbox class="location">
           {#if meeting.isOnline}
             <VideoIcon />
@@ -12,9 +14,11 @@
             <PinIcon />
           {/if}
         </hbox>
-        <hbox class="title" on:click={ev => myOnClick(ev, meeting)}>
-          {meeting.title}
-        </hbox>
+        <Clickable onClick={ev => myOnClick(ev, meeting)} {errorCallback}>
+          <hbox class="title">
+            {meeting.title}
+          </hbox>
+        </Clickable>
       {/each}
     </grid>
   </Scroll>
@@ -24,6 +28,7 @@
 
 <script lang="ts">
   import type { Event as CalendarEvent} from "../../../logic/Calendar/Event";
+  import Clickable from "../../Shared/Clickable.svelte";
   import Scroll from "../../Shared/Scroll.svelte";
   import VideoIcon from 'lucide-svelte/icons/video';
   import PinIcon from 'lucide-svelte/icons/map-pin';
@@ -40,8 +45,6 @@
     if (!(onClick && typeof(onClick) == "function")) {
       return;
     }
-    event.stopPropagation();
-    event.preventDefault();
     disabled = true;
     try {
       await onClick(meeting);

--- a/app/frontend/Settings/Global/WorkspaceAccounts.svelte
+++ b/app/frontend/Settings/Global/WorkspaceAccounts.svelte
@@ -16,10 +16,11 @@
   <vbox class="accounts-list">
     {#each $accounts.each as account}
       <hbox class="account">
-        <hbox class="name page-link"
-          on:click={() => catchErrors(() => onOpenAccount(account))}>
-          {account.name}
-        </hbox>
+        <Clickable onClick={() => onOpenAccount(account)}>
+          <hbox class="name page-link">
+            {account.name}
+          </hbox>
+        </Clickable>
         <hbox class="spacer" flex />
         <hbox class="buttons">
           <WorkspaceAccountMenu {account} {workspace} />
@@ -40,8 +41,8 @@
   import { changedWorkspace } from "../../MainWindow/Selected";
   import WorkspaceAccountMenu from "./WorkspaceAccountMenu.svelte";
   import RoundButton from "../../Shared/RoundButton.svelte";
+  import Clickable from "../../Shared/Clickable.svelte";
   import AddIcon from "lucide-svelte/icons/plus";
-  import { catchErrors } from "../../Util/error";
   import { assert } from "../../../logic/util/util";
   import { Collection } from "svelte-collections";
   import { t } from "../../../l10n/l10n";

--- a/app/frontend/Settings/Mail/Account/Encryption.svelte
+++ b/app/frontend/Settings/Mail/Account/Encryption.svelte
@@ -21,26 +21,27 @@
       <EncryptionKey {key} {identity} />
     {/each}
     {#if $keys.filterObservable(key => key.obsolete).hasItems}
-      <vbox class="expired-header"
-        class:expanded={showObsolete}
-        on:click={() => showObsolete = !showObsolete}>
-        <hbox class="first-row">
-          <hbox class="label font-smallest" flex>
-            {$t`Expired`}
+      <Clickable onClick={() => showObsolete = !showObsolete}>
+        <vbox class="expired-header"
+          class:expanded={showObsolete}>
+          <hbox class="first-row">
+            <hbox class="label font-smallest" flex>
+              {$t`Expired`}
+            </hbox>
+            <RoundButton
+              label={showObsolete ? $t`Collapse` : $t`Expand`}
+              icon={showObsolete ? ChevronUp : ChevronDown}
+              border={false}
+              classes="plain"
+              />
           </hbox>
-          <RoundButton
-            label={showObsolete ? $t`Collapse` : $t`Expand`}
-            icon={showObsolete ? ChevronUp : ChevronDown}
-            border={false}
-            classes="plain"
-            />
-        </hbox>
-        {#if showObsolete}
-          <hbox class="subtitle font-smallest" flex>
-            {$t`These below are your keys that are expired, revoked, or obsolete. They will not be used for new emails. They are still necessary to read old emails that you have received and stored.`}
-          </hbox>
-        {/if}
-      </vbox>
+          {#if showObsolete}
+            <hbox class="subtitle font-smallest" flex>
+              {$t`These below are your keys that are expired, revoked, or obsolete. They will not be used for new emails. They are still necessary to read old emails that you have received and stored.`}
+            </hbox>
+          {/if}
+        </vbox>
+      </Clickable>
     {/if}
     {#if showObsolete}
       {#each $keys.filterObservable(key => key.obsolete).each as key}
@@ -54,6 +55,7 @@
   import { MailIdentity } from "../../../../logic/Mail/MailIdentity";
   import EncryptionKey from "./EncryptionKey.svelte";
   import RoundButton from "../../../Shared/RoundButton.svelte";
+  import Clickable from "../../../Shared/Clickable.svelte";
   import PlusIcon from "lucide-svelte/icons/plus";
   import ChevronUp from "lucide-svelte/icons/chevron-up";
   import ChevronDown from "lucide-svelte/icons/chevron-down";

--- a/app/frontend/Settings/Mail/Account/EncryptionKey.svelte
+++ b/app/frontend/Settings/Mail/Account/EncryptionKey.svelte
@@ -1,35 +1,36 @@
 <vbox class="key" class:obsolete={$key.obsolete}>
-  <hbox class="main-row"
-    on:click={() => isExpanded = !isExpanded}>
-    <hbox class="usage"
-      style:background-color={$key.obsolete ? "grey" : "green"}
-      style:color={$key.obsolete ? "black" : "white"}>
-      {#if $key.obsolete}
-        <DistrustIcon title={$t`Obsolete`} size="16px" />
-      {:else if $key.encryptByDefault}
-        <EncryptIcon title={$t`Use for encryption and signing`} size="16px" />
-      {:else if $key.useToSign}
-        <SignIcon title={$t`Use only for signing messages`} size="16px" />
+  <Clickable onClick={() => isExpanded = !isExpanded}>
+    <hbox class="main-row">
+      <hbox class="usage"
+        style:background-color={$key.obsolete ? "grey" : "green"}
+        style:color={$key.obsolete ? "black" : "white"}>
+        {#if $key.obsolete}
+          <DistrustIcon title={$t`Obsolete`} size="16px" />
+        {:else if $key.encryptByDefault}
+          <EncryptIcon title={$t`Use for encryption and signing`} size="16px" />
+        {:else if $key.useToSign}
+          <SignIcon title={$t`Use only for signing messages`} size="16px" />
+        {:else}
+          <UnusedIcon title={$t`Used only on demand`} size="16px" />
+        {/if}
+      </hbox>
+      <hbox class="name">{$key.name}</hbox>
+      {#if isExpanded}
+        <hbox class="keytype" flex>{$t`Secret key`}</hbox>
       {:else}
-        <UnusedIcon title={$t`Used only on demand`} size="16px" />
+        <hbox flex />
       {/if}
+      <hbox class="system font-small">
+        {key.system}
+      </hbox>
+      <RoundButton
+        label={isExpanded ? $t`Collapse` : $t`Expand`}
+        icon={isExpanded ? ChevronUp : ChevronDown}
+        border={false}
+        classes="plain"
+        />
     </hbox>
-    <hbox class="name">{$key.name}</hbox>
-    {#if isExpanded}
-      <hbox class="keytype" flex>{$t`Secret key`}</hbox>
-    {:else}
-      <hbox flex />
-    {/if}
-    <hbox class="system font-small">
-      {key.system}
-    </hbox>
-    <RoundButton
-      label={isExpanded ? $t`Collapse` : $t`Expand`}
-      icon={isExpanded ? ChevronUp : ChevronDown}
-      border={false}
-      classes="plain"
-      />
-  </hbox>
+  </Clickable>
   {#if isExpanded}
     <vbox class="details">
       {#if $key.obsolete}
@@ -150,6 +151,7 @@
   import Checkbox from "../../../Shared/Checkbox.svelte";
   import RoundButton from "../../../Shared/RoundButton.svelte";
   import Button from "../../../Shared/Button.svelte";
+  import Clickable from "../../../Shared/Clickable.svelte";
   import SignIcon from "lucide-svelte/icons/signature";
   import EncryptIcon from "lucide-svelte/icons/lock";
   import UnusedIcon from "lucide-svelte/icons/circle-dashed";

--- a/app/frontend/Settings/Window/AccountItem.svelte
+++ b/app/frontend/Settings/Window/AccountItem.svelte
@@ -1,8 +1,10 @@
-<vbox class="account" class:selected={itemSelected} on:click={onSelect}>
-  <hbox class="label font-small">
-    {$account.name}
-  </hbox>
-</vbox>
+<Clickable onClick={onSelect}>
+  <vbox class="account" class:selected={itemSelected}>
+    <hbox class="label font-small">
+      {$account.name}
+    </hbox>
+  </vbox>
+</Clickable>
 {#if accountSelected}
   <SubCategoriesList {subCategories} mainCategory={category} />
 {/if}
@@ -13,6 +15,7 @@
   import { accountSettings, type SettingsCategory } from "../SettingsCategory";
   import { selectedCategory, selectedAccount } from "./selected";
   import SubCategoriesList from "./SubCategoriesList.svelte";
+  import Clickable from "../../Shared/Clickable.svelte";
 
   /** in */
   export let account: Account;

--- a/app/frontend/Settings/Window/CategoryItem.svelte
+++ b/app/frontend/Settings/Window/CategoryItem.svelte
@@ -1,8 +1,10 @@
-<vbox class="settings-category" class:selected on:click={onSelect}>
-  <hbox class="label font-small" class:main={category.isMain}>
-    {category.name}
-  </hbox>
-</vbox>
+<Clickable onClick={onSelect}>
+  <vbox class="settings-category" class:selected>
+    <hbox class="label font-small" class:main={category.isMain}>
+      {category.name}
+    </hbox>
+  </vbox>
+</Clickable>
 {#if isSectionOpen}
   <SubCategoriesList subCategories={category.subCategories} mainCategory={category} />
   <AccountsList {category} />
@@ -13,6 +15,7 @@
   import { selectedCategory, selectedAccount } from "./selected";
   import SubCategoriesList from "./SubCategoriesList.svelte";
   import AccountsList from "./AccountsList.svelte";
+  import Clickable from "../../Shared/Clickable.svelte";
   import { appGlobal } from "../../../logic/app";
 
   /** in */

--- a/app/frontend/Setup/Mail/FoundConfig.svelte
+++ b/app/frontend/Setup/Mail/FoundConfig.svelte
@@ -12,15 +12,17 @@
   <vbox class="configs">
     {#each $uniqueConfigs.each as altConfig}
       <vbox class="alt">
-        <hbox class="protocol-header" on:click={event => onChange(altConfig, event)}>
-          <input type="radio"
-            checked={altConfig == config}
-            value={altConfig.protocol}
-            name="protocol"
-            on:change={event => onChange(altConfig, event)}
-            />
-          <label class="protocol" for={altConfig.protocol}>{labelForMailProtocol(altConfig.protocol)}</label>
-        </hbox>
+        <Clickable onClick={event => onChange(altConfig, event)}>
+          <hbox class="protocol-header">
+            <input type="radio"
+              checked={altConfig == config}
+              value={altConfig.protocol}
+              name="protocol"
+              on:change={event => onChange(altConfig, event)}
+              />
+            <label class="protocol" for={altConfig.protocol}>{labelForMailProtocol(altConfig.protocol)}</label>
+          </hbox>
+        </Clickable>
         {#if altConfig == config}
           <hbox class="display">
             <DisplayConfig config={altConfig} />
@@ -36,6 +38,7 @@
   import { labelForMailProtocol } from "../../../logic/Mail/AccountsList/MailAccounts";
   import DisplayConfig from "./DisplayConfig.svelte";
   import StatusMessage from "../Shared/StatusMessage.svelte";
+  import Clickable from "../../Shared/Clickable.svelte";
   import CheckIcon from "lucide-svelte/icons/check";
   import { filterUnique } from "../../../logic/util/collections";
   import type { ArrayColl } from "svelte-collections";

--- a/app/frontend/Setup/Mail/WorkspaceSelector.svelte
+++ b/app/frontend/Setup/Mail/WorkspaceSelector.svelte
@@ -3,18 +3,19 @@
   <vbox class="workspaces-box" class:horizontal>
     <vbox class="workspaces">
       {#each $workspaces.each as workspace}
-        <hbox class="workspace"
-          on:click={event => onChange(workspace, event)}
-          style="background-color: {workspace.color}"
-          >
-          <input type="radio"
-            checked={workspace == selectedWorkspace}
-            value={workspace}
-            name="workspace"
-            on:change={event => onChange(workspace, event)}
-            />
-          <label for="workspace" class="name">{workspace.name}</label>
-        </hbox>
+        <Clickable onClick={event => onChange(workspace, event)}>
+          <hbox class="workspace"
+            style="background-color: {workspace.color}"
+            >
+            <input type="radio"
+              checked={workspace == selectedWorkspace}
+              value={workspace}
+              name="workspace"
+              on:change={event => onChange(workspace, event)}
+              />
+            <label for="workspace" class="name">{workspace.name}</label>
+          </hbox>
+        </Clickable>
       {/each}
     </vbox>
   </vbox>
@@ -23,6 +24,7 @@
 <script lang="ts">
   import type { Workspace } from "../../../logic/Abstract/Workspace";
   import { appGlobal } from "../../../logic/app";
+  import Clickable from "../../Shared/Clickable.svelte";
   import { t } from "../../../l10n/l10n";
 
   export let selectedWorkspace: Workspace = appGlobal.workspaces.last;

--- a/app/frontend/Setup/Shared/ProtocolSelector.svelte
+++ b/app/frontend/Setup/Shared/ProtocolSelector.svelte
@@ -1,16 +1,16 @@
 <vbox class="protocol-selector">
   {#each protocols as protocol}
-    <hbox class="protocol"
-      on:click={event => onChange(protocol, event)}
-      >
-      <input type="radio"
-        checked={protocol.protocolID == selectedProtocol}
-        value={protocol}
-        name="protocol"
-        on:change={event => onChange(protocol, event)}
-        />
-      <label for="protocol" class="name">{protocol.label}</label>
-    </hbox>
+    <Clickable onClick={event => onChange(protocol, event)}>
+      <hbox class="protocol">
+        <input type="radio"
+          checked={protocol.protocolID == selectedProtocol}
+          value={protocol}
+          name="protocol"
+          on:change={event => onChange(protocol, event)}
+          />
+        <label for="protocol" class="name">{protocol.label}</label>
+      </hbox>
+    </Clickable>
   {/each}
 </vbox>
 
@@ -22,6 +22,8 @@
   }
 </script>
 <script lang="ts">
+  import Clickable from "../../Shared/Clickable.svelte";
+
   /** in */
   export let protocols: ProtocolDescription[];
   /** in/out */

--- a/app/frontend/Shared/AccountSelectorRound.svelte
+++ b/app/frontend/Shared/AccountSelectorRound.svelte
@@ -1,44 +1,45 @@
 <hbox class="accounts" class:large>
   {#if showAllOption}
-    <vbox class="account" title={$t`All`}
-      on:click={() => onSelect(null)}
-      >
-      <hbox>
-        <RoundButton
-          label={$t`All`}
-          selected={selectedAccount == null}
-          onClick={() => onSelect(null)}
-          icon={iconDefault}
-          border={false}
-        />
-      </hbox>
-      <div class="name font-smallest">{$t`All`}</div>
-    </vbox>
+    <Clickable onClick={() => onSelect(null)}>
+      <vbox class="account" title={$t`All`}>
+        <hbox>
+          <RoundButton
+            label={$t`All`}
+            selected={selectedAccount == null}
+            onClick={() => onSelect(null)}
+            icon={iconDefault}
+            border={false}
+          />
+        </hbox>
+        <div class="name font-smallest">{$t`All`}</div>
+      </vbox>
+    </Clickable>
   {/if}
   {#each $accounts.each as acc}
-    <vbox class="account" title={acc.name}
-      on:click={() => onSelect(acc)}
-      style="--account-color: {acc.color}"
-      >
-      <hbox>
-        <RoundButton
-          label={acc.name}
-          selected={acc == selectedAccount}
-          onClick={() => onSelect(acc)}
-          icon={acc.icon ?? iconDefault}
-          classes={acc.icon ? "has-logo" : "default-icon"}
-          {iconSize}
-          border={false}
-        />
-      </hbox>
-      <div class="name font-smallest" title={acc.name}>{acc.name}</div>
-    </vbox>
+    <Clickable onClick={() => onSelect(acc)}>
+      <vbox class="account" title={acc.name}
+        style="--account-color: {acc.color}">
+        <hbox>
+          <RoundButton
+            label={acc.name}
+            selected={acc == selectedAccount}
+            onClick={() => onSelect(acc)}
+            icon={acc.icon ?? iconDefault}
+            classes={acc.icon ? "has-logo" : "default-icon"}
+            {iconSize}
+            border={false}
+          />
+        </hbox>
+        <div class="name font-smallest" title={acc.name}>{acc.name}</div>
+      </vbox>
+    </Clickable>
   {/each}
 </hbox>
 
 <script lang="ts">
   import type { Account } from "../../logic/Abstract/Account";
   import RoundButton from "./RoundButton.svelte";
+  import Clickable from "../Shared/Clickable.svelte";
   import type { Collection } from "svelte-collections";
   import type { ConstructorOfATypedSvelteComponent } from "svelte";
   import { t } from "../../l10n/l10n";

--- a/app/frontend/Shared/Clickable.svelte
+++ b/app/frontend/Shared/Clickable.svelte
@@ -1,8 +1,8 @@
 <!-- svelte-ignore a11y_click_events_have_key_events a11y_no_static_element_interactions -->
-<hbox on:click={myOnClick} on:dblclick={myOnDoubleClick}
+<div on:click={myOnClick} on:dblclick={myOnDoubleClick}
   disabled={!!disabled} class:disabled title={tooltip}>
   <slot />
-</hbox>
+</div>
 
 <script lang="ts">
   import { showError } from '../Util/error';
@@ -54,7 +54,7 @@
 </script>
 
 <style>
-  hbox {
-    height: 100%; /* TODO Use flex directives instead */
+  div {
+    display: contents; /* Use child container CSS rules */
   }
 </style>

--- a/app/frontend/Shared/ExpandSection.svelte
+++ b/app/frontend/Shared/ExpandSection.svelte
@@ -1,17 +1,18 @@
 <vbox class="expander">
-   <hbox class="header" class:box={headerBox}
-      on:click={onExpandToggle}>
+  <Clickable onClick={onExpandToggle}>
+    <hbox class="header" class:box={headerBox}>
       <slot name="header" />
-    <hbox flex />
-    <hbox class="buttons top-right">
-      <Button plain
-        icon={expanded ? CollapseIcon : ExpandIcon}
-        label={expanded ? $t`Collapse` : $t`Expand`}
-        onClick={onExpandToggle}
-        classes="expand"
-        iconOnly iconSize="16px" />
+      <hbox flex />
+      <hbox class="buttons top-right">
+        <Button plain
+          icon={expanded ? CollapseIcon : ExpandIcon}
+          label={expanded ? $t`Collapse` : $t`Expand`}
+          onClick={onExpandToggle}
+          classes="expand"
+          iconOnly iconSize="16px" />
+      </hbox>
     </hbox>
-   </hbox>
+  </Clickable>
    {#if expanded}
      <slot />
    {/if}
@@ -19,6 +20,7 @@
 
 <script lang="ts">
   import Button from "./Button.svelte";
+  import Clickable from "./Clickable.svelte";
   import ExpandIcon from "lucide-svelte/icons/chevron-down";
   import CollapseIcon from "lucide-svelte/icons/chevron-up";
   import { t } from "../../l10n/l10n";

--- a/app/frontend/WebApps/LauncherFullPage/LaunchPageButton.svelte
+++ b/app/frontend/WebApps/LauncherFullPage/LaunchPageButton.svelte
@@ -1,14 +1,17 @@
-<vbox class="app" on:click={startApp}>
-  <vbox class="icon">
-    <img src={app.icon} width="96" height="96" alt="" />
+<Clickable onClick={startApp}>
+  <vbox class="app">
+    <vbox class="icon">
+      <img src={app.icon} width="96" height="96" alt="" />
+    </vbox>
+    <vbox class="nameDescr">
+      <h2 class="name font-normal">{app.nameTranslated}</h2>
+    </vbox>
   </vbox>
-  <vbox class="nameDescr">
-    <h2 class="name font-normal">{app.nameTranslated}</h2>
-  </vbox>
-</vbox>
+</Clickable>
 
 <script lang="ts">
   import type { WebAppListed } from "../../../logic/WebApps/WebAppListed";
+  import Clickable from "../../Shared/Clickable.svelte";
 
   export let app: WebAppListed;
   export let runningApp: WebAppListed; /* in/out */

--- a/app/frontend/WebApps/Shop/CategoryEntry.svelte
+++ b/app/frontend/WebApps/Shop/CategoryEntry.svelte
@@ -1,5 +1,7 @@
 <hbox class="category">
-  <hbox flex class="name" on:click={onSelect}>{category.nameTranslated}</hbox>
+  <Clickable onClick={onSelect}>
+    <hbox flex class="name">{category.nameTranslated}</hbox>
+  </Clickable>
   {#if hasChildCategories}
     <Button plain classes="openClose" onClick={toggleOpenClose} icon={isOpen ? ChevronUpIcon : ChevronDownIcon} />
   {/if}
@@ -14,6 +16,7 @@
   import type { WebAppCategory } from "../../../logic/WebApps/WebAppCategory";
   import Categories from "./Categories.svelte";
   import Button from "../../Shared/Button.svelte";
+  import Clickable from "../../Shared/Clickable.svelte";
   import ChevronUpIcon from "lucide-svelte/icons/chevron-up";
   import ChevronDownIcon from "lucide-svelte/icons/chevron-down";
   import type { MapColl } from "svelte-collections";

--- a/app/frontend/WebApps/Shop/WebAppShopButton.svelte
+++ b/app/frontend/WebApps/Shop/WebAppShopButton.svelte
@@ -1,56 +1,58 @@
 <vbox>
-  <vbox class="app" class:selected={app == selectedApp} on:click={onSelect}>
-    <vbox class="icon">
-      <img src={app.icon} width="96" height="96" alt="" />
-    </vbox>
-    <vbox class="nameDescr" flex>
-      <h2 class="app-name font-normal">{app.nameTranslated}</h2>
-      <div class="description font-smallest">{app.descriptionTranslated}</div>
-    </vbox>
-    <hbox class="actions">
-      {#if app.homepage}
-        <a class="homepage font-smallest" href={app.homepage} target="_blank">{$t`Info`}</a>
-      {/if}
-      <hbox flex />
-      <RoundButton
-        label={$t`Add`}
-        icon={AddIcon}
-        onClick={onAdd}
-        classes="add create {adding ? "hidden" : ""}"
-        />
-    </hbox>
-    {#if instances.hasItems}
-      <vbox class="instances-separator" />
-      <vbox class="instances">
-        {#each instances.each as iapp, i}
-          <hbox class="instance">
-            {#if iapp.account}
-              <RoundButton
-                label={iapp.account.name}
-                icon={iapp.account.icon}
-                classes="account plain" border={false}
-                />
-              <hbox class="account-name" flex>
-                {iapp.account.name}
-              </hbox>
-            {:else}
-              <RoundButton label="" icon={CircleIcon} disabled border={false}
-                classes="no-account plain" />
-              <hbox class="account-name" flex>
-                {iapp.nameTranslated?.split(" ").pop() + " " + i}
-              </hbox>
-            {/if}
-            <RoundButton
-              label={$t`Remove`}
-              icon={TrashIcon}
-              onClick={() => onRemove(iapp)}
-              classes="remove plain" border={false}
-              />
-          </hbox>
-        {/each}
+  <Clickable onClick={onSelect}>
+    <vbox class="app" class:selected={app == selectedApp}>
+      <vbox class="icon">
+        <img src={app.icon} width="96" height="96" alt="" />
       </vbox>
-    {/if}
-  </vbox>
+      <vbox class="nameDescr" flex>
+        <h2 class="app-name font-normal">{app.nameTranslated}</h2>
+        <div class="description font-smallest">{app.descriptionTranslated}</div>
+      </vbox>
+      <hbox class="actions">
+        {#if app.homepage}
+          <a class="homepage font-smallest" href={app.homepage} target="_blank">{$t`Info`}</a>
+        {/if}
+        <hbox flex />
+        <RoundButton
+          label={$t`Add`}
+          icon={AddIcon}
+          onClick={onAdd}
+          classes="add create {adding ? "hidden" : ""}"
+          />
+      </hbox>
+      {#if instances.hasItems}
+        <vbox class="instances-separator" />
+        <vbox class="instances">
+          {#each instances.each as iapp, i}
+            <hbox class="instance">
+              {#if iapp.account}
+                <RoundButton
+                  label={iapp.account.name}
+                  icon={iapp.account.icon}
+                  classes="account plain" border={false}
+                  />
+                <hbox class="account-name" flex>
+                  {iapp.account.name}
+                </hbox>
+              {:else}
+                <RoundButton label="" icon={CircleIcon} disabled border={false}
+                  classes="no-account plain" />
+                <hbox class="account-name" flex>
+                  {iapp.nameTranslated?.split(" ").pop() + " " + i}
+                </hbox>
+              {/if}
+              <RoundButton
+                label={$t`Remove`}
+                icon={TrashIcon}
+                onClick={() => onRemove(iapp)}
+                classes="remove plain" border={false}
+                />
+            </hbox>
+          {/each}
+        </vbox>
+      {/if}
+    </vbox>
+  </Clickable>
   {#if adding}
     <AddDialog {app} on:added={onAddDone} />
   {/if}
@@ -63,6 +65,7 @@
   import { appGlobal } from "../../../logic/app";
   import AddDialog from "./AddDialog.svelte";
   import RoundButton from "../../Shared/RoundButton.svelte";
+  import Clickable from "../../Shared/Clickable.svelte";
   import AddIcon from "lucide-svelte/icons/plus";
   import TrashIcon from "lucide-svelte/icons/trash-2";
   import CircleIcon from "lucide-svelte/icons/circle";


### PR DESCRIPTION
- Wrap all elements that don't need `on:click` or `on:dblclick` to be propagated
- Remove the `catchErrors()` wrapping for handler functions
- Remove `event.stopPropagation()` and `event.preventDefault()` that were in handler functions
- Fixed: `<Clickable>` by using `display: contents` which removes the box model or sizing from the element but uses the child box model or size from its children
- `ListViewLine` needs the `on:click` to be propagated for the `<FastList>` to highlight the selected item