### PR TITLE
Router: selectedApp: Compare the correct location URL #1359

### DIFF
--- a/app/frontend/AppsBar/selectedApp.ts
+++ b/app/frontend/AppsBar/selectedApp.ts
@@ -25,8 +25,9 @@ export function openApp(app: MustangApp, params: PageParams) {
 }
 
 export function goTo(pageURL: string, params: PageParams) {
-  let replace = pageURL == window.location.hash;
-  console.log("Go to", pageURL, replace ? "replace" : "", "from", window.location.hash, "with params", params);
+  let location = window.location.hash.slice(1);
+  let replace = pageURL == location;
+  console.log("Go to", pageURL, replace ? "replace" : "", "from", location, "with params", params);
   history.navigate(pageURL, {
     replace,
     state: addParams(params),


### PR DESCRIPTION
- `window.location.hash` included the `#` at the start while `pageURL` did not which meant replace was never `true`
- The location history was never replaced only pushed.
- Fixes #1359 