### PR TITLE
Contacts: Edit persons collection directly #1269

### DIFF
--- a/app/frontend/Contacts/AddressbookChanger.svelte
+++ b/app/frontend/Contacts/AddressbookChanger.svelte
@@ -10,6 +10,7 @@
 <script lang="ts">
   import type { Addressbook } from "../../logic/Contacts/Addressbook";
   import type { Person } from "../../logic/Abstract/Person";
+  import { selectedPerson } from "./Person/Selected";
   import { appGlobal } from "../../logic/app";
   import { selectedWorkspace } from "../MainWindow/Selected";
   import AccountDropDown from "../Shared/AccountDropDown.svelte";
@@ -24,10 +25,16 @@
 
   async function onChangeAddressbook(newAddressbook: Addressbook) {
     console.log("Selected addressbook", newAddressbook?.name, "old", person?.addressbook?.name);
-    if (!person.dbID) {
-      person.addressbook = newAddressbook;
+    let newPerson: Person;
+    if (person.dbID) {
+      newPerson = await person.moveToAddressbook(newAddressbook);
     } else {
-      person.moveToAddressbook(newAddressbook);
+      newPerson = newAddressbook.newPerson();
+      newPerson.copyFrom(person);
+      newPerson.addressbook = newAddressbook;
+      newAddressbook.persons.add(newPerson);
+      person.addressbook.persons.remove(person);
     }
+    $selectedPerson = newPerson;
   }
 </script>

--- a/app/frontend/Contacts/PersonPage/PersonMenu.svelte
+++ b/app/frontend/Contacts/PersonPage/PersonMenu.svelte
@@ -33,6 +33,10 @@
       }
     }
 
-    await toDelete.deleteIt();
+    if (toDelete.dbID) {
+      await toDelete.deleteIt();
+    } else {
+      toDelete.addressbook.persons.remove(toDelete);
+    }
   }
 </script>

--- a/app/frontend/Contacts/PersonsToolbar.svelte
+++ b/app/frontend/Contacts/PersonsToolbar.svelte
@@ -53,7 +53,8 @@
     if (!person) {
       person = addressbook.newPerson();
       person.name = "";
-      persons.add(person);
+      person.addressbook = addressbook;
+      addressbook.persons.add(person);
     }
     $selectedPerson = person;
   }

--- a/app/logic/Abstract/Person.ts
+++ b/app/logic/Abstract/Person.ts
@@ -155,9 +155,9 @@ export class Person extends ContactBase {
   }
 
   /** Person class needs to match account class, so need to clone. */
-  async moveToAddressbook(newAddressbook: Addressbook): Promise<void> {
+  async moveToAddressbook(newAddressbook: Addressbook): Promise<Person> {
     if (this.addressbook == newAddressbook || !newAddressbook) {
-      return;
+      return this;
     }
     let newPerson = newAddressbook.newPerson();
     if (Object.getPrototypeOf(this) == Object.getPrototypeOf(newPerson)) {
@@ -165,7 +165,7 @@ export class Person extends ContactBase {
       this.addressbook = newAddressbook;
       newAddressbook.persons.add(this);
       await this.save();
-      return;
+      return this;
     }
     newPerson.copyFrom(this);
     newPerson.addressbook = newAddressbook;
@@ -173,6 +173,7 @@ export class Person extends ContactBase {
     newAddressbook.persons.add(newPerson);
     await this.deleteIt();
     await newPerson.save();
+    return newPerson;
   }
 
   async copyToAddressbook(newAddressbook: Addressbook): Promise<void> {


### PR DESCRIPTION
- We were adding to the `persons` collection in the PersonsToolBar which made it impossible to remove a person if it was unsaved since it didn't belong to any address book persons collection
- The other problem was that after moving to another address book we didn't select the new instance
- `moveToAddressbook()` would unknowingly save to the DB or server by just calling it even if the contact was not saved yet
- This PR fixes the above problems, however, after changing the Addressbook it would move to the bottom if it's not saved yet and it makes it confusing because on unsaved contacts should always be at the top because it's still being edited.