### PR TITLE
Collections: getNext() try all options first and make sure it's not the same object #1232

### DIFF
--- a/app/logic/util/collections.ts
+++ b/app/logic/util/collections.ts
@@ -34,10 +34,9 @@ export function getNext<T>(list: ArrayColl<T>, curObject: T): T | null {
     return null;
   }
   let position = list.indexOf(curObject);
-  let next = list.getIndex(position + 1)
-    ?? list.last
-    ?? list.first;
-  return next === curObject ? null : next;
+  let next = [list.getIndex(position + 1), list.last, list.first]
+    .find(item => !!item && item !== curObject);
+  return next ?? null;
 }
 
 /** Creates an `ArrayColl` for a JS array, populates it with the contents,

--- a/app/logic/util/collections.ts
+++ b/app/logic/util/collections.ts
@@ -34,7 +34,9 @@ export function getNext<T>(list: ArrayColl<T>, curObject: T): T | null {
     return null;
   }
   let position = list.indexOf(curObject);
-  return list.getIndex(position + 1) ?? list.getIndex(position - 1);
+  return list.getIndex(position + 1)
+    ?? list.getIndex(position - 1)
+    ?? null;
 }
 
 /** Creates an `ArrayColl` for a JS array, populates it with the contents,

--- a/app/logic/util/collections.ts
+++ b/app/logic/util/collections.ts
@@ -34,9 +34,10 @@ export function getNext<T>(list: ArrayColl<T>, curObject: T): T | null {
     return null;
   }
   let position = list.indexOf(curObject);
-  return list.getIndex(position + 1)
+  let next = list.getIndex(position + 1)
     ?? list.last
-    ?? null;
+    ?? list.first;
+  return next === curObject ? null : next;
 }
 
 /** Creates an `ArrayColl` for a JS array, populates it with the contents,

--- a/app/logic/util/collections.ts
+++ b/app/logic/util/collections.ts
@@ -34,9 +34,7 @@ export function getNext<T>(list: ArrayColl<T>, curObject: T): T | null {
     return null;
   }
   let position = list.indexOf(curObject);
-  let next = [list.getIndex(position + 1), list.last, list.first]
-    .find(item => !!item && item !== curObject);
-  return next ?? null;
+  return list.getIndex(position + 1) ?? list.getIndex(position - 1);
 }
 
 /** Creates an `ArrayColl` for a JS array, populates it with the contents,


### PR DESCRIPTION
-  `getNext()`: Try all options first and make sure it's not the same object before null is returned
- We need to find the first option that's that same object
- list.last ?? list.first and then the check if the it is same object would return null even though there's a first object. Because list.last is not null and the next check sets it to null because it's the same object.