### PR TITLE
Contacts: Only change addressBook for unsaved contact #1265

### DIFF
--- a/app/frontend/Contacts/AddressbookChanger.svelte
+++ b/app/frontend/Contacts/AddressbookChanger.svelte
@@ -4,7 +4,7 @@
   filterByWorkspace={false}
   icon={selectedAddressbook?.icon ?? AddressbookIcon}
   {withLabel}
-  on:select={() => catchErrors(() => onChangeAddressbook(selectedAddressbook))}
+  on:select={(ev) => catchErrors(() => onChangeAddressbook(ev.detail as Addressbook))}
   />
 
 <script lang="ts">
@@ -24,6 +24,10 @@
 
   async function onChangeAddressbook(newAddressbook: Addressbook) {
     console.log("Selected addressbook", newAddressbook?.name, "old", person?.addressbook?.name);
-    person.moveToAddressbook(newAddressbook);
+    if (!person.dbID) {
+      person.addressbook = newAddressbook;
+    } else {
+      person.moveToAddressbook(newAddressbook);
+    }
   }
 </script>


### PR DESCRIPTION
- Kind of a regression from #1255 because we weren't getting the latest address book to change to, `$: selectedAddress` is already assigned before onChangeAddressbook and is updated after onChangeAddressbook which never happens in this case
- `person.moveToAddressbook(newAddressbook)` causes the UI to create another contact because it cannot remove an unsaved contact