### PR TITLE
Mail: Attachments: Load attachment.content before saving #1307, #1305

### DIFF
--- a/app/frontend/Mail/Message/AttachmentMenu.svelte
+++ b/app/frontend/Mail/Message/AttachmentMenu.svelte
@@ -27,7 +27,6 @@
 
 <script lang="ts">
   import type { Attachment } from "../../../logic/Abstract/Attachment";
-  import type { EMail } from "../../../logic/Mail/EMail";
   import ButtonMenu from "../../Shared/Menu/ButtonMenu.svelte";
   import MenuItem from "../../Shared/Menu/MenuItem.svelte";
   import OpenIcon from "lucide-svelte/icons/external-link";
@@ -45,10 +44,6 @@
     await attachment.openOSFolder();
   }
   async function saveFile() {
-    if (!attachment.content) {
-      let email = attachment.message as EMail;
-      await email.loadAttachments();
-    }
     await attachment.saveFile();
   }
   async function deleteIt() {

--- a/app/frontend/Mail/Message/AttachmentMenu.svelte
+++ b/app/frontend/Mail/Message/AttachmentMenu.svelte
@@ -27,6 +27,7 @@
 
 <script lang="ts">
   import type { Attachment } from "../../../logic/Abstract/Attachment";
+  import type { EMail } from "../../../logic/Mail/EMail";
   import ButtonMenu from "../../Shared/Menu/ButtonMenu.svelte";
   import MenuItem from "../../Shared/Menu/MenuItem.svelte";
   import OpenIcon from "lucide-svelte/icons/external-link";
@@ -44,6 +45,10 @@
     await attachment.openOSFolder();
   }
   async function saveFile() {
+    if (!attachment.content) {
+      let email = attachment.message as EMail;
+      await email.loadAttachments();
+    }
     await attachment.saveFile();
   }
   async function deleteIt() {

--- a/app/logic/Abstract/Attachment.ts
+++ b/app/logic/Abstract/Attachment.ts
@@ -1,5 +1,6 @@
 import { File as FileEntry } from "../Files/File";
 import { Message } from "./Message";
+import { EMail } from "../Mail/EMail";
 import { appGlobal } from "../app";
 import { Observable, notifyChangedProperty } from "../util/Observable";
 import { saveBlobAsFile } from "../../frontend/Util/util";
@@ -91,6 +92,12 @@ export class Attachment extends Observable {
     return this.filename.split(".").pop();
   }
 
+  async load() {
+    if (!this.content && this.message instanceof EMail) {
+      await this.message.loadAttachments();
+    }
+  }
+
   /** Open the native desktop app with this file */
   async openOSApp() {
     await openOSAppForFile(this.filepathLocal);
@@ -101,6 +108,7 @@ export class Attachment extends Observable {
     await appGlobal.remoteApp.showFileInFolder(this.filepathLocal);
   }
   async saveFile() {
+    await this.load();
     saveBlobAsFile(this.content);
   }
   async deleteFile() {

--- a/app/logic/Mail/EMail.ts
+++ b/app/logic/Mail/EMail.ts
@@ -470,9 +470,9 @@ export class EMail extends Message {
       return;
     }
     try {
-      let att = this.folder.account.contentStorage.find(store => store instanceof RawFilesAttachment); // RawFilesAttachment
-      assert(att, "Raw attachment storage not configured");
-      await att.read(this);
+      let storage = this.folder.account.contentStorage.find(store => store instanceof RawFilesAttachment);
+      assert(storage, "Raw attachment storage not configured");
+      await storage.read(this);
     } catch (ex) {
       console.error(ex);
       // fallback

--- a/app/logic/Mail/EMail.ts
+++ b/app/logic/Mail/EMail.ts
@@ -6,6 +6,7 @@ import type { Tag } from "../Abstract/Tag";
 import { DeleteStrategy, type MailAccountStorage } from "./MailAccount";
 import { PersonUID, findOrCreatePersonUID, kDummyPerson } from "../Abstract/PersonUID";
 import type { MailIdentity } from "./MailIdentity";
+import { RawFilesAttachment } from "./Store/RawFilesAttachment";
 import { EMailProcessorList, ProcessingStartOn } from "./EMailProcessor";
 import type { ExtraData } from "./ExtraData";
 import type { SMLData } from "./SML/SMLData";
@@ -469,7 +470,7 @@ export class EMail extends Message {
       return;
     }
     try {
-      let att = this.folder.account.contentStorage.find(store => (store as any).readAttachment); // RawFilesAttachment
+      let att = this.folder.account.contentStorage.find(store => store instanceof RawFilesAttachment); // RawFilesAttachment
       assert(att, "Raw attachment storage not configured");
       await att.read(this);
     } catch (ex) {


### PR DESCRIPTION
- We were using `SQLSourceEMail` to load the attachments which didn't load the content
- The content was not loaded so an empty file was saved
- Fixes #1307, #1305