### PR TITLE
Contacts: Reference newPerson instead of the oldPerson #1269

### DIFF
--- a/app/frontend/Contacts/AddressbookChanger.svelte
+++ b/app/frontend/Contacts/AddressbookChanger.svelte
@@ -10,7 +10,7 @@
 <script lang="ts">
   import type { Addressbook } from "../../logic/Contacts/Addressbook";
   import type { Person } from "../../logic/Abstract/Person";
-  import { newPerson } from "./Person/Selected";
+  import { newPerson, selectedPerson } from "./Person/Selected";
   import { appGlobal } from "../../logic/app";
   import { selectedWorkspace } from "../MainWindow/Selected";
   import AccountDropDown from "../Shared/AccountDropDown.svelte";
@@ -30,9 +30,9 @@
       person = newAddressbook.newPerson();
       person.addressbook = newAddressbook;
       person.copyFrom(oldPerson);
-      $newPerson = person;
+      $selectedPerson = $newPerson = person;
     } else {
-      person.moveToAddressbook(newAddressbook);
+      $selectedPerson = await person.moveToAddressbook(newAddressbook);
     }
   }
 </script>

--- a/app/logic/Abstract/Person.ts
+++ b/app/logic/Abstract/Person.ts
@@ -154,7 +154,11 @@ export class Person extends ContactBase {
     await other.deleteIt();
   }
 
-  /** Person class needs to match account class, so need to clone. */
+  /** Person class needs to match account class, so need to clone.
+   * @returns reference to the new person created or the existing
+   * person if it was already in the new addressbook or the
+   * same addressbook type
+   */
   async moveToAddressbook(newAddressbook: Addressbook): Promise<Person> {
     if (this.addressbook == newAddressbook || !newAddressbook) {
       return this;

--- a/app/logic/Abstract/Person.ts
+++ b/app/logic/Abstract/Person.ts
@@ -155,9 +155,9 @@ export class Person extends ContactBase {
   }
 
   /** Person class needs to match account class, so need to clone. */
-  async moveToAddressbook(newAddressbook: Addressbook): Promise<void> {
+  async moveToAddressbook(newAddressbook: Addressbook): Promise<Person> {
     if (this.addressbook == newAddressbook || !newAddressbook) {
-      return;
+      return this;
     }
     let newPerson = newAddressbook.newPerson();
     if (Object.getPrototypeOf(this) == Object.getPrototypeOf(newPerson)) {
@@ -165,7 +165,7 @@ export class Person extends ContactBase {
       this.addressbook = newAddressbook;
       newAddressbook.persons.add(this);
       await this.save();
-      return;
+      return this;
     }
     newPerson.copyFrom(this);
     newPerson.addressbook = newAddressbook;
@@ -173,6 +173,7 @@ export class Person extends ContactBase {
     newAddressbook.persons.add(newPerson);
     await this.deleteIt();
     await newPerson.save();
+    return newPerson;
   }
 
   async copyToAddressbook(newAddressbook: Addressbook): Promise<void> {


### PR DESCRIPTION
- Contacts: Reference newPerson instead of the oldPerson in the old addressbook
- Fixes #1269 for remote addressbooks, but OWA is throwing a error `Id is malformed` for some reason