### PR TITLE
Contacts: Person: Update Name with FirstName and LastName #1281

### DIFF
--- a/app/logic/Abstract/Person.ts
+++ b/app/logic/Abstract/Person.ts
@@ -110,6 +110,11 @@ export class Person extends ContactBase {
   notifyObservers(propertyName?: string, oldValue?: any): void {
     if (propertyName == "name" && this.name && typeof (this.name) == "string") {
       this.fixName();
+    } else if ((propertyName == "firstName" &&
+      this.firstName && typeof (this.firstName) == "string") ||
+      (propertyName == "lastName" &&
+        this.lastName && typeof (this.lastName) == "string")) {
+      this.joinName();
     }
     super.notifyObservers(propertyName, oldValue);
   }
@@ -136,6 +141,10 @@ export class Person extends ContactBase {
         }
       }
     }
+  }
+
+  protected joinName() {
+    this.name = [this.firstName ?? "", this.lastName ?? ""].join(" ");
   }
 
   async merge(other: Person) {


### PR DESCRIPTION
- Update Name with FirstName and LastName
- Update it so it's not null and it doesn't trigger a focus on the Name input
- There's one problem with this which I haven't managed to fix where if you only input the lastName it should leave a space infront. If you do `trim()` for the firstName or lastName or both in the function it would make it hard add a space in the Name  input.
- This doesn't seem to cause a reactive loop.
- Fixes #1281 