### PR TITLE
Refactor EWSError #1295

### DIFF
--- a/app/logic/Mail/EWS/EWSAccount.ts
+++ b/app/logic/Mail/EWS/EWSAccount.ts
@@ -352,7 +352,11 @@ export class EWSAccount extends ExchangeMailAccount implements EWSSubscribable {
     } finally {
       lock.release();
     }
-    response.responseText = await response.text();
+    try {
+      response.responseText = await response.text();
+    } catch (ex) {
+      response.responseText = "";
+    }
     this.fatalError = null;
     if (response.status == 200) {
       try {

--- a/app/logic/Mail/EWS/EWSAccount.ts
+++ b/app/logic/Mail/EWS/EWSAccount.ts
@@ -352,10 +352,11 @@ export class EWSAccount extends ExchangeMailAccount implements EWSSubscribable {
     } finally {
       lock.release();
     }
-    response.responseXML = this.parseXML(await response.text());
+    response.responseText = await response.text();
     this.fatalError = null;
     if (response.status == 200) {
       try {
+        response.responseXML = this.parseXML(response.responseText);
         return this.checkResponse(response, aRequest);
       } catch (ex) {
         if (this.isThrottleError(ex)) {
@@ -400,6 +401,7 @@ export class EWSAccount extends ExchangeMailAccount implements EWSSubscribable {
       }
     } else {
       this.throttle.waitForSecond(1);
+      response.responseXML = this.parseXML(response.responseText);
       throw new EWSError(response, aRequest);
     }
   }

--- a/app/logic/Mail/EWS/EWSError.ts
+++ b/app/logic/Mail/EWS/EWSError.ts
@@ -13,57 +13,56 @@ export class EWSError extends Error {
   readonly responseText: string | undefined;
   constructor(aResponse: any, aRequest: JsonRequest) {
     let message = aResponse.statusText;
-    try {
-      let responseXML = aResponse.responseXML;
-      let messageNode = responseXML.querySelector("Message");
-      if (messageNode) {
-        message = messageNode.textContent;
+    let type = 'HTTP ' + aResponse.status;
+    let XML;
+    let error;
+    let responseText;
+    let responseXML = aResponse.responseXML;
+    if (responseXML) {
+      try {
+        let messageNode = responseXML.querySelector("Message");
+        if (messageNode) {
+          message = messageNode.textContent;
+        }
+        let responseCode = responseXML.querySelector("ResponseCode");
+        if (responseCode) {
+          type = responseCode.textContent;
+        }
+        let errorNode = responseXML.querySelector("[ResponseClass=\"Error\"]");
+        if (errorNode) {
+          let errorResponse = XML2JSON(errorNode) as any;
+          message = errorResponse.MessageText;
+          type = errorResponse.ResponseCode;
+        }
+        let innerErrorMessageNode = responseXML.querySelector("[Name=\"InnerErrorMessageText\"]");
+        if (innerErrorMessageNode) {
+          message = innerErrorMessageNode.textContent;
+        }
+        let innerErrorResponseNode = responseXML.querySelector("[Name=\"InnerErrorResponseCode\"]");
+        if (innerErrorResponseNode) {
+          type = innerErrorResponseNode.textContent;
+        }
+        let xmlNode = responseXML.querySelector("MessageXml");
+        if (xmlNode) {
+          // This identifies the XML element causing the error.
+          XML = XML2JSON(xmlNode);
+        }
+        if (messageNode || responseCode || errorNode || xmlNode) {
+          error = XML2JSON(responseXML.documentElement);
+        }
+      } catch (ex) {
+        // The response wasn't XML, so we can't extract an error message.
+        responseText = aResponse.responseText;
       }
-      let errorNode = responseXML.querySelector("[ResponseClass=\"Error\"]");
-      if (errorNode) {
-        let errorResponse = XML2JSON(errorNode) as any;
-        message = errorResponse.MessageText;
-      }
-      let innerErrorNode = responseXML.querySelector("[Name=\"InnerErrorMessageText\"]");
-      if (innerErrorNode) {
-        message = innerErrorNode.textContent;
-      }
-    } catch (ex) {
-      console.log("Could not read error response from server", ex);
     }
     super(message);
     this.request = aRequest;
     this.status = aResponse.status;
     this.statusText = aResponse.statusText;
-    this.type = 'HTTP ' + aResponse.status;
-    try {
-      let responseXML = aResponse.responseXML;
-      let messageNode = responseXML.querySelector("Message");
-      let responseCode = responseXML.querySelector("ResponseCode");
-      if (responseCode) {
-        this.type = responseCode.textContent;
-      }
-      let errorNode = responseXML.querySelector("[ResponseClass=\"Error\"]");
-      if (errorNode) {
-        let errorResponse = XML2JSON(errorNode) as any;
-        this.type = errorResponse.ResponseCode;
-      }
-      let innerErrorNode = responseXML.querySelector("[Name=\"InnerErrorResponseCode\"]");
-      if (innerErrorNode) {
-        this.type = innerErrorNode.textContent;
-      }
-      let xmlNode = responseXML.querySelector("MessageXml");
-      if (xmlNode) {
-        // This identifies the XML element causing the error.
-        this.XML = XML2JSON(xmlNode);
-      }
-      if (messageNode || responseCode || errorNode || xmlNode) {
-        this.error = XML2JSON(responseXML.documentElement);
-      }
-    } catch (ex) {
-      // The response wasn't XML, so we can't extract an error message.
-      this.responseText = aResponse.data;
-    }
+    this.type = type;
+    this.XML = XML;
+    this.error = error;
+    this.responseText = responseText;
   }
 }
 


### PR DESCRIPTION
1. Don't bother trying to parse XML on HTTP 401 errors. (Note that Exchange does return XML for HTTP 500; I don't know about other errors offhand.)
2. Check for non-null `responseXML` to avoid likely exception.
3. Unduplicate code:

```typescript
        let errorNode = responseXML.querySelector("[ResponseClass=\"Error\"]");
        if (errorNode) {
          let errorResponse = XML2JSON(errorNode) as any;
```