### PR TITLE
Startup: Always call `account.login` in case account is RESTful

### DIFF
--- a/app/logic/startup.ts
+++ b/app/logic/startup.ts
@@ -85,9 +85,7 @@ export function loginOnStartup(startupErrorCallback: (ex: Error) => void): void 
   for (let account of allAccounts) {
     if (account.loginOnStartup && !account.isDependentAccount) {
       (async () => {
-        if (!account.isLoggedIn) {
-          await account.login(false);
-        }
+        await account.login(false);
         await account.startup();
       })().catch(errorWithAccountName(account, startupErrorCallback));
     }


### PR DESCRIPTION
As per https://github.com/mustang-im/mustang/pull/1292#issuecomment-4861013957, for ActiveSync, that includes checking the protocol version (#1312).