### PR TITLE
Build: Mac: Explicitly set the ZIP target for macOS #1374

### DIFF
--- a/desktop/electron-builder.yml
+++ b/desktop/electron-builder.yml
@@ -35,6 +35,9 @@ mac:
     - target: dmg
       arch:
         - universal
+    - target: zip
+      arch:
+        - universal
     # Requires CSC_INSTALLER_LINK and CSC_INSTALLER_KEY_PASSWORD secrets on GitHub CI
     # pkg is intentionally arm only
     - target: pkg


### PR DESCRIPTION
- Explicitly set the ZIP target for macOS
- We need to explicitly set the ZIP target now because the PKG target was added
- The ZIP target is the distribution that is downloaded for updates
- Fixes #1374 
- For regression #1369 