### PR TITLE
Files: FileRightPane: Null-check file.account when previewing a parentless file entry #1337

### DIFF
--- a/app/frontend/Files/RightSidePane/FileRightPane.svelte
+++ b/app/frontend/Files/RightSidePane/FileRightPane.svelte
@@ -45,7 +45,7 @@
         onClick={() => openFileInCloudApp(file)}
         icon={OpenCloudIcon}
         label={$t`Open with a cloud app on the web`}
-        disabled={!editors || editors.isEmpty ? $t`${file.account.name} does not offer a cloud app for this file type` : null}
+        disabled={!editors || editors.isEmpty ? $t`${file.account?.name} does not offer a cloud app for this file type` : null}
         iconSize="20px"
         padding="6px"
         classes="secondary"


### PR DESCRIPTION
Opening a Persons-tab file entry in the preview pane crashes with `TypeError: Cannot read properties of undefined (reading 'name')` in `FileRightPane.svelte`.

`Attachment.asFileEntry()` builds a `File` without a `parent`, and `File.account` is `get account() { return this.parent?.account; }`, so `account` is `undefined` for these entries. The "Open with a cloud app" button label then reads `file.account.name` unconditionally and throws when no cloud editor is available.

Guard the access with `file.account?.name`, matching the optional-chaining already used for `account` elsewhere (e.g. `SearchCriteria.svelte`, `AccountList.svelte`).

Fixes #1337
