### PR TITLE
ActiveSync: Always read protocol version on startup

### DIFF
--- a/app/logic/Mail/ActiveSync/ActiveSyncAccount.ts
+++ b/app/logic/Mail/ActiveSync/ActiveSyncAccount.ts
@@ -77,6 +77,14 @@ export class ActiveSyncAccount extends ExchangeMailAccount {
         });
         await this.oAuth2.login(interactive);
       }
+
+      await this.startup();
+    });
+  }
+
+  async startup() {
+    await this.startupRunOnce.runOnce(async () => {
+      // This needs to run first before trying to sync.
       this.protocolVersion = this.getStorageItem("protocolVersion");
       if (this.protocolVersion == "14.0") {
         let request = {
@@ -92,12 +100,6 @@ export class ActiveSyncAccount extends ExchangeMailAccount {
         }
       }
 
-      await this.startup();
-    });
-  }
-
-  async startup() {
-    await this.startupRunOnce.runOnce(async () => {
       await super.startup();
 
       // `listFolders()` will subscribe to new user-added addressbooks and calendars


### PR DESCRIPTION
Reading the protocol version is startup init code, not authentication code. In the case of (say) a bexchange account, the account could be added and would work, but after a restart it would fail because the protocol version was unset.