### PR TITLE
CI: Linux: Run apt-get update before installing libarchive-tools

### DIFF
--- a/.github/workflows/installer-linux-parula.yml
+++ b/.github/workflows/installer-linux-parula.yml
@@ -26,7 +26,9 @@ jobs:
       with:
         # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
         node-version: 24.x
-    - run: sudo apt-get -y install libarchive-tools
+    - run: |
+        sudo apt-get update
+        sudo apt-get -y install libarchive-tools
 
     - run: cd app/build; bash parula-brand.sh
     - run: cd app; yarn install

--- a/.github/workflows/installer-linux.yml
+++ b/.github/workflows/installer-linux.yml
@@ -26,7 +26,9 @@ jobs:
       with:
         # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
         node-version: 24.x
-    - run: sudo apt-get -y install libarchive-tools
+    - run: |
+        sudo apt-get update
+        sudo apt-get -y install libarchive-tools
 
     - run: cd app/build; sh mustang-brand.sh
     - run: cd app; yarn install

--- a/.github/workflows/installer-linuxarm-parula.yml
+++ b/.github/workflows/installer-linuxarm-parula.yml
@@ -34,7 +34,9 @@ jobs:
       with:
         # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
         node-version: 24.x
-    - run: sudo apt-get -y install libarchive-tools
+    - run: |
+        sudo apt-get update
+        sudo apt-get -y install libarchive-tools
 
     - run: cd app/build; bash fix-installer-filenames.sh
     - run: cd app/build; bash parula-brand.sh

--- a/.github/workflows/installer-linuxarm.yml
+++ b/.github/workflows/installer-linuxarm.yml
@@ -34,7 +34,9 @@ jobs:
       with:
         # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
         node-version: 24.x
-    - run: sudo apt-get -y install libarchive-tools
+    - run: |
+        sudo apt-get update
+        sudo apt-get -y install libarchive-tools
 
     - run: cd app/build; bash fix-installer-filenames.sh
     - run: cd app/build; sh mustang-brand.sh


### PR DESCRIPTION
- Run apt-get update before installing libarchive-tools
- The workflow was installing from an outdated package list
- Fixes: https://github.com/mustang-im/mustang/actions/runs/30784999896/job/91600093714
- Successful run: https://github.com/mustang-im/mustang/actions/runs/30839644276/job/91773294583