### PR TITLE
TestData: FakeEvent: Use faker.date.soon instead of faker.date.future #1316

### DIFF
--- a/app/logic/testData.ts
+++ b/app/logic/testData.ts
@@ -487,7 +487,7 @@ class FakeEvent extends Event {
   }
   setTime(future: boolean) {
     this.startTime = future
-      ? faker.date.future({ years: 0.2 })
+      ? faker.date.soon({ days: 60 })
       : faker.date.recent();
     let endTimeMax = new Date(this.startTime);
     endTimeMax.setMinutes(endTimeMax.getMinutes() + 120);


### PR DESCRIPTION
- `faker.date.future()` no longer allows decimal values so 1 year is the minimum
- use `faker.date.soon()` instead for shorter timespan
- Fixes #1316 