### PR TITLE
Shared: AccountDropDown: Avoid setting selectedAccount to `undefined` #1294

### DIFF
--- a/app/frontend/Shared/AccountDropDown.svelte
+++ b/app/frontend/Shared/AccountDropDown.svelte
@@ -69,7 +69,8 @@
     if (selectedAccount === null && showAllOption) {
       return;
     }
-    if (!showAccounts.includes(selectedAccount)) {
+    if (showAccounts.hasItems &&
+      !showAccounts.includes(selectedAccount)) {
       selectedAccount = null;
       defaultSelection();
     }

--- a/app/frontend/Shared/AccountDropDown.svelte
+++ b/app/frontend/Shared/AccountDropDown.svelte
@@ -69,8 +69,8 @@
     if (selectedAccount === null && showAllOption) {
       return;
     }
-    if (showAccounts.hasItems &&
-      !showAccounts.includes(selectedAccount)) {
+    if (!showAccounts.includes(selectedAccount) &&
+        showAccounts.hasItems) {
       selectedAccount = null;
       defaultSelection();
     }


### PR DESCRIPTION
- selectedAccount was being set to undefined because there were no items
- After setting to undefined selectedAccount updates and becomes false which triggers the reactive function above
- Should fix #1294 
- Replaces #1304 