### PR TITLE
Backend: Use Node stream consumers to consume Node streams

### DIFF
--- a/desktop/backend/httpBody.ts
+++ b/desktop/backend/httpBody.ts
@@ -1,3 +1,5 @@
+import { text } from 'node:stream/consumers';
+
 /**
  * Reads a HTTP response body as UTF-8 text.
  * Shared by our HTTP clients `HTTPConnection` and `NetSession`.
@@ -9,14 +11,10 @@
  */
 export async function readBodyText(stream: AsyncIterable<any>,
     onChunk?: (chunk: string) => Promise<void>): Promise<string> {
-  let decoder = new TextDecoder(); // EWS and friends are always UTF-8
   if (!onChunk) {
-    let chunks: Buffer[] = [];
-    for await (let chunk of stream) {
-      chunks.push(chunk);
-    }
-    return decoder.decode(Buffer.concat(chunks));
+    return await text(stream); // EWS and friends are always UTF-8
   }
+  let decoder = new TextDecoder(); // EWS and friends are always UTF-8
   for await (let chunk of stream) {
     let text = decoder.decode(chunk, { stream: true });
     if (text) {

--- a/desktop/backend/httpBody.ts
+++ b/desktop/backend/httpBody.ts
@@ -1,4 +1,4 @@
-import { text } from 'node:stream/consumers';
+import { text as textFromStream } from 'node:stream/consumers';
 
 /**
  * Reads a HTTP response body as UTF-8 text.
@@ -12,7 +12,7 @@ import { text } from 'node:stream/consumers';
 export async function readBodyText(stream: AsyncIterable<any>,
     onChunk?: (chunk: string) => Promise<void>): Promise<string> {
   if (!onChunk) {
-    return await text(stream); // EWS and friends are always UTF-8
+    return await textFromStream(stream); // EWS and friends are always UTF-8
   }
   let decoder = new TextDecoder(); // EWS and friends are always UTF-8
   for await (let chunk of stream) {

--- a/desktop/backend/owa.ts
+++ b/desktop/backend/owa.ts
@@ -1,5 +1,5 @@
-import { session as Session, BrowserWindow, net as Net } from "electron";
-import { Readable } from 'stream';
+import { session as Session, net as Net } from "electron";
+import { text } from 'node:stream/consumers';
 
 const kCanaryName = "X-OWA-CANARY";
 const kHotmailServer = "outlook.live.com";
@@ -118,7 +118,7 @@ export async function fetchText(partition: string, url: string, data?: Dict<stri
           url: url,
         });
       } else {
-        new Response(Readable.toWeb(message)).text().then(text => resolve({
+        text(message).then(text => resolve({
           ok: (message.statusCode >= 200 && message.statusCode <= 299),
           status: message.statusCode,
           statusText: message.statusMessage,

--- a/desktop/backend/owa.ts
+++ b/desktop/backend/owa.ts
@@ -1,5 +1,5 @@
 import { session as Session, net as Net } from "electron";
-import { text } from 'node:stream/consumers';
+import { text as textFromStream } from 'node:stream/consumers';
 
 const kCanaryName = "X-OWA-CANARY";
 const kHotmailServer = "outlook.live.com";
@@ -118,7 +118,7 @@ export async function fetchText(partition: string, url: string, data?: Dict<stri
           url: url,
         });
       } else {
-        text(message).then(text => resolve({
+        textFromStream(message).then(text => resolve({
           ok: (message.statusCode >= 200 && message.statusCode <= 299),
           status: message.statusCode,
           statusText: message.statusMessage,


### PR DESCRIPTION
Instead of hand-rolled loops or messing around with `toWeb`.

(Stream consumers were added in Node 16.7.0)

Note that with chunked streams we want to push chunks eagerly to the front end, so there might not be a better way than our existing hand-rolled loop.