### PR TITLE
Calendar: Outgoing Invitation: Reset recipients to not responded #1272

### DIFF
--- a/app/frontend/Calendar/EditEvent/ParticipantConfirmIcon.svelte
+++ b/app/frontend/Calendar/EditEvent/ParticipantConfirmIcon.svelte
@@ -3,7 +3,7 @@
   class:declined={$participant.response == InvitationResponse.Decline}
   class:tentative={$participant.response == InvitationResponse.Tentative}
   class:organizer={$participant.response == InvitationResponse.Organizer}
-  class:unknown={$participant.response == InvitationResponse.Unknown}
+  class:noresponse={$participant.response == InvitationResponse.NoResponseReceived}
   title={$participant.responseLabel}
   >
   {#if $participant.response == InvitationResponse.Organizer}
@@ -15,7 +15,7 @@
   {:else if $participant.response == InvitationResponse.Tentative}
     <TentativeIcon {size} />
   {:else}
-    <!--<UnknownIcon {size} title={$t`No response yet`} />-->
+    <!--<NoResponseIcon {size} title={$t`No response yet`} />-->
   {/if}
 </hbox>
 

--- a/app/frontend/Calendar/EditEvent/ParticipantsBox.svelte
+++ b/app/frontend/Calendar/EditEvent/ParticipantsBox.svelte
@@ -56,7 +56,7 @@
   export let event: Event;
 
   function onAddPerson(person: PersonUID) {
-    let participant = new Participant(person.emailAddress, person.name, InvitationResponse.Unknown);
+    let participant = new Participant(person.emailAddress, person.name, InvitationResponse.NoResponseReceived);
     event.participants.add(participant);
   }
 </script>

--- a/app/logic/Calendar/Event.ts
+++ b/app/logic/Calendar/Event.ts
@@ -598,6 +598,9 @@ export class Event extends Observable {
     assert(this.calendar, "To save an event, it needs to be in a calendar first");
     assert(this.calendar.storage, "To save an event, the calendar needs to be saved first");
     this.calUID ??= crypto.randomUUID();
+    if (!this.isIncomingMeeting && this.participants.hasItems && this.hasChanged()) {
+      await this.outgoingInvitation.markInvitationsNeeded();
+    }
     await this.calendar.storage.saveEvent(this);
 
     if (this.recurrenceCase == RecurrenceCase.Master) {

--- a/app/logic/Calendar/Invitation/OutgoingInvitation.ts
+++ b/app/logic/Calendar/Invitation/OutgoingInvitation.ts
@@ -109,8 +109,8 @@ export class OutgoingInvitation {
   participantsToNotify(): Collection<Participant> {
     let participants = this.event.participants;
     return this.changesNeedToNotify()
-      ? participants.filterOnce(participant => participant.response != InvitationResponse.Organizer)
-      : participants.subtract(this.event.unedited.participants);
+      ? participants.filterOnce(participant => participant.response != InvitationResponse.Organizer) // everybody
+      : participants.subtract(this.event.unedited.participants); // newly added participants
   }
 
   /**

--- a/app/logic/Calendar/Invitation/OutgoingInvitation.ts
+++ b/app/logic/Calendar/Invitation/OutgoingInvitation.ts
@@ -28,6 +28,7 @@ export class OutgoingInvitation {
   }
 
   async sendInvitationsTo(participants: Collection<Participant>) {
+    this.markInvitationsNeeded();
     let sendTo = participants.filterOnce(participant => participant.isInvitee);
     if (sendTo.isEmpty) {
       return;
@@ -109,7 +110,7 @@ export class OutgoingInvitation {
   participantsToNotify(): Collection<Participant> {
     let participants = this.event.participants;
     return this.changesNeedToNotify()
-      ? participants.filterOnce(participant => participant.response != InvitationResponse.Organizer) // everybody
+      ? participants.filterOnce(participant => participant.response != InvitationResponse.Organizer) // all invitees
       : participants.subtract(this.event.unedited.participants); // newly added participants
   }
 

--- a/app/logic/Calendar/Invitation/OutgoingInvitation.ts
+++ b/app/logic/Calendar/Invitation/OutgoingInvitation.ts
@@ -28,9 +28,6 @@ export class OutgoingInvitation {
   }
 
   async sendInvitationsTo(participants: Collection<Participant>) {
-    for (let participant of participants) {
-      participant.response ||= InvitationResponse.NoResponseReceived;
-    }
     let sendTo = participants.filterOnce(participant => participant.isInvitee);
     if (sendTo.isEmpty) {
       return;
@@ -56,10 +53,7 @@ export class OutgoingInvitation {
     let removed = unedited.participants.subtract(event.participants);
     // Use the original event when sending cancellations
     await unedited.outgoingInvitation.sendCancellationsTo(removed);
-    let notify = this.changesNeedToNotify()
-      ? event.participants
-      : event.participants.subtract(unedited.participants);
-    await this.sendInvitationsTo(notify);
+    await this.sendInvitationsTo(this.participantsToNotify());
   }
 
   async sendCancellations() {
@@ -96,6 +90,27 @@ export class OutgoingInvitation {
       email.html = this.event.descriptionHTML;
     }
     await email.folder.account.send(email);
+  }
+
+  /**
+   * Mark anyone we're notifying as no response recieved.
+   * This always applies for new recipients.
+   */
+  markInvitationsNeeded() {
+    for (let participant of this.participantsToNotify()) {
+      participant.response = InvitationResponse.NoResponseReceived;
+    }
+  }
+
+  /**
+   * Get the participants we need to notify about this change.
+   * Always includes newly added participnts.
+   */
+  participantsToNotify(): Collection<Participant> {
+    let participants = this.event.participants;
+    return this.changesNeedToNotify()
+      ? participants.filterOnce(participant => participant.response != InvitationResponse.Organizer)
+      : participants.subtract(this.event.unedited.participants);
   }
 
   /**


### PR DESCRIPTION
Changing e.g. the event alarm doesn't send any messages.
Changing the event participants only sends messages to those participants.
Major changes send messages to all participants.
This change makes it so that the participation status is reset to no response received only for those participants.
This is done in `event.saveLocally` because it needs to be saved.
`sendInvitationsTo` no longer needs to mark new participants as no response received.
I also refactored out some code that was shared with `sendInvitationsTo`.

This PR does not handle the case where you receive an updated invitation.