### PR TITLE
EMail: Check for unLoaded attachments #1305

### DIFF
--- a/app/logic/Mail/EMail.ts
+++ b/app/logic/Mail/EMail.ts
@@ -478,6 +478,8 @@ export class EMail extends Message {
       // fallback
       await this.loadMIME();
     }
+    let unLoaded = this.attachments.filterOnce(a => !a.content).map(a => a.filename);
+    assert(!unLoaded.hasItems, `Error loading attachments: ${unLoaded.join(", ")}`);
   }
 
   async loadBody() {


### PR DESCRIPTION
- Check for unloaded attachments after failing to load `.content` from `RawAttachmentsStorage` and `parseMIME`
- Mentioned in https://github.com/mustang-im/mustang/issues/1305#issuecomment-4860779778