### PR TITLE
Files: FilesHeader: Make subDirs and files reactive

### DIFF
--- a/app/frontend/Files/MainPane/FilesHeader.svelte
+++ b/app/frontend/Files/MainPane/FilesHeader.svelte
@@ -76,8 +76,8 @@
 
   export let dir: Directory;
 
-  let subDirs = dir.subDirs;
-  let files = dir.files;
+  $: subDirs = dir.subDirs;
+  $: files = dir.files;
 
   let parentDirs: Directory[] = [];
   $: dir, getParentDirs()


### PR DESCRIPTION
- The files count was not updating, it was stuck on the count of the first loaded directory
- `subDirs` and `files` are subscribed but it was never reassigned to the new `ArrayColl` of the new directory