### PR TITLE
EventContent: Use the correct handler function mistake from #1205

### DIFF
--- a/app/frontend/Calendar/DayView/EventContent.svelte
+++ b/app/frontend/Calendar/DayView/EventContent.svelte
@@ -1,4 +1,4 @@
-<Clickable onClick={onSelect} onDoubleClick={onSelect}>
+<Clickable onClick={onSelect} onDoubleClick={onOpen}>
   <hbox class="event font-small" flex
     title={eventAsText}>
     {#if showTime}


### PR DESCRIPTION
- EventContent: Use the correct handler function mistake from #1205 