### PR TITLE
OWA: Mail: Chunking for new mail notifications

### DIFF
--- a/app/logic/Mail/OWA/Notification/OWAExchangeNotifications.ts
+++ b/app/logic/Mail/OWA/Notification/OWAExchangeNotifications.ts
@@ -16,11 +16,17 @@ export class OWAExchangeNotifications extends OWANotifications {
       if (!stream.ok) {
         throw new Error(`stream fetch failed with HTTP ${stream.status} ${stream.statusText}`);
       }
+      const endScript = "</script>";
+      let data = "";
       for await (let chunk of stream.body) {
         // Avoid racing with ourselves, if we caused the notification.
         await new Promise(resolve => setTimeout(resolve, 100));
-        let matches = chunk.match(/<script>.*?<\/script>/g);
+        // A notification can be split across chunks,
+        // so keep the incomplete tail for the next chunk.
+        data += chunk;
+        let matches = data.match(/<script>.*?<\/script>/g);
         if (matches) {
+          data = data.slice(data.lastIndexOf(endScript) + endScript.length);
           let messages: any[] = [];
           for (let match of matches) {
             let script = match.slice(8, -9);


### PR DESCRIPTION
OWA: Mail: New mail notifications were lost when they arrived split acoss network chunks.

The stream parser only matched complete <script> blocks within a single chunk. Chunk boundaries are arbitrary, so a notification split across two chunks matched in neither and was silently dropped - the new mail did not appear until the next notification or a manual refresh. Buffer the incomplete tail, like the EWS notification stream does.

Please adopt the PR. Feel free to modify it as you see fit.