### PR TITLE
JMAP: Calendar: Set event description: = not == #1323

### DIFF
--- a/app/logic/Calendar/JMAP/JSCalendarEvent.ts
+++ b/app/logic/Calendar/JMAP/JSCalendarEvent.ts
@@ -109,10 +109,10 @@ export class JSCalendarEvent {
     // Text
     jmap.title = event.title;
     if (event.hasHTML) {
-      jmap.descriptionContentType == "text/html";
+      jmap.descriptionContentType = "text/html";
       jmap.description = event.descriptionHTML;
     } else {
-      jmap.descriptionContentType == "text/plain";
+      jmap.descriptionContentType = "text/plain";
       jmap.description = event.descriptionText;
     }
 


### PR DESCRIPTION
- JMAP: Calendar: Set event description instead of doing a comparison
- Fixes #1323 