### PR TITLE
Mail: SearchPane: Don't listen to changes from $search because it causes an infinitive loop - #1203

### DIFF
--- a/app/frontend/Mail/Search/SearchPane.svelte
+++ b/app/frontend/Mail/Search/SearchPane.svelte
@@ -74,7 +74,7 @@
   let tags = search.tags;
   let attachmentTypes = search.hasAttachmentMIMETypes;
 
-  $: isOpen && $globalSearchTerm, $search, $tags, $attachmentTypes, startSearchDebounced();
+  $: isOpen && $globalSearchTerm, $tags, $attachmentTypes, startSearchDebounced();
   const startSearchDebounced = debounce(() => startSearch(), 300);
   async function startSearch() {
     try {


### PR DESCRIPTION
- SearchPane: Don't listen to changes from $search because it causes an infinitive loop

When `startSearch()` it sets the `bodyText` property which causes an update and triggers another update in the UI

https://github.com/mustang-im/mustang/blob/544eca4e8fef48c962fd2e463c6cf586053bbe8c/app/frontend/Mail/Search/SearchPane.svelte#L89