### PR TITLE
Svelte 5: Remove debounce for <svelte:component> #1208

### DIFF
--- a/app/frontend/MainWindow/MainWindow.svelte
+++ b/app/frontend/MainWindow/MainWindow.svelte
@@ -88,9 +88,7 @@
 
   // $: sidebarApp = $mustangApps.filter(app => app.showSidebar).first; // TODO watch `app` property changes
   $: $sidebarApp = $meetMustangApp.showSidebar ? meetMustangApp : null;
-  let sidebar;
-  const setSidebarDebounced = debounce(() => sidebar = $sidebarApp?.sidebar);
-  $: $sidebarApp?.sidebar, setSidebarDebounced();
+  $: sidebar = $sidebarApp?.sidebar;
   $: rtl = rtlLocales.includes(getUILocale()) ? 'rtl' : null;
   categoriesLoaded; /* make sure to import the file, so that that categories load */
 

--- a/app/frontend/Settings/Window/MainContent.svelte
+++ b/app/frontend/Settings/Window/MainContent.svelte
@@ -1,7 +1,7 @@
 <Scroll>
   <vbox flex class="settings-content">
-    {#if categoryDebounced?.windowContent}
-      <svelte:component this={categoryDebounced.windowContent} account={$selectedAccount} />
+    {#if category?.windowContent}
+      <svelte:component this={category.windowContent} account={$selectedAccount} />
     {/if}
   </vbox>
 </Scroll>
@@ -10,18 +10,8 @@
   import type { SettingsCategory } from "../SettingsCategory";
   import { selectedAccount } from "./selected";
   import Scroll from "../../Shared/Scroll.svelte";
-  import debounce from "lodash/debounce";
 
   export let category: SettingsCategory;
-
-  // HACK to work around Svelte bug: Some vars in components are temporarily undefined
-  // This caused: Settings | IMAP account | Server deletes password #777
-  let categoryDebounced: SettingsCategory;
-  const selectCategoryDebounced = debounce(selectCategory, 1);
-  $: category, selectCategoryDebounced();
-  function selectCategory() {
-    categoryDebounced = category;
-  }
 </script>
 
 <style>


### PR DESCRIPTION
- We needed to debounce setting `<svelte:component this={component } />` in Svelte 4 because it would emit an update with `undefined` and that would get read or written
- Without this change it doesn't break but it might just be a few milliseconds slower
- Settings: MainContent: Revert fix for #777
- MainWindow: Revert #605