### PR TITLE
Calendar: Incoming Invitation: Reset participation to not responded #1272

### DIFF
--- a/app/logic/Calendar/ActiveSync/ActiveSyncIncomingInvitation.ts
+++ b/app/logic/Calendar/ActiveSync/ActiveSyncIncomingInvitation.ts
@@ -34,14 +34,17 @@ export class ActiveSyncIncomingInvitation extends IncomingInvitation {
     await this.calendar.listEvents(); // Exchange will have created a calendar item if there wasn't one already
   }
 
+  async updateInvitation() {
+    await this.updateFromInvitationMessage();
+  }
   async updateCancelled() {
-    await this.updateFromOtherInvitationMessage();
+    await this.updateFromInvitationMessage();
   }
   async updateParticipantReply() {
-    await this.updateFromOtherInvitationMessage();
+    await this.updateFromInvitationMessage();
   }
   /** Exchange server auto-processes these */
-  async updateFromOtherInvitationMessage() {
+  async updateFromInvitationMessage() {
     await this.calendar.listEvents();
   }
 }

--- a/app/logic/Calendar/EWS/EWSIncomingInvitation.ts
+++ b/app/logic/Calendar/EWS/EWSIncomingInvitation.ts
@@ -24,14 +24,17 @@ export class EWSIncomingInvitation extends IncomingInvitation {
     await this.calendar.listEvents(); // Exchange will have created a calendar item if there wasn't one already
   }
 
+  async updateInvitation() {
+    await this.updateFromInvitationMessage();
+  }
   async updateCancelled() {
-    await this.updateFromOtherInvitationMessage();
+    await this.updateFromInvitationMessage();
   }
   async updateParticipantReply() {
-    await this.updateFromOtherInvitationMessage();
+    await this.updateFromInvitationMessage();
   }
   /** Exchange server auto-processes these */
-  async updateFromOtherInvitationMessage() {
+  async updateFromInvitationMessage() {
     await this.calendar.listEvents();
   }
 }

--- a/app/logic/Calendar/ICal/ICalEMailProcessor.ts
+++ b/app/logic/Calendar/ICal/ICalEMailProcessor.ts
@@ -27,13 +27,10 @@ export class ICalEMailProcessor extends EMailProcessor {
     }
     email.event = event;
 
-    if (email.invitationMessage == InvitationMessage.ParticipantReply ||
-        email.invitationMessage == InvitationMessage.CancelledEvent) {
-      let foundEventInCalendars = email.folder.account.calendarsAvailable.filterOnce(cal => cal.hasMatchingEvent(event));
-      for (let calendar of foundEventInCalendars) {
-        let incomingInvitation = calendar.getIncomingInvitationForEMail(email);
-        await incomingInvitation.updateFromOtherInvitationMessage();
-      }
+    let foundEventInCalendars = email.folder.account.calendarsAvailable.filterOnce(cal => cal.hasMatchingEvent(event));
+    for (let calendar of foundEventInCalendars) {
+      let incomingInvitation = calendar.getIncomingInvitationForEMail(email);
+      await incomingInvitation.updateFromInvitationMessage();
     }
   }
 }

--- a/app/logic/Calendar/ICal/ICalIncomingInvitation.ts
+++ b/app/logic/Calendar/ICal/ICalIncomingInvitation.ts
@@ -32,6 +32,23 @@ export class ICalIncomingInvitation extends IncomingInvitation {
     }
   }
 
+  async updateInvitation() {
+    assert(this.invitationMessage == InvitationMessage.Invitation, "Not an invitation");
+    let event = this.calEvent();
+    if (!event) {
+      // Event is not yet in the user's calendar, nothing to do.
+      return;
+    }
+    let { myParticipant } = ICalIncomingInvitation.participantMe(event, this.message.folder.account);
+    let timestamp = this.event.lastUpdateTime;
+    if (myParticipant &&
+      (!myParticipant.lastUpdateTime || myParticipant.lastUpdateTime < timestamp)) {
+      this.myParticipation = myParticipant.response = InvitationResponse.NoResponseReceived;
+      myParticipant.lastUpdateTime = timestamp;
+      await event.save();
+    }
+  }
+
   static async respondToInvitationFromCalEvent(calEvent: Event, response: InvitationResponseInMessage, mailAccount?: MailAccount) {
     let { identity, myParticipant } = this.participantMe(calEvent, mailAccount);
     let hasChanged = myParticipant.response != response;

--- a/app/logic/Calendar/Invitation/IncomingInvitation.ts
+++ b/app/logic/Calendar/Invitation/IncomingInvitation.ts
@@ -45,6 +45,11 @@ export class IncomingInvitation {
     throw new AbstractFunction();
   }
 
+  /** InvitationEvent: the organiser invited you to a meeting */
+  async updateInvitation() {
+    throw new AbstractFunction();
+  }
+
   /** CancelledEvent: the organiser cancelled an incoming meeting */
   async updateCancelled() {
     assert(this.invitationMessage == InvitationMessage.CancelledEvent, "Not a cancellation");
@@ -78,9 +83,11 @@ export class IncomingInvitation {
     }
   }
 
-  /** Handle CancelledEvent and ParticpantReply */
-  async updateFromOtherInvitationMessage() {
-    if (this.invitationMessage == InvitationMessage.CancelledEvent) {
+  /** Automatic processing when we receive an invitation message */
+  async updateFromInvitationMessage() {
+    if (this.invitationMessage == InvitationMessage.Invitation) {
+      await this.updateInvitation();
+    } else if (this.invitationMessage == InvitationMessage.CancelledEvent) {
       await this.updateCancelled();
     } else if (this.invitationMessage == InvitationMessage.ParticipantReply) {
       await this.updateParticipantReply();

--- a/app/logic/Calendar/JMAP/JMAPIncomingInvitation.ts
+++ b/app/logic/Calendar/JMAP/JMAPIncomingInvitation.ts
@@ -12,13 +12,16 @@ export class JMAPIncomingInvitation extends IncomingInvitation {
     await this.calendar.listEvents(); // Check what the server did
   }
 
+  async updateInvitation() {
+    // Auto-processed by server?
+  }
   async updateCancelled() {
     // Auto-processed by server?
   }
   async updateParticipantReply() {
     // Auto-processed by server?
   }
-  async updateFromOtherInvitationMessage() {
+  async updateFromInvitationMessage() {
     // ??
   }
 }

--- a/app/logic/Calendar/OWA/OWAIncomingInvitation.ts
+++ b/app/logic/Calendar/OWA/OWAIncomingInvitation.ts
@@ -40,14 +40,19 @@ export class OWAIncomingInvitation extends IncomingInvitation {
     }
   }
 
+  async updateInvitation() {
+    if (this.itemID) {
+      await this.updateFromInvitationMessage();
+    }
+  }
   async updateCancelled() {
-    await this.updateFromOtherInvitationMessage();
+    await this.updateFromInvitationMessage();
   }
   async updateParticipantReply() {
-    await this.updateFromOtherInvitationMessage();
+    await this.updateFromInvitationMessage();
   }
   /** Exchange server auto-processes these */
-  async updateFromOtherInvitationMessage() {
+  async updateFromInvitationMessage() {
     assert(this.itemID, "UI should have been disabled");
     await this.calendar.getEvents([this.itemID], new ArrayColl<OWAEvent>());
   }


### PR DESCRIPTION
This makes it so that all incoming iMip messages have automatic processing:
- Requests reset your participation had you already replied to the previous invitation
- Cancellations and replies as before