### PR TITLE
Not let `login` call `startup`, but let the caller decide #1036 #1291

### DIFF
--- a/app/frontend/Contacts/PersonsToolbar.svelte
+++ b/app/frontend/Contacts/PersonsToolbar.svelte
@@ -62,7 +62,7 @@
     let ab = $selectedAddressbook;
     assert(ab?.canSync, "Cannot sync " + ab.protocol);
     if (!ab.isLoggedIn) {
-      await ab.loginAndStartup();
+      await ab.login();
     }
     await ab.listContacts();
   }

--- a/app/frontend/Contacts/PersonsToolbar.svelte
+++ b/app/frontend/Contacts/PersonsToolbar.svelte
@@ -62,8 +62,7 @@
     let ab = $selectedAddressbook;
     assert(ab?.canSync, "Cannot sync " + ab.protocol);
     if (!ab.isLoggedIn) {
-      await ab.login(true);
-      await ab.startup();
+      await ab.loginAndStartup();
     }
     await ab.listContacts();
   }

--- a/app/frontend/Contacts/PersonsToolbar.svelte
+++ b/app/frontend/Contacts/PersonsToolbar.svelte
@@ -63,6 +63,7 @@
     assert(ab?.canSync, "Cannot sync " + ab.protocol);
     if (!ab.isLoggedIn) {
       await ab.login(true);
+      await ab.startup();
     }
     await ab.listContacts();
   }

--- a/app/frontend/Files/FolderLeftPane/AccountListItem.svelte
+++ b/app/frontend/Files/FolderLeftPane/AccountListItem.svelte
@@ -53,7 +53,7 @@
 
   async function login() {
     if (!account.isLoggedIn) {
-      await account.loginAndStartup();
+      await account.login();
     }
     await account.sync();
   }

--- a/app/frontend/Files/FolderLeftPane/AccountListItem.svelte
+++ b/app/frontend/Files/FolderLeftPane/AccountListItem.svelte
@@ -54,6 +54,7 @@
   async function login() {
     if (!account.isLoggedIn) {
       await account.login(true);
+      await account.startup();
     }
     await account.sync();
   }

--- a/app/frontend/Files/FolderLeftPane/AccountListItem.svelte
+++ b/app/frontend/Files/FolderLeftPane/AccountListItem.svelte
@@ -53,8 +53,7 @@
 
   async function login() {
     if (!account.isLoggedIn) {
-      await account.login(true);
-      await account.startup();
+      await account.loginAndStartup();
     }
     await account.sync();
   }

--- a/app/frontend/Files/FolderLeftPane/AccountMenu.svelte
+++ b/app/frontend/Files/FolderLeftPane/AccountMenu.svelte
@@ -14,6 +14,7 @@
   async function sync() {
     if (!account.isLoggedIn) {
       await account.login(true);
+      await account.startup();
     }
     await account.sync();
   }

--- a/app/frontend/Files/FolderLeftPane/AccountMenu.svelte
+++ b/app/frontend/Files/FolderLeftPane/AccountMenu.svelte
@@ -13,7 +13,7 @@
 
   async function sync() {
     if (!account.isLoggedIn) {
-      await account.loginAndStartup();
+      await account.login();
     }
     await account.sync();
   }

--- a/app/frontend/Files/FolderLeftPane/AccountMenu.svelte
+++ b/app/frontend/Files/FolderLeftPane/AccountMenu.svelte
@@ -13,8 +13,7 @@
 
   async function sync() {
     if (!account.isLoggedIn) {
-      await account.login(true);
-      await account.startup();
+      await account.loginAndStartup();
     }
     await account.sync();
   }

--- a/app/frontend/Mail/LeftPane/AccountListItem.svelte
+++ b/app/frontend/Mail/LeftPane/AccountListItem.svelte
@@ -59,7 +59,7 @@
   export let account: MailAccount;
 
   async function login() {
-    await account.loginAndStartup();
+    await account.loginAndSync();
   }
 
   async function openSettings() {

--- a/app/frontend/Mail/LeftPane/AccountListItem.svelte
+++ b/app/frontend/Mail/LeftPane/AccountListItem.svelte
@@ -60,6 +60,7 @@
 
   async function login() {
     await account.login(true);
+    await account.startup();
   }
 
   async function openSettings() {

--- a/app/frontend/Mail/LeftPane/AccountListItem.svelte
+++ b/app/frontend/Mail/LeftPane/AccountListItem.svelte
@@ -59,8 +59,7 @@
   export let account: MailAccount;
 
   async function login() {
-    await account.login(true);
-    await account.startup();
+    await account.loginAndStartup();
   }
 
   async function openSettings() {

--- a/app/frontend/Mail/LeftPane/AccountMenu.svelte
+++ b/app/frontend/Mail/LeftPane/AccountMenu.svelte
@@ -25,6 +25,7 @@
   async function getNewMessages() {
     if (!account.isLoggedIn) {
       await account.login(true);
+      await account.startup();
     }
     await account.inbox.getNewMessages();
 

--- a/app/frontend/Mail/LeftPane/AccountMenu.svelte
+++ b/app/frontend/Mail/LeftPane/AccountMenu.svelte
@@ -24,8 +24,7 @@
 
   async function getNewMessages() {
     if (!account.isLoggedIn) {
-      await account.login(true);
-      await account.startup();
+      await account.loginAndStartup();
     }
     await account.inbox.getNewMessages();
 

--- a/app/frontend/Mail/LeftPane/AccountMenu.svelte
+++ b/app/frontend/Mail/LeftPane/AccountMenu.svelte
@@ -24,7 +24,7 @@
 
   async function getNewMessages() {
     if (!account.isLoggedIn) {
-      await account.loginAndStartup();
+      await account.login();
     }
     await account.inbox.getNewMessages();
 

--- a/app/frontend/Mail/LeftPane/FolderHeader.svelte
+++ b/app/frontend/Mail/LeftPane/FolderHeader.svelte
@@ -39,8 +39,7 @@
   $: account = folder?.account;
 
   async function login() {
-    await account.login(true);
-    await account.startup();
+    await account.loginAndStartup();
   }
 </script>
 

--- a/app/frontend/Mail/LeftPane/FolderHeader.svelte
+++ b/app/frontend/Mail/LeftPane/FolderHeader.svelte
@@ -40,6 +40,7 @@
 
   async function login() {
     await account.login(true);
+    await account.startup();
   }
 </script>
 

--- a/app/frontend/Mail/LeftPane/FolderHeader.svelte
+++ b/app/frontend/Mail/LeftPane/FolderHeader.svelte
@@ -39,7 +39,7 @@
   $: account = folder?.account;
 
   async function login() {
-    await account.loginAndStartup();
+    await account.loginAndSync();
   }
 </script>
 

--- a/app/frontend/Mail/LeftPane/FolderMenu.svelte
+++ b/app/frontend/Mail/LeftPane/FolderMenu.svelte
@@ -58,8 +58,7 @@
   async function getNewMessages() {
     let account = folder.account;
     if (!account.isLoggedIn) {
-      await account.login(true);
-      await account.startup();
+      await account.loginAndStartup();
     }
     await folder.getNewMessages();
   }

--- a/app/frontend/Mail/LeftPane/FolderMenu.svelte
+++ b/app/frontend/Mail/LeftPane/FolderMenu.svelte
@@ -59,6 +59,7 @@
     let account = folder.account;
     if (!account.isLoggedIn) {
       await account.login(true);
+      await account.startup();
     }
     await folder.getNewMessages();
   }

--- a/app/frontend/Mail/LeftPane/FolderMenu.svelte
+++ b/app/frontend/Mail/LeftPane/FolderMenu.svelte
@@ -58,7 +58,7 @@
   async function getNewMessages() {
     let account = folder.account;
     if (!account.isLoggedIn) {
-      await account.loginAndStartup();
+      await account.login();
     }
     await folder.getNewMessages();
   }

--- a/app/frontend/Mail/LeftPane/GetMailButton.svelte
+++ b/app/frontend/Mail/LeftPane/GetMailButton.svelte
@@ -52,8 +52,7 @@
       let account = folder.account;
       if (!account.isLoggedIn) {
         status = Status.Login;
-        await account.login(true);
-        await account.startup();
+        await account.loginAndStartup();
       }
       status = Status.Fetching;
       await folder.getNewMessages();

--- a/app/frontend/Mail/LeftPane/GetMailButton.svelte
+++ b/app/frontend/Mail/LeftPane/GetMailButton.svelte
@@ -52,7 +52,7 @@
       let account = folder.account;
       if (!account.isLoggedIn) {
         status = Status.Login;
-        await account.loginAndStartup();
+        await account.login();
       }
       status = Status.Fetching;
       await folder.getNewMessages();

--- a/app/frontend/Mail/LeftPane/GetMailButton.svelte
+++ b/app/frontend/Mail/LeftPane/GetMailButton.svelte
@@ -53,6 +53,7 @@
       if (!account.isLoggedIn) {
         status = Status.Login;
         await account.login(true);
+        await account.startup();
       }
       status = Status.Fetching;
       await folder.getNewMessages();

--- a/app/frontend/Mail/Vertical/FetchingM.svelte
+++ b/app/frontend/Mail/Vertical/FetchingM.svelte
@@ -22,8 +22,7 @@
       loggingIn = true;
       let account = folder.account;
       if (!account.isLoggedIn) {
-        await account.login(true);
-        await account.startup();
+        await account.loginAndStartup();
       }
       loggingIn = false;
       checkingMail = true;

--- a/app/frontend/Mail/Vertical/FetchingM.svelte
+++ b/app/frontend/Mail/Vertical/FetchingM.svelte
@@ -22,7 +22,7 @@
       loggingIn = true;
       let account = folder.account;
       if (!account.isLoggedIn) {
-        await account.loginAndStartup();
+        await account.login();
       }
       loggingIn = false;
       checkingMail = true;

--- a/app/frontend/Mail/Vertical/FetchingM.svelte
+++ b/app/frontend/Mail/Vertical/FetchingM.svelte
@@ -23,6 +23,7 @@
       let account = folder.account;
       if (!account.isLoggedIn) {
         await account.login(true);
+        await account.startup();
       }
       loggingIn = false;
       checkingMail = true;

--- a/app/frontend/Settings/Mail/Account/Folders.svelte
+++ b/app/frontend/Settings/Mail/Account/Folders.svelte
@@ -31,7 +31,7 @@
   {:else if !$mailAccount?.isLoggedIn}
     <vbox class="login">
       <hbox class="label">{$t`Please log in to account ${mailAccount?.name} first`}</hbox>
-      <Button label={$t`Login`} onClick={async () => await mailAccount.loginAndStartup()} />
+      <Button label={$t`Login`} onClick={async () => await mailAccount.loginAndSync()} />
     </vbox>
   {/if}
 </vbox>

--- a/app/frontend/Settings/Mail/Account/Folders.svelte
+++ b/app/frontend/Settings/Mail/Account/Folders.svelte
@@ -31,7 +31,7 @@
   {:else if !$mailAccount?.isLoggedIn}
     <vbox class="login">
       <hbox class="label">{$t`Please log in to account ${mailAccount?.name} first`}</hbox>
-      <Button label={$t`Login`} onClick={async () => await account.loginAndStartup()} />
+      <Button label={$t`Login`} onClick={async () => await mailAccount.loginAndStartup()} />
     </vbox>
   {/if}
 </vbox>

--- a/app/frontend/Settings/Mail/Account/Folders.svelte
+++ b/app/frontend/Settings/Mail/Account/Folders.svelte
@@ -31,7 +31,7 @@
   {:else if !$mailAccount?.isLoggedIn}
     <vbox class="login">
       <hbox class="label">{$t`Please log in to account ${mailAccount?.name} first`}</hbox>
-      <Button label={$t`Login`} onClick={login} />
+      <Button label={$t`Login`} onClick={async () => await account.loginAndStartup()} />
     </vbox>
   {/if}
 </vbox>
@@ -58,10 +58,6 @@
   $: mailAccount = account as MailAccount;
   let selectedFolders: ArrayColl<Folder>;
   let isCreating: "toplevel" | "subfolder" | false = false;
-
-  async function login() {
-    await account.loginAndStartup();
-  }
 </script>
 
 <style>

--- a/app/frontend/Settings/Mail/Account/Folders.svelte
+++ b/app/frontend/Settings/Mail/Account/Folders.svelte
@@ -60,8 +60,7 @@
   let isCreating: "toplevel" | "subfolder" | false = false;
 
   async function login() {
-    await account.login(true);
-    await account.startup();
+    await account.loginAndStartup();
   }
 </script>
 

--- a/app/frontend/Settings/Mail/Account/Folders.svelte
+++ b/app/frontend/Settings/Mail/Account/Folders.svelte
@@ -31,7 +31,7 @@
   {:else if !$mailAccount?.isLoggedIn}
     <vbox class="login">
       <hbox class="label">{$t`Please log in to account ${mailAccount?.name} first`}</hbox>
-      <Button label={$t`Login`} onClick={async () => await mailAccount.login(true)} />
+      <Button label={$t`Login`} onClick={login} />
     </vbox>
   {/if}
 </vbox>
@@ -58,6 +58,11 @@
   $: mailAccount = account as MailAccount;
   let selectedFolders: ArrayColl<Folder>;
   let isCreating: "toplevel" | "subfolder" | false = false;
+
+  async function login() {
+    await account.login(true);
+    await account.startup();
+  }
 </script>
 
 <style>

--- a/app/logic/Abstract/Account.ts
+++ b/app/logic/Abstract/Account.ts
@@ -106,8 +106,12 @@ export class Account extends Observable {
   }
 
   async loginAndStartup(interactive = true): Promise<void> {
-    await this.login(interactive);
-    await this.startup();
+    if (this.isDependentAccount) {
+      await this.mainAccount.loginAndStartup(interactive);
+    } else {
+      await this.login(interactive);
+      await this.startup();
+    }
   }
 
   /** For setup only. Test that the login works. */

--- a/app/logic/Abstract/Account.ts
+++ b/app/logic/Abstract/Account.ts
@@ -60,22 +60,18 @@ export class Account extends Observable {
   }
 
   /**
-   * For local accounts, this is the startup entry point. It is overridden
-   * e.g. for contacts and calendar to load data from the database.
-   * Startup for accounts that need to log in will attempt to use a
-   * noninteractive `login` call instead. However if this is successful
-   * then the account's login code should finish by running its startup code.
+   * This is the entry point to perform post-login sync on this account.
    */
-  async startup() {
+  async initialSync() {
   }
 
   /**
-   * Convenience method for accounts to use to start up dependent accounts.
-   * This should be called after the account has finished its own startup.
+   * Convenience method for accounts to use to sync all dependent accounts.
+   * This should be called after the account has finished its own sync.
    */
-  protected async startupDependentAccounts() {
+  protected async syncDependentAccounts() {
     for (let dependent of this.dependentAccounts()) {
-      dependent.startup()
+      dependent.initialSync()
         .catch(dependent.errorCallback);
     }
   }
@@ -105,13 +101,13 @@ export class Account extends Observable {
     }
   }
 
-  async loginAndStartup(interactive = true): Promise<void> {
+  async loginAndSync(interactive = true): Promise<void> {
     if (this.isDependentAccount) {
-      await this.mainAccount.loginAndStartup(interactive);
+      await this.mainAccount.loginAndSync(interactive);
       return;
     }
     await this.login(interactive);
-    await this.startup();
+    await this.initialSync();
   }
 
   /** For setup only. Test that the login works. */

--- a/app/logic/Abstract/Account.ts
+++ b/app/logic/Abstract/Account.ts
@@ -76,6 +76,28 @@ export class Account extends Observable {
     }
   }
 
+  /**
+   * Entry point to notify the account that login has completed.
+   * Could potentially be used in conjunction with network offline events
+   * (`disconnect()` when going offline and `connected()` when back online)?
+   */
+  async connected() {
+  }
+
+  /**
+   * Convenience method for accounts to use to notify all dependent accounts
+   * that the login has completed.
+   */
+  protected async dependentAccountsConnected() {
+    for (let dependent of this.dependentAccounts()) {
+      try {
+        await dependent.connected();
+      } catch (ex) {
+        dependent.errorCallback(ex);
+      }
+    }
+  }
+
   get isLoggedIn(): boolean {
     return false;
   }

--- a/app/logic/Abstract/Account.ts
+++ b/app/logic/Abstract/Account.ts
@@ -105,6 +105,11 @@ export class Account extends Observable {
     }
   }
 
+  async loginAndStartup(interactive = true): Promise<void> {
+    await this.login(interactive);
+    await this.startup();
+  }
+
   /** For setup only. Test that the login works. */
   async verifyLogin(): Promise<void> {
     await this.login(true);

--- a/app/logic/Abstract/Account.ts
+++ b/app/logic/Abstract/Account.ts
@@ -108,10 +108,10 @@ export class Account extends Observable {
   async loginAndStartup(interactive = true): Promise<void> {
     if (this.isDependentAccount) {
       await this.mainAccount.loginAndStartup(interactive);
-    } else {
-      await this.login(interactive);
-      await this.startup();
+      return;
     }
+    await this.login(interactive);
+    await this.startup();
   }
 
   /** For setup only. Test that the login works. */

--- a/app/logic/Calendar/Calendar.ts
+++ b/app/logic/Calendar/Calendar.ts
@@ -71,8 +71,8 @@ export class Calendar extends Account {
     return this.events.some(ev => ev.calUID == event.calUID);
   }
 
-  async startup() {
-    await super.startup();
+  async initialSync() {
+    await super.initialSync();
     await this.listEvents();
   }
 

--- a/app/logic/Calendar/EWS/EWSCalendar.ts
+++ b/app/logic/Calendar/EWS/EWSCalendar.ts
@@ -34,8 +34,7 @@ export class EWSCalendar extends ExchangeCalendar implements EWSSubscribable {
     await this.account.unsubscribeNotifications(this);
   }
 
-  async initialSync(): Promise<void> {
-    await super.initialSync();
+  async connect(): Promise<void> {
     if (this.username != this.account.username) {
       await this.account.subscribeToNotificationsForSubaccount(this);
     }

--- a/app/logic/Calendar/EWS/EWSCalendar.ts
+++ b/app/logic/Calendar/EWS/EWSCalendar.ts
@@ -34,8 +34,8 @@ export class EWSCalendar extends ExchangeCalendar implements EWSSubscribable {
     await this.account.unsubscribeNotifications(this);
   }
 
-  async startup(): Promise<void> {
-    await super.startup();
+  async initialSync(): Promise<void> {
+    await super.initialSync();
     if (this.username != this.account.username) {
       await this.account.subscribeToNotificationsForSubaccount(this);
     }

--- a/app/logic/Contacts/Addressbook.ts
+++ b/app/logic/Contacts/Addressbook.ts
@@ -32,8 +32,8 @@ export class Addressbook extends Account {
     return true; // for local addressbook
   }
 
-  async startup() {
-    await super.startup();
+  async initialSync() {
+    await super.initialSync();
     await this.listContacts();
   }
 

--- a/app/logic/Contacts/EWS/EWSAddressbook.ts
+++ b/app/logic/Contacts/EWS/EWSAddressbook.ts
@@ -36,8 +36,8 @@ export class EWSAddressbook extends Addressbook implements EWSSubscribable {
     await this.account.unsubscribeNotifications(this);
   }
 
-  async startup(): Promise<void> {
-    await super.startup();
+  async initialSync(): Promise<void> {
+    await super.initialSync();
     if (this.username != this.account.username) {
       await this.account.subscribeToNotificationsForSubaccount(this);
     }

--- a/app/logic/Contacts/EWS/EWSAddressbook.ts
+++ b/app/logic/Contacts/EWS/EWSAddressbook.ts
@@ -36,8 +36,7 @@ export class EWSAddressbook extends Addressbook implements EWSSubscribable {
     await this.account.unsubscribeNotifications(this);
   }
 
-  async initialSync(): Promise<void> {
-    await super.initialSync();
+  async connected(): Promise<void> {
     if (this.username != this.account.username) {
       await this.account.subscribeToNotificationsForSubaccount(this);
     }

--- a/app/logic/Files/FileSharingAccount.ts
+++ b/app/logic/Files/FileSharingAccount.ts
@@ -16,8 +16,8 @@ export class FileSharingAccount extends Account {
     return dir;
   }
 
-  async startup() {
-    await super.startup();
+  async initialSync() {
+    await super.initialSync();
     await this.sync();
   }
 

--- a/app/logic/Mail/ActiveSync/ActiveSyncAccount.ts
+++ b/app/logic/Mail/ActiveSync/ActiveSyncAccount.ts
@@ -37,7 +37,7 @@ export class ActiveSyncAccount extends ExchangeMailAccount {
   protected throttle = new Throttle(50, 1);
   protected semaphore = new Semaphore(20);
   protected loginRunOnce = new RunOnce();
-  protected startupRunOnce = new RunOnce();
+  protected syncRunOnce = new RunOnce();
 
   constructor() {
     super();
@@ -94,9 +94,9 @@ export class ActiveSyncAccount extends ExchangeMailAccount {
     });
   }
 
-  async startup() {
-    await this.startupRunOnce.runOnce(async () => {
-      await super.startup();
+  async initialSync() {
+    await this.syncRunOnce.runOnce(async () => {
+      await super.initialSync();
 
       // `listFolders()` will subscribe to new user-added addressbooks and calendars
 
@@ -110,7 +110,7 @@ export class ActiveSyncAccount extends ExchangeMailAccount {
       // is in sync, so each pingable registers with the account when
       // it's ready to be specified in the Ping operation.
 
-      await this.startupDependentAccounts();
+      await this.syncDependentAccounts();
     });
   }
 

--- a/app/logic/Mail/ActiveSync/ActiveSyncAccount.ts
+++ b/app/logic/Mail/ActiveSync/ActiveSyncAccount.ts
@@ -91,7 +91,17 @@ export class ActiveSyncAccount extends ExchangeMailAccount {
           throw new ActiveSyncError("Settings", response.DeviceInformation.Status, this);
         }
       }
+      await this.connected();
     });
+  }
+
+  async connected() {
+    appGlobal.searchOnlyAddressbooks.add(new ActiveSyncGAL(this));
+
+    // If this is a reconnect, try to continue from where we left off.
+    if (!this.listening) {
+      this.listenForPings().catch(this.errorCallback);
+    }
   }
 
   async initialSync() {
@@ -99,10 +109,6 @@ export class ActiveSyncAccount extends ExchangeMailAccount {
       await super.initialSync();
 
       // `listFolders()` will subscribe to new user-added addressbooks and calendars
-
-      if (!this.isDependentAccount) {
-        appGlobal.searchOnlyAddressbooks.add(new ActiveSyncGAL(this));
-      }
 
       // ActiveSync doesn't have streaming notifications, instead it
       // provides the Ping operation which will tell us when a pingable

--- a/app/logic/Mail/ActiveSync/ActiveSyncAccount.ts
+++ b/app/logic/Mail/ActiveSync/ActiveSyncAccount.ts
@@ -91,8 +91,6 @@ export class ActiveSyncAccount extends ExchangeMailAccount {
           throw new ActiveSyncError("Settings", response.DeviceInformation.Status, this);
         }
       }
-
-      await this.startup();
     });
   }
 

--- a/app/logic/Mail/EWS/EWSAccount.ts
+++ b/app/logic/Mail/EWS/EWSAccount.ts
@@ -103,8 +103,6 @@ export class EWSAccount extends ExchangeMailAccount implements EWSSubscribable {
       await ensureLicensed(); // Not in generic `Account`, to keep license code in the proprietary parts
       await super.login(interactive);
       await this.loginCommon(interactive);
-
-      await this.startup();
     });
   }
 

--- a/app/logic/Mail/EWS/EWSAccount.ts
+++ b/app/logic/Mail/EWS/EWSAccount.ts
@@ -103,22 +103,28 @@ export class EWSAccount extends ExchangeMailAccount implements EWSSubscribable {
       await ensureLicensed(); // Not in generic `Account`, to keep license code in the proprietary parts
       await super.login(interactive);
       await this.loginCommon(interactive);
+      await this.connected();
+      await this.dependentAccountsConnected();
     });
+  }
+
+  async connected() {
+    if (this.isDependentAccount) {
+      await (this.mainAccount as EWSAccount).subscribeToNotificationsForSubaccount(this);
+    } else {
+      appGlobal.searchOnlyAddressbooks.add(new EWSGAL(this));
+
+      await this.subscribeToNotifications();
+    }
   }
 
   async initialSync() {
     await this.syncRunOnce.runOnce(async () => {
       await super.initialSync();
       if (this.isDependentAccount) {
-        await (this.mainAccount as EWSAccount).subscribeToNotificationsForSubaccount(this);
         return;
       }
       await this.syncDependentAccounts();
-
-      appGlobal.searchOnlyAddressbooks.add(new EWSGAL(this));
-      // `listFolders()` will subscribe to new user-added addressbooks and calendars
-
-      await this.subscribeToNotifications();
     });
   }
 

--- a/app/logic/Mail/EWS/EWSAccount.ts
+++ b/app/logic/Mail/EWS/EWSAccount.ts
@@ -35,7 +35,7 @@ export class EWSAccount extends ExchangeMailAccount implements EWSSubscribable {
   protected throttle = new Throttle(50, 1);
   protected semaphore = new Semaphore(20);
   protected loginRunOnce = new RunOnce();
-  protected startupRunOnce = new RunOnce();
+  protected syncRunOnce = new RunOnce();
   /** null: if this is our account
    * msgfolderroot: if this is an account shared with us
    * inbox: if this is an inbox shared with us */
@@ -106,14 +106,14 @@ export class EWSAccount extends ExchangeMailAccount implements EWSSubscribable {
     });
   }
 
-  async startup() {
-    await this.startupRunOnce.runOnce(async () => {
-      await super.startup();
+  async initialSync() {
+    await this.syncRunOnce.runOnce(async () => {
+      await super.initialSync();
       if (this.isDependentAccount) {
         await (this.mainAccount as EWSAccount).subscribeToNotificationsForSubaccount(this);
         return;
       }
-      await this.startupDependentAccounts();
+      await this.syncDependentAccounts();
 
       appGlobal.searchOnlyAddressbooks.add(new EWSGAL(this));
       // `listFolders()` will subscribe to new user-added addressbooks and calendars
@@ -985,7 +985,7 @@ export class EWSAccount extends ExchangeMailAccount implements EWSSubscribable {
     account.identities.add(identity);
     await account.save();
     appGlobal.emailAccounts.add(account);
-    await account.startup();
+    await account.initialSync();
     return account;
   }
 
@@ -1016,7 +1016,7 @@ export class EWSAccount extends ExchangeMailAccount implements EWSSubscribable {
     addressbook.username = person.emailAddress;
     addressbook.folderID = sanitize.nonemptystring(folder.FolderId.Id);
     appGlobal.addressbooks.add(addressbook);
-    await addressbook.startup();
+    await addressbook.initialSync();
     return addressbook;
   }
 
@@ -1047,7 +1047,7 @@ export class EWSAccount extends ExchangeMailAccount implements EWSSubscribable {
     calendar.username = person.emailAddress;
     calendar.folderID = sanitize.nonemptystring(folder.FolderId.Id);
     appGlobal.calendars.add(calendar);
-    await calendar.startup();
+    await calendar.initialSync();
     return calendar;
   }
 

--- a/app/logic/Mail/Graph/GraphAccount.ts
+++ b/app/logic/Mail/Graph/GraphAccount.ts
@@ -54,8 +54,6 @@ export class GraphAccount extends ExchangeMailAccount {
 
       await this.loginOAuth2(interactive);
     });
-
-    await this.startup();
   }
 
   async startup() {

--- a/app/logic/Mail/Graph/GraphAccount.ts
+++ b/app/logic/Mail/Graph/GraphAccount.ts
@@ -31,7 +31,7 @@ export class GraphAccount extends ExchangeMailAccount {
   pollIntervalMinutes = 10;
   logging = false;
   protected loginRunOnce = new RunOnce();
-  protected startupRunOnce = new RunOnce();
+  protected syncRunOnce = new RunOnce();
 
   constructor() {
     super();
@@ -56,15 +56,15 @@ export class GraphAccount extends ExchangeMailAccount {
     });
   }
 
-  async startup() {
-    await this.startupRunOnce.runOnce(async () => {
-      await super.startup();
+  async initialSync() {
+    await this.syncRunOnce.runOnce(async () => {
+      await super.initialSync();
       let inbox = this.inbox as GraphFolder;
       assert(inbox, "Inbox not found");
       inbox.startPolling();
 
       await this.createDefaultDependentAccounts();
-      await this.startupDependentAccounts();
+      await this.syncDependentAccounts();
     });
   }
 

--- a/app/logic/Mail/IMAP/IMAPAccount.ts
+++ b/app/logic/Mail/IMAP/IMAPAccount.ts
@@ -63,9 +63,9 @@ export class IMAPAccount extends MailAccount {
     await this.connection(interactive);
   }
 
-  async startup() {
+  async initialSync() {
     this.namespaces = await this.getNamespaces();
-    await super.startup();
+    await super.initialSync();
     this.notifyObservers();
     (this.inbox as IMAPFolder).startPolling();
   }

--- a/app/logic/Mail/IMAP/IMAPAccount.ts
+++ b/app/logic/Mail/IMAP/IMAPAccount.ts
@@ -61,7 +61,6 @@ export class IMAPAccount extends MailAccount {
     await this.storage.readFolderHierarchy(this);
 
     await this.connection(interactive);
-    await this.startup();
   }
 
   async startup() {

--- a/app/logic/Mail/JMAP/JMAPAccount.ts
+++ b/app/logic/Mail/JMAP/JMAPAccount.ts
@@ -59,12 +59,15 @@ export class JMAPAccount extends MailAccount {
 
     await this.loginOAuth2(interactive);
     await this.getSession();
+    await this.connected();
+  }
+
+  async connected() {
+    this.startPushListener().catch(this.errorCallback);
   }
 
   async initialSync() {
     await super.initialSync();
-    this.startPushListener()
-      .catch(this.errorCallback);
     let inbox = this.inbox as JMAPFolder;
     assert(inbox, "Inbox not found");
     inbox.startPolling();

--- a/app/logic/Mail/JMAP/JMAPAccount.ts
+++ b/app/logic/Mail/JMAP/JMAPAccount.ts
@@ -59,11 +59,10 @@ export class JMAPAccount extends MailAccount {
 
     await this.loginOAuth2(interactive);
     await this.getSession();
-    await this.startup();
   }
 
-  async startup() {
-    await super.startup();
+  async initialSync() {
+    await super.initialSync();
     this.startPushListener()
       .catch(this.errorCallback);
     let inbox = this.inbox as JMAPFolder;
@@ -76,7 +75,7 @@ export class JMAPAccount extends MailAccount {
     if (this.haveCalendar) {
       await this.listCalendars();
     }
-    await this.startupDependentAccounts();
+    await this.syncDependentAccounts();
   }
 
   async verifyLogin(): Promise<void> {

--- a/app/logic/Mail/MailAccount.ts
+++ b/app/logic/Mail/MailAccount.ts
@@ -44,8 +44,8 @@ export class MailAccount extends TCPAccount {
 
   readonly rootFolders: Collection<Folder> = new ArrayColl<Folder>();
 
-  async startup() {
-    await super.startup();
+  async initialSync() {
+    await super.initialSync();
     await this.listFolders();
     assert(this.inbox, gt`Inbox not found`);
     await this.inbox.getNewMessages();

--- a/app/logic/Mail/OWA/OWAAccount.ts
+++ b/app/logic/Mail/OWA/OWAAccount.ts
@@ -179,7 +179,24 @@ export class OWAAccount extends ExchangeMailAccount {
       this.authorizationHeader = await appGlobal.remoteApp.OWA.getAnyScrapedAuth(this.partition);
       this.hasLoggedIn = true;
       this.notifyObserversOfSubaccounts();
+      await this.connected();
     });
+  }
+
+  async connected() {
+    if (this.isDependentAccount) {
+      return;
+    }
+
+    appGlobal.searchOnlyAddressbooks.add(new OWAGAL(this));
+
+    await this.callOWA(new OWASubscribeToNotificationRequest());
+
+    this.notifications = this.isOffice365()
+      ? new OWAOffice365Notifications(this)
+      : new OWAExchangeNotifications(this);
+    this.notifications.start()
+      .catch(this.errorCallback);
   }
 
   async initialSync() {
@@ -196,18 +213,6 @@ export class OWAAccount extends ExchangeMailAccount {
         appGlobal.addressbooks.add(addressbook);
         await addressbook.save();
       }
-
-      if (!this.isDependentAccount) {
-        appGlobal.searchOnlyAddressbooks.add(new OWAGAL(this));
-      }
-
-      await this.callOWA(new OWASubscribeToNotificationRequest());
-
-      this.notifications = this.isOffice365()
-        ? new OWAOffice365Notifications(this)
-        : new OWAExchangeNotifications(this);
-      this.notifications.start()
-        .catch(this.errorCallback);
 
       await this.syncDependentAccounts();
     });

--- a/app/logic/Mail/OWA/OWAAccount.ts
+++ b/app/logic/Mail/OWA/OWAAccount.ts
@@ -59,7 +59,7 @@ export class OWAAccount extends ExchangeMailAccount {
   protected throttle = new Throttle(50, 1);
   protected semaphore = new Semaphore(20);
   protected loginRunOnce = new RunOnce();
-  protected startupRunOnce = new RunOnce();
+  protected syncRunOnce = new RunOnce();
   // null: if this is our account
   // msgfolderroot: if this is an account shared with us
   // inbox: if this is an inbox shared with us
@@ -182,10 +182,10 @@ export class OWAAccount extends ExchangeMailAccount {
     });
   }
 
-  async startup() {
-    await this.startupRunOnce.runOnce(async () => {
+  async initialSync() {
+    await this.syncRunOnce.runOnce(async () => {
       // `listFolders()` will subscribe to new user-added calendars
-      await super.startup();
+      await super.initialSync();
 
       // Create primary addressbook automatically
       let haveAddressbook = appGlobal.addressbooks.some(addressbook => addressbook.mainAccount == this);
@@ -209,7 +209,7 @@ export class OWAAccount extends ExchangeMailAccount {
       this.notifications.start()
         .catch(this.errorCallback);
 
-      await this.startupDependentAccounts();
+      await this.syncDependentAccounts();
     });
   }
 

--- a/app/logic/Mail/OWA/OWAAccount.ts
+++ b/app/logic/Mail/OWA/OWAAccount.ts
@@ -179,8 +179,6 @@ export class OWAAccount extends ExchangeMailAccount {
       this.authorizationHeader = await appGlobal.remoteApp.OWA.getAnyScrapedAuth(this.partition);
       this.hasLoggedIn = true;
       this.notifyObserversOfSubaccounts();
-
-      await this.startup();
     });
   }
 

--- a/app/logic/startup.ts
+++ b/app/logic/startup.ts
@@ -88,7 +88,7 @@ export function loginOnStartup(startupErrorCallback: (ex: Error) => void): void 
         if (!account.isLoggedIn) {
           await account.login(false);
         }
-        await account.startup();
+        await account.initialSync();
       })().catch(errorWithAccountName(account, startupErrorCallback));
     }
   }


### PR DESCRIPTION
- Assumes all UI callers want the account to start up
- Removes the automatic startup from those mail accounts that have it
- Fixes #1291