### PR TITLE
Contacts: PersonMenu: Select the correct person during and after delete #1228

### DIFF
--- a/app/frontend/Contacts/PersonPage/PersonMenu.svelte
+++ b/app/frontend/Contacts/PersonPage/PersonMenu.svelte
@@ -21,13 +21,15 @@
   export let person: Person;
 
   async function deleteIt() {
+    let toDelete = person;
     if (person == $selectedPerson) {
-      $selectedPerson = getNext(person.addressbook?.persons, person);
+      let next = getNext(person.addressbook?.persons, person);
+      $selectedPerson = next === toDelete ? null : next;
       if (appGlobal.isMobile) {
         goTo(URLPart`/contacts/person/${person.id}/edit`, { person });
       }
     }
 
-    await person.deleteIt();
+    await toDelete.deleteIt();
   }
 </script>

--- a/app/frontend/Contacts/PersonPage/PersonMenu.svelte
+++ b/app/frontend/Contacts/PersonPage/PersonMenu.svelte
@@ -22,9 +22,8 @@
 
   async function deleteIt() {
     let toDelete = person;
-    if (person == $selectedPerson) {
-      let next = getNext(person.addressbook?.persons, person);
-      $selectedPerson = next === toDelete ? null : next;
+    if (toDelete == $selectedPerson) {
+      $selectedPerson = getNext(toDelete.addressbook?.persons, toDelete);
       if (appGlobal.isMobile) {
         if ($selectedPerson) {
           goTo(URLPart`/contacts/person/${$selectedPerson.id}/edit`, { person: $selectedPerson });

--- a/app/frontend/Contacts/PersonPage/PersonMenu.svelte
+++ b/app/frontend/Contacts/PersonPage/PersonMenu.svelte
@@ -26,7 +26,11 @@
       let next = getNext(person.addressbook?.persons, person);
       $selectedPerson = next === toDelete ? null : next;
       if (appGlobal.isMobile) {
-        goTo(URLPart`/contacts/person/${person.id}/edit`, { person });
+        if ($selectedPerson) {
+          goTo(URLPart`/contacts/person/${$selectedPerson.id}/edit`, { person: $selectedPerson });
+        } else {
+          goTo(URLPart`/contacts`, {});
+        }
       }
     }
 


### PR DESCRIPTION
- The person variable changed while the delete was not complete
- The fix is to save the reference to the person we're going to delete and use it throughout
- The other problem was that next might be the person we're going to delete so we should not select that as next
- On mobile we need to navigate back to main Contacts screen if there's no other contacts