### PR TITLE
Calendar: DurationSelector, DurationUnit: Use function bindings #1229

### DIFF
--- a/app/frontend/Calendar/EditEvent/DurationSelector.svelte
+++ b/app/frontend/Calendar/EditEvent/DurationSelector.svelte
@@ -1,6 +1,5 @@
 <select
-  on:change={event => adaptAllDays(event.target.value)}
-  bind:value={durationInSeconds}><!-- `on:change` must be before `bind:value` in the code, to get the value before the `Event.duration` setter adapts it -->
+  bind:value={getDurationInSeconds, adaptAllDays}><!-- `on:change` must be before `bind:value` in the code, to get the value before the `Event.duration` setter adapts it -->
   {#if allDay}
     <option value={1 * k1HourS}>{$plural(1, { one: 'hour', other: 'hours' })}</option>
     {#each kDayOptions as day}
@@ -30,14 +29,18 @@
   /** in only */
   export let allDay = false;
 
+  function getDurationInSeconds() {
+    return durationInSeconds;
+  }
+
   function adaptAllDays(newValue: number) {
     console.log("adapt", newValue, durationInSeconds);
     if (newValue < k1DayS) {
       dispatchEvent("setAllDay", false);
     } else if (kDayOptions.includes(newValue / k1DayS)) {
       dispatchEvent("setAllDay", true);
-      durationInSeconds = newValue;
     }
+    durationInSeconds = newValue;
   }
 </script>
 

--- a/app/frontend/Calendar/EditEvent/DurationUnit.svelte
+++ b/app/frontend/Calendar/EditEvent/DurationUnit.svelte
@@ -1,5 +1,4 @@
-<select id="duration-unit" bind:value={unitInSeconds} {disabled}
-  on:change={unitChanged}>
+<select id="duration-unit" bind:value={getUnitInSeconds, unitChanged} {disabled}>
   {#if !allDay}
     <option value={k1MinuteS}>{$plural(durationInUnit, { one: 'minute', other: 'minutes' })}</option>
   {/if}
@@ -28,7 +27,12 @@
     durationInSeconds = durationInUnit * unitInSeconds;
   }
 
-  function unitChanged() {
+  function getUnitInSeconds() {
+    return unitInSeconds;
+  }
+
+  function unitChanged(value: number) {
+    unitInSeconds = value;
     adaptAllDays();
     durationInSeconds = durationInUnit * unitInSeconds;
   }


### PR DESCRIPTION
- Use [Function-bindings](https://svelte.dev/docs/svelte/bind#Function-bindings) to emit event before changing the value
- The on:change was removed because it causes one extra update with same value because it runs independently (1 for on:change, bind:value), in Svelte 4 updates with same values and in the same component are batched and that's other problem

What happens:

1. `adaptAllDays()` is called and the value is still the same `1hour`
2. The parent receives the event and updates the `Event` object
3. The `Event` object is updated and `Event.duration` with the old value is written back to the component, <- this is an extra update
4. `bind:value` writes back to the `Event.duration`