### PR TITLE
Settings: MailConnectedAccounts: Don't set calendars on every account update #1294

### DIFF
--- a/app/frontend/Settings/Mail/ConnectedAccounts.svelte
+++ b/app/frontend/Settings/Mail/ConnectedAccounts.svelte
@@ -24,7 +24,12 @@
 
   export let account: MailAccount;
 
-  $: calendars = account.calendarsAvailable;
+  let lastAccount = account;
+  let calendars = account.calendarsAvailable;
+  $: if (account !== lastAccount) {
+    lastAccount = account;
+    calendars = account.calendarsAvailable;
+  }
 </script>
 
 <style>

--- a/app/frontend/Settings/Mail/ConnectedAccounts.svelte
+++ b/app/frontend/Settings/Mail/ConnectedAccounts.svelte
@@ -27,8 +27,8 @@
   let lastAccount = account;
   let calendars = account.calendarsAvailable;
   $: if (account !== lastAccount) {
-    lastAccount = account;
     calendars = account.calendarsAvailable;
+    lastAccount = account;
   }
 </script>
 


### PR DESCRIPTION
- The calendars collection was being updated on every account update, especially whenever `account.calendar` was updated because of the binding
- https://github.com/mustang-im/mustang/blob/0b9ecfc23038ab90e83af8d6312ce8b696efb2cd/app/frontend/Settings/Mail/ConnectedAccounts.svelte#L8
- It happened more because the collection was empty which triggers setting `account.calendar` to `undefined` and since it's `undefined` there will be an infinite loop, however placing a condition to not set it if the collection is empty didn't help.
https://github.com/mustang-im/mustang/blob/0b9ecfc23038ab90e83af8d6312ce8b696efb2cd/app/frontend/Shared/AccountDropDown.svelte#L62-L65
- Fixes #1294 