### PR TITLE
Settings: Use goTo() instead of setting  directly #1241

### DIFF
--- a/app/frontend/Settings/AccountGeneral.svelte
+++ b/app/frontend/Settings/AccountGeneral.svelte
@@ -69,9 +69,8 @@
 <script lang="ts">
   import type { Account } from "../../logic/Abstract/Account";
   import { accountSettings, settingsCategories } from "./SettingsCategory";
-  import { selectedCategory } from "./Window/selected";
   import { selectedAccount as selectedMailAccount, selectedFolder, selectedMessage, selectedMessages } from "../Mail/Selected";
-  import { openSettingsCategoryForAccount } from "./Window/CategoriesUtils";
+  import { openSettingsCategory, openSettingsCategoryForAccount } from "./Window/CategoriesUtils";
   import { accountColors } from "../../logic/Abstract/Workspace";
   import { MailAccount } from "../../logic/Mail/MailAccount";
   import { ChatAccount } from "../../logic/Chat/ChatAccount";
@@ -107,7 +106,7 @@
     if (account.mainAccount) {
       openSettingsCategoryForAccount(account.mainAccount);
     } else {
-      $selectedCategory = settingsCategories.first;
+      openSettingsCategory(settingsCategories.first);
     }
     if ($selectedMailAccount == account) {
       $selectedMailAccount = appGlobal.emailAccounts.first;

--- a/app/frontend/Settings/Global/WorkspaceAccountMenu.svelte
+++ b/app/frontend/Settings/Global/WorkspaceAccountMenu.svelte
@@ -30,8 +30,7 @@
 <script lang="ts">
   import { Workspace } from "../../../logic/Abstract/Workspace";
   import { Account } from "../../../logic/Abstract/Account";
-  import { accountSettings } from "../SettingsCategory";
-  import { selectedCategory, selectedAccount } from "../Window/selected";
+  import { openSettingsCategoryForAccount } from "../Window/CategoriesUtils";
   import { appGlobal } from "../../../logic/app";
   import { changedWorkspace, selectedWorkspace } from "../../MainWindow/Selected";
   import ButtonMenu from "../../Shared/Menu/ButtonMenu.svelte";
@@ -48,8 +47,7 @@
   let workspaces = appGlobal.workspaces;
 
   function onOpenAccount() {
-    $selectedAccount = account;
-    $selectedCategory = accountSettings.find(cat => account instanceof cat.type && cat.isMain);
+    openSettingsCategoryForAccount(account);
   }
   async function onMove(otherWorkspace: Workspace) {
     account.workspace = otherWorkspace;

--- a/app/frontend/Settings/Global/WorkspaceAccounts.svelte
+++ b/app/frontend/Settings/Global/WorkspaceAccounts.svelte
@@ -33,8 +33,9 @@
 <script lang="ts">
   import { Workspace } from "../../../logic/Abstract/Workspace";
   import { Account } from "../../../logic/Abstract/Account";
-  import { settingsCategories, accountSettings } from "../SettingsCategory";
-  import { selectedCategory, selectedAccount } from "../Window/selected";
+  import { settingsCategories } from "../SettingsCategory";
+  import { selectedCategory } from "../Window/selected";
+  import { openSettingsCategory, openSettingsCategoryForAccount } from "../Window/CategoriesUtils";
   import { SetupMustangApp } from "../../Setup/SetupMustangApp";
   import { openApp } from "../../AppsBar/selectedApp";
   import { settingsMustangApp } from "../Window/SettingsMustangApp";
@@ -56,8 +57,7 @@
   $: accounts = $changedWorkspace && allAccounts.filter(acc => acc.workspace == workspace);
 
   function onOpenAccount(account: Account) {
-    $selectedAccount = account;
-    $selectedCategory = accountSettings.find(cat => account instanceof cat.type && cat.isMain);
+    openSettingsCategoryForAccount(account);
   }
 
   function onNewAccount() {
@@ -74,8 +74,7 @@
       .find(cat => cat.id == "global")
       .subCategories
       .find(cat => cat.id == "global-workspaces");
-    $selectedCategory = workspacesSettings;
-    openApp(settingsMustangApp, {});
+    openSettingsCategory(workspacesSettings);
   }
 </script>
 

--- a/app/frontend/Settings/Global/WorkspaceAccounts.svelte
+++ b/app/frontend/Settings/Global/WorkspaceAccounts.svelte
@@ -34,11 +34,9 @@
   import { Workspace } from "../../../logic/Abstract/Workspace";
   import { Account } from "../../../logic/Abstract/Account";
   import { settingsCategories } from "../SettingsCategory";
-  import { selectedCategory } from "../Window/selected";
-  import { openSettingsCategory, openSettingsCategoryForAccount } from "../Window/CategoriesUtils";
+  import { openSettingsCategory, openSettingsCategoryByID, openSettingsCategoryForAccount } from "../Window/CategoriesUtils";
   import { SetupMustangApp } from "../../Setup/SetupMustangApp";
   import { openApp } from "../../AppsBar/selectedApp";
-  import { settingsMustangApp } from "../Window/SettingsMustangApp";
   import { changedWorkspace } from "../../MainWindow/Selected";
   import WorkspaceAccountMenu from "./WorkspaceAccountMenu.svelte";
   import RoundButton from "../../Shared/RoundButton.svelte";
@@ -70,11 +68,7 @@
   }
 
   function onReOpenThis() {
-    let workspacesSettings = settingsCategories
-      .find(cat => cat.id == "global")
-      .subCategories
-      .find(cat => cat.id == "global-workspaces");
-    openSettingsCategory(workspacesSettings);
+    openSettingsCategoryByID("global-workspaces");
   }
 </script>
 

--- a/app/frontend/Settings/Window/AccountItem.svelte
+++ b/app/frontend/Settings/Window/AccountItem.svelte
@@ -14,6 +14,7 @@
   import { MailAccount } from "../../../logic/Mail/MailAccount";
   import { accountSettings, type SettingsCategory } from "../SettingsCategory";
   import { selectedCategory, selectedAccount } from "./selected";
+  import { getSettingsCategoryForAccount, openSettingsCategoryForAccount } from "./CategoriesUtils";
   import SubCategoriesList from "./SubCategoriesList.svelte";
   import Clickable from "../../Shared/Clickable.svelte";
 
@@ -23,7 +24,7 @@
 
   $: accountSelected = account == $selectedAccount;
   $: itemSelected = account == $selectedAccount && $selectedCategory == mainAccountCategory;
-  $: mainAccountCategory = accountSettings.find(cat => account instanceof cat.type && cat.isMain);
+  $: mainAccountCategory = getSettingsCategoryForAccount(account);
   $: subCategories = accountSettings.filterObservable(cat => account instanceof cat.type && !cat.isMain && showCat(cat, account));
 
   function showCat(category: SettingsCategory, account: Account): boolean {
@@ -34,8 +35,7 @@
   }
 
   function onSelect() {
-    $selectedAccount = account;
-    $selectedCategory = mainAccountCategory;
+    openSettingsCategoryForAccount(account);
   }
 </script>
 

--- a/app/frontend/Settings/Window/CategoriesUtils.ts
+++ b/app/frontend/Settings/Window/CategoriesUtils.ts
@@ -29,23 +29,26 @@ export function getSettingsCategoryForApp(app: MustangApp) {
   return getAllSettingsCategories().find(cat => cat.forApp == app);
 }
 
-export function openSettingsCategoryByID(id: string) {
-  let cat = getSettingsCategoryByID(id);
-  selectedCategory.set(cat);
-  openApp(settingsMustangApp, {});
-}
-
 export function openSettingsCategoryForApp(app: MustangApp) {
-  let cat = getSettingsCategoryForApp(app);
+  openSettingsCategory(getSettingsCategoryForApp(app));
+}
+
+export function openSettingsCategoryByID(id: string) {
+  openSettingsCategory(getSettingsCategoryByID(id));
+}
+
+export function openSettingsCategory(cat: SettingsCategory) {
   selectedCategory.set(cat);
-  // openApp(settingsMustangApp, { category: cat });
   openApp(settingsMustangApp, {});
 }
 
-export function openSettingsCategoryForAccount(account: Account, category = "main") {
-  // let mainCat = getAllSettingsCategories().find(cat => cat.accounts.contains(account));
-  let cat = accountSettings.find(cat => account instanceof cat.type &&
-    cat.id == category || category == "main" && cat.isMain);
+export function getSettingsCategoryForAccount(account: Account, categoryID = "main") {
+  return accountSettings.find(cat => account instanceof cat.type &&
+    cat.id == categoryID || categoryID == "main" && cat.isMain);
+}
+
+export function openSettingsCategoryForAccount(account: Account, categoryID = "main") {
+  let cat = getSettingsCategoryForAccount(account, categoryID);
   assert(cat, "Account not found in settings");
   selectedAccount.set(account);
   selectedCategory.set(cat);

--- a/app/frontend/Settings/Window/CategoryItem.svelte
+++ b/app/frontend/Settings/Window/CategoryItem.svelte
@@ -13,6 +13,7 @@
 <script lang="ts">
   import type { SettingsCategory } from "../SettingsCategory";
   import { selectedCategory, selectedAccount } from "./selected";
+  import { openSettingsCategory } from "./CategoriesUtils";
   import SubCategoriesList from "./SubCategoriesList.svelte";
   import AccountsList from "./AccountsList.svelte";
   import Clickable from "../../Shared/Clickable.svelte";
@@ -28,11 +29,8 @@
     if (appGlobal.isMobile && (category.subCategories.hasItems || category.accounts.hasItems)) {
       isSectionOpen = !isSectionOpen;
     } else {
-      $selectedCategory = category;
+      openSettingsCategory(category);
     }
-    /*if (!category.parent.accounts.contains($selectedAccount)) {
-      $selectedAccount = null;
-    }*/
   }
 </script>
 

--- a/app/frontend/Settings/Window/SettingsApp.svelte
+++ b/app/frontend/Settings/Window/SettingsApp.svelte
@@ -23,6 +23,7 @@
   import { settingsCategories } from "../SettingsCategory";
   import { globalSearchTerm, openApp } from "../../AppsBar/selectedApp";
   import { selectedCategory } from "./selected";
+  import { openSettingsCategory } from "./CategoriesUtils";
   import { mailMustangApp } from "../../Mail/MailMustangApp";
   import SettingsCategoriesPane from "./CategoriesPane.svelte";
   import MainContent from "./MainContent.svelte";
@@ -31,7 +32,6 @@
   import RoundButton from "../../Shared/RoundButton.svelte";
   import CloseIcon from "lucide-svelte/icons/x";
   import { t } from "../../../l10n/l10n";
-  import { openSettingsCategory } from "./CategoriesUtils";
 
   let categories = settingsCategories;
 

--- a/app/frontend/Settings/Window/SettingsApp.svelte
+++ b/app/frontend/Settings/Window/SettingsApp.svelte
@@ -31,6 +31,7 @@
   import RoundButton from "../../Shared/RoundButton.svelte";
   import CloseIcon from "lucide-svelte/icons/x";
   import { t } from "../../../l10n/l10n";
+  import { openSettingsCategory } from "./CategoriesUtils";
 
   let categories = settingsCategories;
 
@@ -38,12 +39,12 @@
   function onSearch(searchTerm: string) {
     for (let cat of categories) {
       if (cat.searchMatchesDirect(searchTerm)) {
-        $selectedCategory = cat;
+        openSettingsCategory(cat);
         return;
       }
       for (let subCat of cat.subCategories) {
         if (subCat.searchMatchesDirect(searchTerm)) {
-          $selectedCategory = subCat;
+          openSettingsCategory(subCat);
           return;
         }
       }


### PR DESCRIPTION
SettingsRoutes.svelte
```
    {params?.category ? $selectedCategory = params.category : null, "" }
    <SettingsApp />
```
If something changed to a settings category using `goTo()` with the `param` set to a category, and then something else changed to another settings category merely by setting `$selectedCategory = `, then the above like would overwrite `$selectedCategory` with the old value from `param`.

The fix is to always use `goTo()` with param.