### PR TITLE
Mobile: Checkbox: Fix styling - #1199

### DIFF
--- a/app/frontend/Shared/Checkbox.svelte
+++ b/app/frontend/Shared/Checkbox.svelte
@@ -34,7 +34,7 @@
     {/if}
   {/if}
 
-  {#if !toggle && allowIndetermined}
+  {#if !toggle || allowIndetermined}
     <hbox class="state-icon-wrapper">
       {#if checked === true}
         <CheckIcon strokeWidth={5} size={12} />

--- a/app/frontend/Shared/Checkbox.svelte
+++ b/app/frontend/Shared/Checkbox.svelte
@@ -183,15 +183,16 @@
       inset 0 1px 2px rgba(255, 255, 255, 0.2);
   }
   :global(.mobile) .checkbox {
-    min-height: 44px;
+    min-height: 32px;
   }
   :global(.mobile) .knob {
-    top: 14px;
+    height: 32px;
+    width: 32px;
   }
   :global(.mobile) .knob-wrapper {
-    height: 44px;
-    width: 44px;
-    min-width: 44px;
+    height: 32px;
+    width: 64px;
+    min-width: 64px;
   }
   :global(.mobile) .indetermined .knob {
     left: 16px;

--- a/app/frontend/Shared/Checkbox.svelte
+++ b/app/frontend/Shared/Checkbox.svelte
@@ -34,7 +34,7 @@
     {/if}
   {/if}
 
-  {#if !toggle || allowIndetermined}
+  {#if !toggle && allowIndetermined}
     <hbox class="state-icon-wrapper">
       {#if checked === true}
         <CheckIcon strokeWidth={5} size={12} />


### PR DESCRIPTION
- The Toggle checkbox seems to be broken even in Svelte 4 so I could only fix the component itself
- There was also a floating icon because of the `||` condition
- However since the toggle is bigger on mobile it makes it appear as if there's no space around the checkbox
<img width="253" height="307" alt="image" src="https://github.com/user-attachments/assets/d7bc7f0b-19ab-4c1f-84ad-d710e62413be" />

