### PR TITLE
Calendar: Send online meeting link in server-generated invitations - fixed #1347

### DIFF
--- a/app/logic/Calendar/ActiveSync/ActiveSyncEvent.ts
+++ b/app/logic/Calendar/ActiveSync/ActiveSyncEvent.ts
@@ -86,10 +86,10 @@ export class ActiveSyncEvent extends ExchangeEvent {
     }
     this.alarm = wbxmljs.Reminder ? new Date(this.startTime.getTime() - k1MinuteMS * sanitize.integer(wbxmljs.Reminder)) : null;
     if (wbxmljs.EnhancedLocation != undefined) {
-      this.location = sanitize.nonemptystring(wbxmljs.EnhancedLocation.DisplayName, "");
+      this.setLocationFromServer(sanitize.nonemptystring(wbxmljs.EnhancedLocation.DisplayName, ""));
     }
     if (wbxmljs.Location != undefined) {
-      this.location = sanitize.nonemptystring(wbxmljs.Location, "");
+      this.setLocationFromServer(sanitize.nonemptystring(wbxmljs.Location, ""));
     }
     if (wbxmljs.MeetingStatus) {
       this.isCancelled = (sanitize.integer(wbxmljs.MeetingStatus, 0) & 4) !== 0;
@@ -146,7 +146,7 @@ export class ActiveSyncEvent extends ExchangeEvent {
       // Attendee is guaranteed in ActiveSync 16.1 and Timezone is in 14.x.
       AllDayEvent: this.allDay ? "1" : "0",
       EndTime: toCompact(this.endTime, version16_1 && this.allDay),
-      Location: version16_1 ? [] : this.location || {}, // Allows exception to have no location
+      Location: version16_1 ? [] : this.locationForServer || {}, // Allows exception to have no location
       Reminder: this.alarm ? String((this.alarm.getTime() - this.startTime.getTime()) / -k1MinuteMS | 0) : version16_1 ? {} : [],
       StartTime: toCompact(this.startTime, version16_1 && this.allDay),
       UID: !version16_1 && !this.parentEvent && this.calUID || [],
@@ -164,7 +164,7 @@ export class ActiveSyncEvent extends ExchangeEvent {
       Subject: this.title,
       // These fields are in code page 17.
       Body: this.rawHTMLDangerous ? { Type: "2", Data: this.rawHTMLDangerous } : { Type: "1", Data: [this.descriptionText ?? ""] },
-      EnhancedLocation: version16_1 ? { DisplayName: this.location || [] } : [],
+      EnhancedLocation: version16_1 ? { DisplayName: this.locationForServer || [] } : [],
     };
   }
 

--- a/app/logic/Calendar/ActiveSync/ActiveSyncEvent.ts
+++ b/app/logic/Calendar/ActiveSync/ActiveSyncEvent.ts
@@ -146,7 +146,7 @@ export class ActiveSyncEvent extends ExchangeEvent {
       // Attendee is guaranteed in ActiveSync 16.1 and Timezone is in 14.x.
       AllDayEvent: this.allDay ? "1" : "0",
       EndTime: toCompact(this.endTime, version16_1 && this.allDay),
-      Location: version16_1 ? [] : this.locationForServer || {}, // Allows exception to have no location
+      Location: version16_1 ? [] : this.getLocationForServer() || {}, // Allows exception to have no location
       Reminder: this.alarm ? String((this.alarm.getTime() - this.startTime.getTime()) / -k1MinuteMS | 0) : version16_1 ? {} : [],
       StartTime: toCompact(this.startTime, version16_1 && this.allDay),
       UID: !version16_1 && !this.parentEvent && this.calUID || [],
@@ -164,7 +164,7 @@ export class ActiveSyncEvent extends ExchangeEvent {
       Subject: this.title,
       // These fields are in code page 17.
       Body: this.rawHTMLDangerous ? { Type: "2", Data: this.rawHTMLDangerous } : { Type: "1", Data: [this.descriptionText ?? ""] },
-      EnhancedLocation: version16_1 ? { DisplayName: this.locationForServer || [] } : [],
+      EnhancedLocation: version16_1 ? { DisplayName: this.getLocationForServer() || [] } : [],
     };
   }
 

--- a/app/logic/Calendar/EWS/EWSEvent.ts
+++ b/app/logic/Calendar/EWS/EWSEvent.ts
@@ -100,7 +100,7 @@ export class EWSEvent extends ExchangeEvent {
     } else {
       this.alarm = null;
     }
-    this.location = sanitize.nonemptystring(xmljs.Location, "");
+    this.setLocationFromServer(sanitize.nonemptystring(xmljs.Location, ""));
     this.isCancelled = sanitize.boolean(xmljs.IsCancelled, false);
     let organizer: string | undefined;
     let participants: Participant[] = [];
@@ -192,7 +192,7 @@ export class EWSEvent extends ExchangeEvent {
     request.addField("CalendarItem", "Start", this.dateString(this.startTime), "calendar:Start");
     request.addField("CalendarItem", "End", this.dateString(this.endTime), "calendar:End");
     request.addField("CalendarItem", "IsAllDayEvent", this.allDay, "calendar:IsAllDayEvent");
-    request.addField("CalendarItem", "Location", this.location, "calendar:Location");
+    request.addField("CalendarItem", "Location", this.locationForServer, "calendar:Location");
     request.addField("CalendarItem", "RequiredAttendees", this.participants.hasItems ? {
       t$Attendee: this.participants.contents.map(entry => ({
         t$Mailbox: {

--- a/app/logic/Calendar/EWS/EWSEvent.ts
+++ b/app/logic/Calendar/EWS/EWSEvent.ts
@@ -192,7 +192,7 @@ export class EWSEvent extends ExchangeEvent {
     request.addField("CalendarItem", "Start", this.dateString(this.startTime), "calendar:Start");
     request.addField("CalendarItem", "End", this.dateString(this.endTime), "calendar:End");
     request.addField("CalendarItem", "IsAllDayEvent", this.allDay, "calendar:IsAllDayEvent");
-    request.addField("CalendarItem", "Location", this.locationForServer, "calendar:Location");
+    request.addField("CalendarItem", "Location", this.getLocationForServer(), "calendar:Location");
     request.addField("CalendarItem", "RequiredAttendees", this.participants.hasItems ? {
       t$Attendee: this.participants.contents.map(entry => ({
         t$Mailbox: {

--- a/app/logic/Calendar/Event.ts
+++ b/app/logic/Calendar/Event.ts
@@ -521,6 +521,29 @@ export class Event extends Observable {
     this.onlineMeetingURL = await this.createOnlineMeetingWithAccount.createMeetingURL();
   }
 
+  /** For backends that have only a single location field and no dedicated field
+   * for the online meeting URL (Exchange, ActiveSync): put the URL in the
+   * location, like other clients do and like we do in iCal for backwards compat.
+   * Otherwise the server-generated invitation wouldn't contain the URL at all.
+   * @see getICal() @see setLocationFromServer() the inverse */
+  get locationForServer(): string {
+    return this.location || this.isOnline && this.onlineMeetingURL || "";
+  }
+
+  /** Inverse of `locationForServer`: If the location that the server gave us is
+   * actually the online meeting URL, move it to `onlineMeetingURL`.
+   * @see ICalToEvent, which does the same for other clients */
+  setLocationFromServer(location: string | null): void {
+    this.location = location || "";
+    if (!this.onlineMeetingURL && this.location.startsWith("https://")) {
+      this.isOnline = true;
+      this.onlineMeetingURL = sanitize.url(this.location, null);
+    }
+    if (this.location == this.onlineMeetingURL) {
+      this.location = "";
+    }
+  }
+
   /** Call this whenever the master changes */
   generateRecurringInstances(endDate?: Date) {
     assert(this.recurrenceCase == RecurrenceCase.Master, "Only for master");

--- a/app/logic/Calendar/Event.ts
+++ b/app/logic/Calendar/Event.ts
@@ -522,24 +522,22 @@ export class Event extends Observable {
   }
 
   /** For backends that have only a single location field and no dedicated field
-   * for the online meeting URL (Exchange, ActiveSync): put the URL in the
-   * location, like other clients do and like we do in iCal for backwards compat.
-   * Otherwise the server-generated invitation wouldn't contain the URL at all.
-   * @see getICal() @see setLocationFromServer() the inverse */
-  get locationForServer(): string {
+   * for the online meeting URL, put the URL in the location, like other clients do.
+   * @see setLocationFromServer() the inverse */
+  getLocationForServer(): string {
     return this.location || this.isOnline && this.onlineMeetingURL || "";
   }
 
-  /** Inverse of `locationForServer`: If the location that the server gave us is
-   * actually the online meeting URL, move it to `onlineMeetingURL`.
-   * @see ICalToEvent, which does the same for other clients */
+  /** If the location is actually the online meeting URL,
+   * move it to `onlineMeetingURL`.
+   * @see getLocationForServer() for the inverse */
   setLocationFromServer(location: string | null): void {
     this.location = location || "";
     if (!this.onlineMeetingURL && this.location.startsWith("https://")) {
       this.isOnline = true;
       this.onlineMeetingURL = sanitize.url(this.location, null);
     }
-    if (this.location == this.onlineMeetingURL) {
+    if (this.location == this.onlineMeetingURL) { // Our own backwards compat code for online meeting URL
       this.location = "";
     }
   }

--- a/app/logic/Calendar/ICal/ICalGenerator.ts
+++ b/app/logic/Calendar/ICal/ICalGenerator.ts
@@ -22,16 +22,13 @@ export function getICal(event: Event, method?: iCalMethod): string | null {
   if (event.title) {
     lines.push(["SUMMARY", event.title]);
   }
-  if (event.location) {
-    lines.push(["LOCATION", event.location]);
+  if (event.locationForServer) {
+    lines.push(["LOCATION", event.locationForServer]);
   }
   if (event.isOnline && event.onlineMeetingURL) {
     // <https://www.rfc-editor.org/rfc/rfc7986#section-5.11>
+    // `locationForServer` already put the URL in `LOCATION` for clients that don't know `CONFERENCE`
     lines.push(["CONFERENCE", event.onlineMeetingURL]);
-    if (!event.location) {
-      // Backwards compat, because other clients don't know `CONFERENCE`
-      lines.push(["LOCATION", event.onlineMeetingURL]);
-    }
     // Maybe also add to the end of descriptionText and HTML?
     // if (!event.descriptionHTML.includes(event.onlineMeetingURL)) { ...
   }

--- a/app/logic/Calendar/ICal/ICalGenerator.ts
+++ b/app/logic/Calendar/ICal/ICalGenerator.ts
@@ -22,8 +22,8 @@ export function getICal(event: Event, method?: iCalMethod): string | null {
   if (event.title) {
     lines.push(["SUMMARY", event.title]);
   }
-  if (event.locationForServer) {
-    lines.push(["LOCATION", event.locationForServer]);
+  if (event.getLocationForServer()) {
+    lines.push(["LOCATION", event.getLocationForServer()]);
   }
   if (event.isOnline && event.onlineMeetingURL) {
     // <https://www.rfc-editor.org/rfc/rfc7986#section-5.11>

--- a/app/logic/Calendar/ICal/ICalToEvent.ts
+++ b/app/logic/Calendar/ICal/ICalToEvent.ts
@@ -113,14 +113,8 @@ export function convertICalContainerToEvent(vevent: ICalContainer, event: Event)
     event.onlineMeetingURL = vevent.entries.conference[0].value;
   }
   if (vevent.entries.location) {
-    event.location = vevent.entries.location[0].value;
-    if (!event.onlineMeetingURL && event.location.startsWith("https://")) { // other clients may send online meeting URL in `LOCATION`
-      event.isOnline = true;
-      event.onlineMeetingURL = sanitize.url(event.location, null);
-    }
-    if (event.location == event.onlineMeetingURL) { // Our own backwards compat code for online meeting URL
-      event.location = null;
-    }
+    // Some clients send the online meeting URL in `LOCATION` (see `CONFERENCE` above)
+    event.setLocationFromServer(vevent.entries.location[0].value);
   }
   if (vevent.entries.status?.[0].value == "CANCELLED") {
     event.isCancelled = true;

--- a/app/logic/Calendar/OWA/OWAEvent.ts
+++ b/app/logic/Calendar/OWA/OWAEvent.ts
@@ -204,7 +204,7 @@ export class OWAEvent extends ExchangeEvent {
     request.addField("CalendarItem", "Start", this.dateString(this.startTime), "calendar:Start");
     request.addField("CalendarItem", "End", this.dateString(this.endTime), "calendar:End");
     request.addField("CalendarItem", "IsAllDayEvent", this.allDay, "calendar:IsAllDayEvent");
-    request.addField("CalendarItem", "Location", { __type: "EnhancedLocation:#Exchange", DisplayName: this.locationForServer, PostalAddress: { __type: "PersonaPostalAddress:#Exchange", Type: "Business", LocationSource: "None", } }, "EnhancedLocation");
+    request.addField("CalendarItem", "Location", { __type: "EnhancedLocation:#Exchange", DisplayName: this.getLocationForServer(), PostalAddress: { __type: "PersonaPostalAddress:#Exchange", Type: "Business", LocationSource: "None", } }, "EnhancedLocation");
     request.addField("CalendarItem", "RequiredAttendees", this.participants.hasItems ? this.participants.contents.map(entry => ({
       __type: "AttendeeType:#Exchange",
       Mailbox: {

--- a/app/logic/Calendar/OWA/OWAEvent.ts
+++ b/app/logic/Calendar/OWA/OWAEvent.ts
@@ -95,9 +95,9 @@ export class OWAEvent extends ExchangeEvent {
     } else {
       this.alarm = null;
     }
-    this.location = sanitize.nonemptystring(json.Location?.DisplayName, "");
     this.onlineMeetingURL = sanitize.url(json.OnlineMeetingJoinUrl, null);
     this.isOnline = sanitize.boolean(json.IsOnlineMeeting, false);
+    this.setLocationFromServer(sanitize.nonemptystring(json.Location?.DisplayName, ""));
     this.isCancelled = sanitize.boolean(json.IsCancelled, false);
     let organizer: string | undefined;
     let participants: Participant[] = [];
@@ -204,7 +204,7 @@ export class OWAEvent extends ExchangeEvent {
     request.addField("CalendarItem", "Start", this.dateString(this.startTime), "calendar:Start");
     request.addField("CalendarItem", "End", this.dateString(this.endTime), "calendar:End");
     request.addField("CalendarItem", "IsAllDayEvent", this.allDay, "calendar:IsAllDayEvent");
-    request.addField("CalendarItem", "Location", { __type: "EnhancedLocation:#Exchange", DisplayName: this.location || "", PostalAddress: { __type: "PersonaPostalAddress:#Exchange", Type: "Business", LocationSource: "None", } }, "EnhancedLocation");
+    request.addField("CalendarItem", "Location", { __type: "EnhancedLocation:#Exchange", DisplayName: this.locationForServer, PostalAddress: { __type: "PersonaPostalAddress:#Exchange", Type: "Business", LocationSource: "None", } }, "EnhancedLocation");
     request.addField("CalendarItem", "RequiredAttendees", this.participants.hasItems ? this.participants.contents.map(entry => ({
       __type: "AttendeeType:#Exchange",
       Mailbox: {


### PR DESCRIPTION
Should fix #1347

Generally the right fix

Problems:
* The function names are confusing
* Maybe also use the new functions in iCal