### PR TITLE
Svelte 5: Don't subscribe to objects that are re-assigned which also use .filterObservable()

### DIFF
--- a/app/frontend/Mail/MailChat/MailChat.svelte
+++ b/app/frontend/Mail/MailChat/MailChat.svelte
@@ -13,7 +13,7 @@
     <ViewSwitcher />
   </vbox>
   <vbox class="right-pane" slot="right">
-    {#if $filteredMessages.hasItems && selectedPerson }
+    {#if $filteredMessages && selectedPerson }
       <PaymentBar account={$selectedAccount} showWhenNoAccount={false} />
       <Header person={selectedPerson} />
       <vbox flex class="messages background-pattern">

--- a/app/frontend/Mail/MailChat/MailChat.svelte
+++ b/app/frontend/Mail/MailChat/MailChat.svelte
@@ -65,7 +65,7 @@
   $: filteredMessages = $globalSearchTerm
     ? personMessages.filterObservable(msg => msg.text?.toLowerCase().includes($globalSearchTerm))
     : personMessages;
-  $: account = personMessages.first?.folder.account ?? accounts.first;
+  $: account = $personMessages.first?.folder.account ?? $accounts.first;
   $: chatRoom = new MailChatRoom(account, selectedPerson, personMessages);
 </script>
 

--- a/app/frontend/Mail/MailChat/MailChat.svelte
+++ b/app/frontend/Mail/MailChat/MailChat.svelte
@@ -13,11 +13,11 @@
     <ViewSwitcher />
   </vbox>
   <vbox class="right-pane" slot="right">
-    {#if filteredMessages && selectedPerson }
+    {#if $filteredMessages.hasItems && selectedPerson }
       <PaymentBar account={$selectedAccount} showWhenNoAccount={false} />
       <Header person={selectedPerson} />
       <vbox flex class="messages background-pattern">
-        <MessageList messages={filteredMessages}>
+        <MessageList messages={$filteredMessages}>
           <svelte:fragment slot="message" let:message let:previousMessage>
             <MailMessage {message} {previousMessage} />
           </svelte:fragment>
@@ -57,15 +57,15 @@
   export let accounts: Collection<MailAccount>; /** in */
 
   let selectedPerson: PersonUID;
-  $: folders = mergeColls<Folder>($accounts.map(account => account.rootFolders));
+  $: folders = mergeColls<Folder>(accounts.map(account => account.rootFolders));
   // $: folders = $accounts.map(account => account.inbox);
-  $: allMessages = mergeColls<EMail>($folders.map(folder => folder.messages)).sortBy(msg => -msg.sent.getTime());
-  $: persons = $allMessages.map(msg => msg.contact as PersonUID).unique();
-  $: personMessages = $allMessages.filterObservable(msg => msg.contact == selectedPerson);
+  $: allMessages = mergeColls<EMail>(folders.map(folder => folder.messages)).sortBy(msg => -msg.sent.getTime());
+  $: persons = allMessages.map(msg => msg.contact as PersonUID).unique();
+  $: personMessages = allMessages.filterObservable(msg => msg.contact == selectedPerson);
   $: filteredMessages = $globalSearchTerm
     ? personMessages.filterObservable(msg => msg.text?.toLowerCase().includes($globalSearchTerm))
     : personMessages;
-  $: account = $personMessages.first?.folder.account ?? $accounts.first;
+  $: account = personMessages.first?.folder.account ?? accounts.first;
   $: chatRoom = new MailChatRoom(account, selectedPerson, personMessages);
 </script>
 

--- a/app/frontend/Mail/MailChat/MailChat.svelte
+++ b/app/frontend/Mail/MailChat/MailChat.svelte
@@ -17,7 +17,7 @@
       <PaymentBar account={$selectedAccount} showWhenNoAccount={false} />
       <Header person={selectedPerson} />
       <vbox flex class="messages background-pattern">
-        <MessageList messages={$filteredMessages}>
+        <MessageList messages={filteredMessages}>
           <svelte:fragment slot="message" let:message let:previousMessage>
             <MailMessage {message} {previousMessage} />
           </svelte:fragment>

--- a/app/frontend/Meet/InMeeting.svelte
+++ b/app/frontend/Meet/InMeeting.svelte
@@ -30,8 +30,8 @@
   let selectedParticipant: MeetingParticipant = null;
   $: me = meeting.myParticipant;
   $: allStreams = meeting.videos;
-  $: videos = $allStreams.filterObservable(video => video.hasVideo || video.isScreenShare);
-  $: audioOnlyStreams = $allStreams.filterObservable(video => !video.hasVideo && !video.isMe);
+  $: videos = allStreams.filterObservable(video => video.hasVideo || video.isScreenShare);
+  $: audioOnlyStreams = allStreams.filterObservable(video => !video.hasVideo && !video.isMe);
 
   // Show sidebar only when there are no participants, and
   // close it when the first person joins

--- a/app/frontend/WebApps/Shop/WebAppShopButton.svelte
+++ b/app/frontend/WebApps/Shop/WebAppShopButton.svelte
@@ -20,10 +20,10 @@
           classes="add create {adding ? "hidden" : ""}"
           />
       </hbox>
-      {#if instances.hasItems}
+      {#if $instances.hasItems}
         <vbox class="instances-separator" />
         <vbox class="instances">
-          {#each instances.each as iapp, i}
+          {#each $instances.each as iapp, i}
             <hbox class="instance">
               {#if iapp.account}
                 <RoundButton
@@ -82,7 +82,7 @@
   }
 
   $: myApps = appGlobal.webApps.myApps;
-  $: instances = $myApps.filterObservable(a => a.id == app.id);
+  $: instances = myApps.filterObservable(a => a.id == app.id);
 
   function onAdd() {
     adding = true;


### PR DESCRIPTION
- Svelte 5: Don't subscribe to objects that are re-assigned which also use .filterObservable()
- MailChat was the only one that froze silently but the other's didn't I did notice some lag though. But I'm not sure if there's some other bug causing it.