### PR TITLE
Fix typo in 0066ebf

### DIFF
--- a/app/logic/Calendar/Calendar.ts
+++ b/app/logic/Calendar/Calendar.ts
@@ -118,7 +118,7 @@ export class Calendar extends Account {
   get meetAccount(): MeetAccount | null {
     let meet = appGlobal.meetAccounts.find(cal => cal.id == this.meetAccountID);
     if (!meet) {
-      this.mainAccount = meet = this.meetAccountsAvailable.first;
+      this.meetAccount = meet = this.meetAccountsAvailable.first;
     }
     return meet;
 


### PR DESCRIPTION
Opening calendar accounts in settings was detaching them from their main accounts. Oops...