### PR TITLE
NTLM: NetSession: Fix race condition creating conn

### DIFF
--- a/app/logic/Auth/NTLM/NTLMChromiumSession.ts
+++ b/app/logic/Auth/NTLM/NTLMChromiumSession.ts
@@ -16,29 +16,24 @@ import { appGlobal } from "../../app";
  */
 export class NTLMChromiumSession {
   protected readonly account: EWSAccount;
-  /** Only for a dedicated connection @see `newDedicatedConnection()` */
-  protected readonly streamID: string | null;
-  /** Backend `NetSession` (via JPC) */
-  protected conn: any = null;
+  /** Backend `NetSession` (via JPC).
+   * Keep the Promise here to avoid race conditions initialising it. */
+  protected conn: Promise<any>;
 
   constructor(account: EWSAccount, streamID: string | null = null) {
     this.account = account;
-    this.streamID = streamID;
-  }
-
-  /** Cookies, HTTP auth state, and the pool of 6 TCP connections are
-   * per partition, which isolates the accounts and streams from each other. */
-  protected get partition(): string {
-    let accountPartition = this.account.webSessionID ?? "ntlm-setup";
-    return this.streamID == null
-      ? accountPartition
-      : `${accountPartition}:stream:${this.streamID}`;
+    /** Cookies, HTTP auth state, and the pool of 6 TCP connections are per
+     * partition, which isolates the accounts and streams from each other. */
+    let partition = this.account.webSessionID ?? "ntlm-setup";
+    if (streamID) {
+      partition = `${partition}:stream:${streamID}`;
+    }
+    this.conn = appGlobal.remoteApp.newNetSession(this.account.url,
+      partition, this.account.username, this.account.password);
   }
 
   async request(body: string, options: NTLMRequestOptions = {}): Promise<NTLMResponse> {
-    this.conn ??= await appGlobal.remoteApp.newNetSession(this.account.url,
-      this.partition, this.account.username, this.account.password);
-    let response = await this.conn.request({ headers: options.headers, body }, options.onChunk);
+    let response = await (await this.conn).request({ headers: options.headers, body }, options.onChunk);
     return new NTLMResponse(response);
   }
 

--- a/app/logic/Auth/NTLM/NTLMChromiumSession.ts
+++ b/app/logic/Auth/NTLM/NTLMChromiumSession.ts
@@ -1,5 +1,6 @@
 import { NTLMResponse, type NTLMRequestOptions } from "./NTLMResponse";
 import type { EWSAccount } from "../../Mail/EWS/EWSAccount";
+import { RunOnce } from "../../util/flow/RunOnce";
 import { appGlobal } from "../../app";
 
 /**
@@ -16,24 +17,30 @@ import { appGlobal } from "../../app";
  */
 export class NTLMChromiumSession {
   protected readonly account: EWSAccount;
-  /** Backend `NetSession` (via JPC).
-   * Keep the Promise here to avoid race conditions initialising it. */
-  protected conn: Promise<any>;
+  /** Cookies, HTTP auth state, and the pool of 6 TCP connections are per
+   * partition, which isolates the accounts and streams from each other. */
+  protected partition: string;
+  /** Backend `NetSession` (via JPC) */
+  protected conn: any = null;
+  /** Protect the initialisation of `conn` */
+  protected connRunOnce = new RunOnce();
 
   constructor(account: EWSAccount, streamID: string | null = null) {
     this.account = account;
-    /** Cookies, HTTP auth state, and the pool of 6 TCP connections are per
-     * partition, which isolates the accounts and streams from each other. */
-    let partition = this.account.webSessionID ?? "ntlm-setup";
+    this.partition = this.account.webSessionID ?? "ntlm-setup";
     if (streamID) {
-      partition = `${partition}:stream:${streamID}`;
+      this.partition = `${this.partition}:stream:${streamID}`;
     }
-    this.conn = appGlobal.remoteApp.newNetSession(this.account.url,
-      partition, this.account.username, this.account.password);
   }
 
   async request(body: string, options: NTLMRequestOptions = {}): Promise<NTLMResponse> {
-    let response = await (await this.conn).request({ headers: options.headers, body }, options.onChunk);
+    if (!this.conn) {
+      await this.connRunOnce.runOnce(async () => {
+        this.conn = await appGlobal.remoteApp.newNetSession(this.account.url,
+          this.partition, this.account.username, this.account.password);
+      });
+    }
+    let response = await this.conn.request({ headers: options.headers, body }, options.onChunk);
     return new NTLMResponse(response);
   }
 


### PR DESCRIPTION
Two instances of `callEWS` can invoke `NTLMChromiumSession.request` simultaneously on a new `NTLMChromiumSession` object. Since `request` tries to create `conn` lazily, both invocations try to initialise `conn`. Instead, make `conn` a `Promise` to the `NetSession` object and definitely initialise the `Promise` once in the constructor, `await`ing it in `request` as necessary.

Because the creation of the `NetSession` object is asynchronous, the second invocation will see `conn` is still `null` because the first invocation hasn't assigned it yet, and it ends up creating a second `NetSession` object. Currently the only possible practical upshot seems to be limited to requests that are still pending on the first `NetSession` object as they can't be properly closed by the second `NetSession` object.

While I was here I folded the `partition` getter into the constructor as `partition` is only needed to create the `NetSession` object.