### PR TITLE
Files: lastModOnServer is null when syncing for the first time #1246

### DIFF
--- a/app/logic/Files/WebDAV/WebDAVFile.ts
+++ b/app/logic/Files/WebDAV/WebDAVFile.ts
@@ -29,9 +29,9 @@ export class WebDAVFile extends File {
     let size = sanitize.integer(stat.size, 0)
     let etag = sanitize.nonemptystring(stat.etag, null);
     let lastMod = sanitize.date(stat.lastmod, new Date());
-    if (this.lastModOnServer.getTime() == this.lastMod.getTime() &&
+    if (this.lastModOnServer?.getTime() == this.lastMod.getTime() &&
         (this.size != size || this.etag != etag ||
-         this.lastModOnServer.getTime() != lastMod.getTime())) {
+         this.lastModOnServer?.getTime() != lastMod.getTime())) {
       this.deleteLocalCache()
         .catch(this.account.errorCallback);
     }
@@ -40,7 +40,7 @@ export class WebDAVFile extends File {
     if (this.lastMod.getTime() != lastMod.getTime()) {
       this.lastMod = lastMod;
     }
-    if (this.lastModOnServer.getTime() != this.lastMod.getTime()) {
+    if (this.lastModOnServer?.getTime() != this.lastMod.getTime()) {
       this.lastModOnServer = new Date(this.lastMod); // Make copy, not same object
     }
     this.serverURL = sanitize.url(new URL(this.path, this.account.url).href, null);


### PR DESCRIPTION
- `NextcloudFile.fromDAV()` is called when the account is setup and at that point the `lastModOnServer` for the file is not set yet
- https://github.com/mustang-im/mustang/blob/b510bf8377168a875fcb2acfef42652db87fe3d8/app/logic/Files/File.ts#L24
- But it should not be null for other functions