### PR TITLE
Shared: AccountDropDown: Don't show picker if it is disabled

### DIFF
--- a/app/frontend/Shared/AccountDropDown.svelte
+++ b/app/frontend/Shared/AccountDropDown.svelte
@@ -78,6 +78,9 @@
 
   let selectE: HTMLSelectElement;
   function onIconClick() {
+    if (disabled) {
+      return;
+    }
     selectE.showPicker();
   }
 


### PR DESCRIPTION
- Fixes
```
InvalidStateError: Failed to execute 'showPicker' on 'HTMLSelectElement': showPicker() cannot be used on immutable controls.
    at onIconClick (AccountDropDown.svelte:89:2)
    at HTMLDivElement.myOnClick (Clickable.svelte:34:5)
```

- The picker was still being shown even `AccountDropDown` is disabled