### PR TITLE
EWS: NTLM: Move requests back to the backend

### DIFF
--- a/app/logic/Mail/EWS/EWSAccount.ts
+++ b/app/logic/Mail/EWS/EWSAccount.ts
@@ -340,12 +340,16 @@ export class EWSAccount extends ExchangeMailAccount implements EWSSubscribable {
 
     let response: any;
     try {
-      response = await fetch(this.url, this.createRequestOptions({ authorizationHeader: options?.authorizationHeader, body: this.request2XML(aRequest) }));
+      if (this.authMethod == AuthMethod.NTLM) {
+        response = await appGlobal.remoteApp.netRequest(this.url, this.createRequestOptions({ body: this.request2XML(aRequest) }), this.webSessionID, this.username, this.password);
+      } else {
+        response = await fetch(this.url, this.createRequestOptions({ authorizationHeader: options?.authorizationHeader, body: this.request2XML(aRequest) }));
+      }
     } finally {
       lock.release();
     }
     try {
-      response.responseText = await response.text();
+      response.responseText ??= await response.text();
     } catch (ex) {
       response.responseText = "";
     }
@@ -368,16 +372,13 @@ export class EWSAccount extends ExchangeMailAccount implements EWSSubscribable {
         options.isRepeating = true;
         return await this.callEWS(aRequest, options); // repeat the call
       }
-      if (options?.isRepeating) {
+      if (options?.isRepeating || this.authMethod == AuthMethod.NTLM) {
         let ex = new EWSError(response, aRequest);
         throw new LoginError(ex, gt`Login failed`);
       } else if (this.oAuth2) {
         await this.oAuth2.reset();
         await this.oAuth2.login(false); // will throw error, if interactive login is needed
         return repeat();
-      } else if (this.authMethod == AuthMethod.NTLM) {
-        let authorizationHeader = await this.loginWithNTLM();
-        return repeat({ authorizationHeader });
       } else if (this.authMethod == AuthMethod.Password) {
         assert(/\bBasic\b/.test(response.headers.get("WWW-Authenticate")), gt`Your account is configured to use ${gt`Password`} authentication, but your server does not support it. Please change your account settings or set up the account again.`);
         throw this.fatalError = new LoginError(null, gt`Password incorrect`);
@@ -413,6 +414,7 @@ export class EWSAccount extends ExchangeMailAccount implements EWSSubscribable {
         let data = "";
         let response = await fetch(this.url, this.createRequestOptions({ body, signal }));
         if (this.authMethod == AuthMethod.NTLM && response.status == 401) {
+          console.log("(two initial 401s expected during callStream's NTLM login)");
           let authorizationHeader = await this.loginWithNTLM();
           response = await fetch(this.url, this.createRequestOptions({ authorizationHeader, body, signal })); // Repeat the call
         }

--- a/desktop/backend/backend.ts
+++ b/desktop/backend/backend.ts
@@ -8,7 +8,8 @@ import { ImapFlow } from 'imapflow';
 import { Database } from "@radically-straightforward/sqlite"; // formerly @leafac/sqlite
 import Zip from "adm-zip";
 import ky from 'ky';
-import { shell, nativeTheme, Notification, Tray, nativeImage, app, BrowserWindow, webContents, Menu, MenuItemConstructorOptions, clipboard, NativeImage, session, desktopCapturer, type DesktopCapturerSource, autoUpdater, systemPreferences, powerMonitor } from "electron";
+import { net as Net, shell, nativeTheme, Notification, Tray, nativeImage, app, BrowserWindow, webContents, Menu, MenuItemConstructorOptions, clipboard, NativeImage, session, desktopCapturer, type DesktopCapturerSource, autoUpdater, systemPreferences, powerMonitor } from "electron";
+import { Readable } from "stream";
 import electronUpdater, { type UpdateCheckResult } from 'electron-updater';
 import nodemailer from 'nodemailer';
 import MailComposer from 'nodemailer/lib/mail-composer';
@@ -55,6 +56,7 @@ export function createJPCSecret(): string {
 async function createSharedAppObject() {
   return {
     kyCreate,
+    netRequest,
     OWA,
     newOSNotification,
     isOSNotificationSupported,
@@ -248,6 +250,45 @@ export class HTTPFetchError extends Error {
       }
     }
   }
+}
+
+function netRequest(url, options, partition, username, password) {
+  let triedAuth = false;
+  let body = options.body;
+  delete options.body;
+  options.url = url;
+  options.partition = partition;
+  options.credentials = 'include';
+  return new Promise((resolve, reject) => {
+    let request = Net.request(options);
+    request.on('response', message => {
+      if ([101, 204, 205, 304].includes(message.statusCode)) {
+        resolve({
+          ok: (message.statusCode >= 200 && message.statusCode <= 299),
+          status: message.statusCode,
+          statusText: message.statusMessage,
+          responseText: '',
+        });
+      } else {
+        new Response(Readable.toWeb(message)).text().then(text => resolve({
+          ok: (message.statusCode >= 200 && message.statusCode <= 299),
+          status: message.statusCode,
+          statusText: message.statusMessage,
+          responseText: text,
+        })).catch(reject);
+      }
+    });
+    request.on('login', (authInfo, callback) => {
+      if (triedAuth || authInfo.isProxy) {
+        callback();
+      } else {
+        triedAuth = true;
+        callback(username, password);
+      }
+    });
+    request.on('error', reject);
+    request.end(body);
+  });
 }
 
 function newHTTPServer() {


### PR DESCRIPTION
Electron's `net.request` can actually perform partitioned NTLM login. In particular, I can set up an account on a server, and try to set up a second account on the same server with a bogus username and password, and this will fail, although the first account is still performing EWS requests successfully.

Streaming notifications are not currently included in these changes. I would have to work out how to do streaming with `net.request`, and I can't test multiple streams (by default there is only one stream per account and so our existing NTLM will always succeed, although the developer console will log two HTTP 401 errors as it authenticates).

Annoyingly `net` is already imported from `node:net` as the default import (which here is equivalent to `*`) when possibly it should have been `import { Socket } from "node:net";` so I had to rename electron's `net`.