### PR TITLE
FastList: disconnect instead to unobserve from all items #1274

### DIFF
--- a/app/frontend/Shared/FastList.svelte
+++ b/app/frontend/Shared/FastList.svelte
@@ -178,7 +178,7 @@
     const updateSizeThrottled = throttle(updateSize, 30);
     const resizeObserver = new ResizeObserver(updateSizeThrottled);
     resizeObserver.observe(listE);
-    return () => resizeObserver.unobserve(listE);
+    return () => resizeObserver.disconnect();
   });
 
   function onKey(event: KeyboardEvent) {


### PR DESCRIPTION
- FastList: disconnect instead to unobserve from all items of the instance even if the reference is lost
- Sometimes the variables are cleared before the component is destroyed which makes `unobserve(listE)` undefined
- use `disconnect()` because it doesn't require a reference and it unobserves all items of the ResizeObserver instance to avoid leaks
- https://developer.mozilla.org/en-US/docs/Web/API/ResizeObserver/disconnect