### PR TITLE
Shared: Editor: Don't allow space before and after the special symbol for Bold, Italic, Strike #1226

### DIFF
--- a/app/frontend/Shared/Editor/HTMLEditor.svelte
+++ b/app/frontend/Shared/Editor/HTMLEditor.svelte
@@ -39,7 +39,12 @@
     editor = new Editor({
       element: rootEl,
       extensions: [
-        StarterKit,
+        // Disable some extensions because you cannot override the default
+        // input/mark rules
+        StarterKit.configure({
+          bold: false,
+          italic: false,
+        }),
         LinkFeature,
         CodeWordFeature,
         SplitBlockquote,

--- a/app/frontend/Shared/Editor/HTMLEditor.svelte
+++ b/app/frontend/Shared/Editor/HTMLEditor.svelte
@@ -10,7 +10,7 @@
   import ImageResize from 'tiptap-extension-resize-image';
   import { SplitBlockquote } from './SplitBlockquote';
   import { Footer } from './Footer';
-  import { BoldStar, ItalicSlash } from './StdConventions';
+  import { BoldStar, ItalicSlash, StrikeDoubleTidle } from './StdConventions';
   import { ParagraphNewLine } from './ParagraphNewLine';
   import { TabIndent } from './TabIndent';
   // import CodeBlockLowlightFeature from '@tiptap/extension-code-block-lowlight';
@@ -44,6 +44,7 @@
         StarterKit.configure({
           bold: false,
           italic: false,
+          strike: false,
         }),
         LinkFeature,
         CodeWordFeature,
@@ -58,6 +59,7 @@
         }),
         BoldStar,
         ItalicSlash,
+        StrikeDoubleTidle,
         ParagraphNewLine,
         TabIndent,
         // CodeBlockLowlightFeature.configure({

--- a/app/frontend/Shared/Editor/StdConventions.ts
+++ b/app/frontend/Shared/Editor/StdConventions.ts
@@ -1,6 +1,7 @@
 import { markInputRule, markPasteRule } from '@tiptap/core';
 import { Bold } from '@tiptap/extension-bold';
 import { Italic } from '@tiptap/extension-italic';
+import { Strike } from '@tiptap/extension-strike';
 
 export const starInputRegex = /(?:^|\s)((?:\*)((?:\S(?:[^*]*\S)?))(?:\*))$/
 export const starPasteRegex = /(?:^|\s)((?:\*)((?:\S(?:[^*]*\S)?))(?:\*))/g
@@ -42,6 +43,28 @@ export const ItalicSlash = Italic.extend({
     return [
       markPasteRule({
         find: slashPasteRegex,
+        type: this.type,
+      }),
+    ]
+  },
+});
+
+const doubleTildeInputRegex = /(?:^|\s)((?:~~)((?:\S(?:(?:(?!~~).)*\S)?))(?:~~))$/
+const doubleTildePasteRegex = /(?:^|\s)((?:~~)((?:\S(?:(?:(?!~~).)*\S)?))(?:~~))/g
+
+export const StrikeDoubleTidle = Strike.extend({
+  addInputRules() {
+    return [
+      markInputRule({
+        find: doubleTildeInputRegex,
+        type: this.type,
+      }),
+    ]
+  },
+  addPasteRules() {
+    return [
+      markPasteRule({
+        find: doubleTildePasteRegex,
         type: this.type,
       }),
     ]

--- a/app/frontend/Shared/Editor/StdConventions.ts
+++ b/app/frontend/Shared/Editor/StdConventions.ts
@@ -2,8 +2,8 @@ import { markInputRule, markPasteRule } from '@tiptap/core';
 import { Bold } from '@tiptap/extension-bold';
 import { Italic } from '@tiptap/extension-italic';
 
-export const starInputRegex = /(?:^|\s)((?:\*)((?:[^*]+))(?:\*))$/
-export const starPasteRegex = /(?:^|\s)((?:\*)((?:[^*]+))(?:\*))/g
+export const starInputRegex = /(?:^|\s)((?:\*(?:\S+(?:\s+\S+)*)\*))$/
+export const starPasteRegex = /(?:^|\s)((?:\*(?:\S+(?:\s+\S+)*)\*))/g
 
 /** Makes `*abc*` **bold** instead of _italic_ */
 export const BoldStar = Bold.extend({
@@ -25,8 +25,8 @@ export const BoldStar = Bold.extend({
   },
 });
 
-export const slashInputRegex = /(?:^|\s)((?:\/)((?:[^*]+))(?:\/))$/
-export const slashPasteRegex = /(?:^|\s)((?:\/)((?:[^*]+))(?:\/))/g
+export const slashInputRegex = /(?:^|\s)((?:\/(?:\S+(?:\s+\S+)*)\/))$/
+export const slashPasteRegex = /(?:^|\s)((?:\/(?:\S+(?:\s+\S+)*)\/))/g
 
 /** Makes `/abc/` _italic_ */
 export const ItalicSlash = Italic.extend({

--- a/app/frontend/Shared/Editor/StdConventions.ts
+++ b/app/frontend/Shared/Editor/StdConventions.ts
@@ -3,8 +3,8 @@ import { Bold } from '@tiptap/extension-bold';
 import { Italic } from '@tiptap/extension-italic';
 import { Strike } from '@tiptap/extension-strike';
 
-export const starInputRegex = /(?:^|\s)((?:\*)((?:\S(?:[^*]*\S)?))(?:\*))$/
-export const starPasteRegex = /(?:^|\s)((?:\*)((?:\S(?:[^*]*\S)?))(?:\*))/g
+export const starInputRegex = /(?:^|\s)((?:\*)((?:\p{Letter}(?:[^*]*\p{Letter})?))(?:\*))$/u
+export const starPasteRegex = /(?:^|\s)((?:\*)((?:\p{Letter}(?:[^*]*\p{Letter})?))(?:\*))/gu
 
 /** Makes `*abc*` **bold** instead of _italic_ */
 export const BoldStar = Bold.extend({
@@ -26,8 +26,8 @@ export const BoldStar = Bold.extend({
   },
 });
 
-export const slashInputRegex = /(?:^|\s)((?:\/)((?:\S(?:[^\/]*\S)?))(?:\/))$/
-export const slashPasteRegex = /(?:^|\s)((?:\/)((?:\S(?:[^\/]*\S)?))(?:\/))/g
+export const slashInputRegex = /(?:^|\s)((?:\/)((?:\p{Letter}(?:[^\/]*\p{Letter})?))(?:\/))$/u
+export const slashPasteRegex = /(?:^|\s)((?:\/)((?:\p{Letter}(?:[^\/]*\p{Letter})?))(?:\/))/gu
 
 /** Makes `/abc/` _italic_ */
 export const ItalicSlash = Italic.extend({
@@ -49,8 +49,8 @@ export const ItalicSlash = Italic.extend({
   },
 });
 
-const doubleTildeInputRegex = /(?:^|\s)((?:~~)((?:\S(?:(?:(?!~~).)*\S)?))(?:~~))$/
-const doubleTildePasteRegex = /(?:^|\s)((?:~~)((?:\S(?:(?:(?!~~).)*\S)?))(?:~~))/g
+const doubleTildeInputRegex = /(?:^|\s)((?:~~)((?:\p{Letter}(?:(?:(?!~~).)*\p{Letter})?))(?:~~))$/u
+const doubleTildePasteRegex = /(?:^|\s)((?:~~)((?:\p{Letter}(?:(?:(?!~~).)*\p{Letter})?))(?:~~))/gu
 
 /** Makes `~~abc~~` ~~strike~~ */
 export const StrikeDoubleTidle = Strike.extend({

--- a/app/frontend/Shared/Editor/StdConventions.ts
+++ b/app/frontend/Shared/Editor/StdConventions.ts
@@ -2,8 +2,8 @@ import { markInputRule, markPasteRule } from '@tiptap/core';
 import { Bold } from '@tiptap/extension-bold';
 import { Italic } from '@tiptap/extension-italic';
 
-export const starInputRegex = /(?:^|\s)((?:\*(?:\S+(?:\s+\S+)*)\*))$/
-export const starPasteRegex = /(?:^|\s)((?:\*(?:\S+(?:\s+\S+)*)\*))/g
+export const starInputRegex = /(?:^|\s)((?:\*)((?:\S(?:[^*]*\S)?))(?:\*))$/
+export const starPasteRegex = /(?:^|\s)((?:\*)((?:\S(?:[^*]*\S)?))(?:\*))/g
 
 /** Makes `*abc*` **bold** instead of _italic_ */
 export const BoldStar = Bold.extend({
@@ -25,8 +25,8 @@ export const BoldStar = Bold.extend({
   },
 });
 
-export const slashInputRegex = /(?:^|\s)((?:\/(?:\S+(?:\s+\S+)*)\/))$/
-export const slashPasteRegex = /(?:^|\s)((?:\/(?:\S+(?:\s+\S+)*)\/))/g
+export const slashInputRegex = /(?:^|\s)((?:\/)((?:\S(?:[^*]*\S)?))(?:\/))$/
+export const slashPasteRegex = /(?:^|\s)((?:\/)((?:\S(?:[^*]*\S)?))(?:\/))/g
 
 /** Makes `/abc/` _italic_ */
 export const ItalicSlash = Italic.extend({

--- a/app/frontend/Shared/Editor/StdConventions.ts
+++ b/app/frontend/Shared/Editor/StdConventions.ts
@@ -3,8 +3,8 @@ import { Bold } from '@tiptap/extension-bold';
 import { Italic } from '@tiptap/extension-italic';
 import { Strike } from '@tiptap/extension-strike';
 
-export const starInputRegex = /(?:^|\s)((?:\*)((?:\p{Letter}(?:[^*]*\p{Letter})?))(?:\*))$/u
-export const starPasteRegex = /(?:^|\s)((?:\*)((?:\p{Letter}(?:[^*]*\p{Letter})?))(?:\*))/gu
+export const starInputRegex = /(?:^|\s)((?:\*)((?:\p{Letter}(?:[^*\n]*\p{Letter})?))(?:\*))$/u
+export const starPasteRegex = /(?:^|\s)((?:\*)((?:\p{Letter}(?:[^*\n]*\p{Letter})?))(?:\*))/gu
 
 /** Makes `*abc*` **bold** instead of _italic_ */
 export const BoldStar = Bold.extend({
@@ -26,8 +26,8 @@ export const BoldStar = Bold.extend({
   },
 });
 
-export const slashInputRegex = /(?:^|\s)((?:\/)((?:\p{Letter}(?:[^\/]*\p{Letter})?))(?:\/))$/u
-export const slashPasteRegex = /(?:^|\s)((?:\/)((?:\p{Letter}(?:[^\/]*\p{Letter})?))(?:\/))/gu
+export const slashInputRegex = /(?:^|\s)((?:\/)((?:\p{Letter}(?:[^\/\n]*\p{Letter})?))(?:\/))$/u
+export const slashPasteRegex = /(?:^|\s)((?:\/)((?:\p{Letter}(?:[^\/\n]*\p{Letter})?))(?:\/))/gu
 
 /** Makes `/abc/` _italic_ */
 export const ItalicSlash = Italic.extend({
@@ -49,8 +49,8 @@ export const ItalicSlash = Italic.extend({
   },
 });
 
-const doubleTildeInputRegex = /(?:^|\s)((?:~~)((?:\p{Letter}(?:(?:(?!~~).)*\p{Letter})?))(?:~~))$/u
-const doubleTildePasteRegex = /(?:^|\s)((?:~~)((?:\p{Letter}(?:(?:(?!~~).)*\p{Letter})?))(?:~~))/gu
+const doubleTildeInputRegex = /(?:^|\s)((?:~~)((?:\p{Letter}(?:(?:(?!~~)[^\n])*\p{Letter})?))(?:~~))$/u
+const doubleTildePasteRegex = /(?:^|\s)((?:~~)((?:\p{Letter}(?:(?:(?!~~)[^\n])*\p{Letter})?))(?:~~))/gu
 
 /** Makes `~~abc~~` ~~strike~~ */
 export const StrikeDoubleTidle = Strike.extend({

--- a/app/frontend/Shared/Editor/StdConventions.ts
+++ b/app/frontend/Shared/Editor/StdConventions.ts
@@ -52,6 +52,7 @@ export const ItalicSlash = Italic.extend({
 const doubleTildeInputRegex = /(?:^|\s)((?:~~)((?:\S(?:(?:(?!~~).)*\S)?))(?:~~))$/
 const doubleTildePasteRegex = /(?:^|\s)((?:~~)((?:\S(?:(?:(?!~~).)*\S)?))(?:~~))/g
 
+/** Makes `~~abc~~` ~~strike~~ */
 export const StrikeDoubleTidle = Strike.extend({
   addInputRules() {
     return [

--- a/app/frontend/Shared/Editor/StdConventions.ts
+++ b/app/frontend/Shared/Editor/StdConventions.ts
@@ -26,8 +26,8 @@ export const BoldStar = Bold.extend({
   },
 });
 
-export const slashInputRegex = /(?:^|\s)((?:\/)((?:\S(?:[^*]*\S)?))(?:\/))$/
-export const slashPasteRegex = /(?:^|\s)((?:\/)((?:\S(?:[^*]*\S)?))(?:\/))/g
+export const slashInputRegex = /(?:^|\s)((?:\/)((?:\S(?:[^\/]*\S)?))(?:\/))$/
+export const slashPasteRegex = /(?:^|\s)((?:\/)((?:\S(?:[^\/]*\S)?))(?:\/))/g
 
 /** Makes `/abc/` _italic_ */
 export const ItalicSlash = Italic.extend({


### PR DESCRIPTION
- Disable the default extension because adding a rule does not override existing rules
- Make sure there's no space before and after the special symbol for Bold, Italic and Strike

## How it works

### Bold

1. `*bold*` renders **bold**
2. `* bold *` renders * bold *
3. `*bo ld*` renders **bo ld**


### Italic

1. `/italic/` renders _italic_
2. `* italic *` renders / italic /
3. `/ita lic/` renders _ita lic_

### Strike

1. `~~strike~~` renders ~~strike~~
2. `~~ strike ~~` renders ~~ strike ~~
3. `~~stri ke~~` renders ~~stri ke~~
4. `~~stri~ke~~` renders ~~stri~ke~~