### PR TITLE
Only generate a single notification when filling recurrences #1254

### DIFF
--- a/app/logic/Calendar/Event.ts
+++ b/app/logic/Calendar/Event.ts
@@ -750,14 +750,15 @@ export class Event extends Observable {
    *
    * TODO Call this when the user scrolls further than the default fill date.
    */
-  fillRecurrences(seriesEndTime: Date = new Date(Date.now() + 1e11)): Collection<Event> {
+  fillRecurrences(seriesEndTime: Date = new Date(Date.now() + 1e11)) {
     assert(this.recurrenceCase == RecurrenceCase.Master, "Not a recurrence master");
     if (this.instances.hasItems || // cached
         !this.calendar) { // Not for pseudo events in messages
       // TODO Fill more, if seriesEndTime >> last.startTime
-      return this.instances;
+      return;
     }
     let occurrences = this.recurrenceRule.getOccurrencesByDate(seriesEndTime);
+    let instances = [];
     for (let occurrence of occurrences) {
       if (this.exceptions.some(exception => exception.recurrenceStartTime.getTime() == occurrence.getTime())) {
         continue;
@@ -773,9 +774,9 @@ export class Event extends Observable {
       if (this.alarm) {
         instance.alarm = new Date(this.alarm.getTime() + instance.startTime.getTime() - this.startTime.getTime());
       }
-      this.instances.add(instance);
+      instances.push(instance);
     }
-    return this.instances;
+    this.instances.addAll(instances);
   }
 
   /**


### PR DESCRIPTION
- Editing a daily repeating event generates a new recurrence rule which has no end date and so generates hundreds of instances.
- Event's `instances` array notifies once for each instance being added.
- ObservableFilteredCollectionObserver/ArrayColl notifies even when no items are being added.
- Svelte 4 efficiently coalesces multiple notifications, Svelte 5 does not. In fact, Svelte 5 records you doing this, in case it thinks you're causing an infinite loop, which is why it's so slow.

Checking the various collections:
- `ArrayColl` always notifies when no items are being added
- `SetColl` optimises away notifications when there are no changes
- `SortedCollection` always notifies when no items are being added
- `SubtractCollection` optimises away notifications when there are no changes
- `TransformedCollection` optimises away notifications when there are no changes
- No collection notifies when no items are being removed

Optimising ArrayColl did not appear to provide a significant benefit, so I have skipped that for now.