### PR TITLE
Contacts: Make selectedaddrdssbook reactive for the correct color

### DIFF
--- a/app/frontend/Contacts/AddressbookChanger.svelte
+++ b/app/frontend/Contacts/AddressbookChanger.svelte
@@ -1,5 +1,5 @@
 <AccountDropDown
-  bind:selectedAccount={selectedAddressbook}
+  selectedAccount={selectedAddressbook}
   accounts={addressbooks}
   filterByWorkspace={false}
   icon={selectedAddressbook?.icon ?? AddressbookIcon}
@@ -19,7 +19,7 @@
   export let person: Person;
   export let withLabel = false;
 
-  let selectedAddressbook = person?.addressbook;
+  $: selectedAddressbook = person?.addressbook;
   $: addressbooks = appGlobal.addressbooks.filter(acc => acc.workspace == $selectedWorkspace || !$selectedWorkspace);
 
   async function onChangeAddressbook(newAddressbook: Addressbook) {


### PR DESCRIPTION
- The color of the selectedAddressbook was not being updated
- The selectedAccount is in/out but it's only being used as an in here, so I removed the `bind`.
- The Addressbook is changed using the `onChangeAddressbook` here which changes the `$: ` statement.