### PR TITLE
ActiveSync: Fix deleting remainder of series

### DIFF
--- a/app/logic/Calendar/ActiveSync/ActiveSyncEvent.ts
+++ b/app/logic/Calendar/ActiveSync/ActiveSyncEvent.ts
@@ -291,6 +291,7 @@ export class ActiveSyncEvent extends ExchangeEvent {
         [exceptionField]: toCompact(event.recurrenceStartTime, this.calendar.account.protocolVersion == "16.1" && this.allDay),
       },
     }))));
+    await super.makeExclusions(exclusions);
   }
 
   async respondToInvitation(response: InvitationResponseInMessage): Promise<void> {


### PR DESCRIPTION
Steps to reproduce problem:
1. Create a recurring event
2. Create an exception as the, say, tenth occurrence
3. Try to delete all occurrences starting at, say, the fifth occurrence

Expected result: Five occurrences remain: 1, 2, 3, 4, 10.

Actual result: Ten occurrences remain, but this changes to 5 if the event happens to synchronise from the server.