### PR TITLE
Shared: HTMLEditor: Display inline images as block level element #1180

### DIFF
--- a/app/frontend/Shared/Editor/HTMLEditor.svelte
+++ b/app/frontend/Shared/Editor/HTMLEditor.svelte
@@ -54,7 +54,7 @@
         Footer,
         ImageResize.configure({
           allowBase64: true,
-          inline: true,
+          inline: false,
           HTMLAttributes: {
             style: "max-width: 90%; height: auto; margin: 10px;"
           },


### PR DESCRIPTION
- The `inline` was set to true therefore the it was an inline level element and it make all text typed on the right
- Fixes #1180 