### PR TITLE
S/MIME: .p12 import

### DIFF
--- a/app/frontend/Settings/Mail/Account/EncryptionImport.svelte
+++ b/app/frontend/Settings/Mail/Account/EncryptionImport.svelte
@@ -85,7 +85,7 @@
   import { SMIMEPrivateKey } from "../../../../logic/Mail/Encryption/SMIME/SMIMEPrivateKey";
   import { TrustLevel } from "../../../../logic/Mail/Encryption/enums";
   import { MailIdentity } from "../../../../logic/Mail/MailIdentity";
-  import { importPrivateKey } from "../../../../logic/Mail/Encryption/KeyUtils";
+  import { importPrivateKey, readKeyFile } from "../../../../logic/Mail/Encryption/KeyUtils";
   import FileSelector from "../../../Mail/Composer/Attachments/FileSelector.svelte";
   import Menu from "../../../Shared/Menu/Menu.svelte";
   import MenuItem from "../../../Shared/Menu/MenuItem.svelte";
@@ -104,20 +104,20 @@
   export let showObsolete: boolean;
 
   let showPassword = false;
-  let passphrase: string;
+  let passphrase = "";
   async function onFilePassword() {
     await onImportFile(passphrase);
     showPassword = false;
   }
 
   let fileSelector: FileSelector;
-  const acceptFileTypes = [ "application/pgp-secret-keys", ".asc", "application/pkcs8", "application/x-pem-file", ".key", "text/plain" ];
+  const acceptFileTypes = [ "application/pgp-secret-keys", ".asc", "application/pkcs8", "application/x-pem-file", ".key", "application/x-pkcs12", ".p12", ".pfx", "text/plain" ];
   async function onImportFile(passphrase: string) {
     let file = await fileSelector.selectFile();
     if (!file) {
       return;
     }
-    let fileContent = await file.text();
+    let fileContent = await readKeyFile(file, passphrase);
     let key = await importPrivateKey(fileContent, passphrase);
     let existing = identity.encryptionPrivateKeys.find(existing => existing.id == key.id);
     if (!existing) {

--- a/app/logic/Mail/Encryption/KeyUtils.ts
+++ b/app/logic/Mail/Encryption/KeyUtils.ts
@@ -6,6 +6,7 @@ import { PGPPrivateKey } from "./PGP/PGPPrivateKey";
 import { PGPPublicKey } from "./PGP/PGPPublicKey";
 import { SMIMEPrivateKey } from "./SMIME/SMIMEPrivateKey";
 import { SMIMEPublicKey } from "./SMIME/SMIMEPublicKey";
+import { PKCS12 } from "./SMIME/PKCS12";
 import { readAutoCryptKeys } from "./PGP/AutoCrypt";
 import { EncryptionSystem } from "./enums";
 import type { EMail } from "../EMail";
@@ -70,6 +71,24 @@ export function getMyPrivateKey<T extends PublicKey & PrivateKey>(identity: Mail
   return (keys.find(key => key.encryptByDefault && key.useToSign) ??
     keys.find(key => key.useToSign) ??
     keys.first) as T | null;
+}
+
+/**
+ * Reads the key file that the user picked.
+ * .p12 files, also called .pfx, are binary and encrypted, so they are
+ * converted here into the PEM that `importPrivateKey()` reads.
+ * @returns the contents of the file, as PEM
+ */
+export async function readKeyFile(file: File, passphrase: string): Promise<string> {
+  let fileContents = new Uint8Array(await file.arrayBuffer());
+  // PEM and ASCII armor start with the "-----BEGIN " line,
+  // whereas a .p12 file starts with the ASN.1 tag for a sequence.
+  if (fileContents[0] != 0x30) {
+    return new TextDecoder().decode(fileContents);
+  }
+  let p12 = new PKCS12(passphrase);
+  await p12.read(fileContents);
+  return await p12.toPEM();
 }
 
 export async function importPrivateKey(fileContent: string, passphrase: string): Promise<PublicKey & PrivateKey> {

--- a/app/logic/Mail/Encryption/SMIME/PBES2.ts
+++ b/app/logic/Mail/Encryption/SMIME/PBES2.ts
@@ -1,0 +1,48 @@
+import { EncryptedPrivateKeyInfo, KeyDerivationAlgorithm, Null, OctetString, PBES2Params, PBKDF2Params } from "./SMIMEASN1";
+import { sanitize } from "../../../../../lib/util/sanitizeDatatypes";
+import { assert } from "../../../util/util";
+
+/**
+ * Decrypts data that is protected with a passphrase, using PBES2, RFC 8018.
+ * The passphrase is stretched with PBKDF2, and the result is used as the
+ * key for AES in CBC mode.
+ * @param parameters the parameters of the `pkcs5PBES2` algorithm identifier
+ */
+export async function decryptPBES2(data: Uint8Array, parameters: Uint8Array, passphrase: string): Promise<Uint8Array> {
+  let pbes2 = PBES2Params.decode(parameters);
+  if (pbes2.keyDerivationFunc.algorithm != "pkcs5PBKDF2") {
+    throw new Error("Unsupported private key derivation function");
+  }
+  let pbkdf2 = PBKDF2Params.decode(pbes2.keyDerivationFunc.parameters);
+  if (pbkdf2.salt.type != "specified") {
+    throw new Error("Unsupported private key derivation salt");
+  }
+  let hash = sanitize.translate(pbkdf2.prf.algorithm, KeyDerivationAlgorithm);
+  // Cap the iterations, otherwise a malicious key file would freeze the app
+  let iterations = sanitize.integerRange(Number(pbkdf2.iterationCount), 1, 10000000);
+  let derivation = { name: "PBKDF2", salt: pbkdf2.salt.value, iterations, hash };
+  let passphraseKey = await crypto.subtle.importKey("raw", new TextEncoder().encode(passphrase), "PBKDF2", false, ["deriveKey"]);
+  let iv = OctetString.decode(pbes2.encryptionScheme.parameters);
+  let length = sanitize.translate(pbes2.encryptionScheme.algorithm, { aes128cbc: 128, aes192cbc: 192, aes256cbc: 256 });
+  let key = await crypto.subtle.deriveKey(derivation, passphraseKey, { name: "AES-CBC", length }, false, ["decrypt"]);
+  return new Uint8Array(await crypto.subtle.decrypt({ name: "AES-CBC", iv }, key, data));
+}
+
+/**
+ * Encrypts a private key with a passphrase, using PBES2 with AES-256-CBC,
+ * so that we do not store the key in the clear.
+ * @param privateKey the key in PKCS#8 form
+ * @returns the encrypted key, ASCII-armored
+ */
+export async function encryptPrivateKey(privateKey: Uint8Array, passphrase: string): Promise<string> {
+  assert(passphrase, "Need a passphrase to protect the private key");
+  let salt = crypto.getRandomValues(new Uint8Array(8));
+  let iv = crypto.getRandomValues(new Uint8Array(16));
+  let passphraseKey = await crypto.subtle.importKey("raw", new TextEncoder().encode(passphrase), "PBKDF2", false, ["deriveKey"]);
+  let derivedKey = await crypto.subtle.deriveKey({ name: "PBKDF2", salt, iterations: 2048, hash: "SHA-256" }, passphraseKey, { name: "AES-CBC", length: 256 }, false, ["encrypt"]);
+  let encryptedData = new Uint8Array(await crypto.subtle.encrypt({ name: "AES-CBC", iv }, derivedKey, privateKey));
+  let pbkdf2: PBKDF2Params = { salt: { type: "specified", value: salt }, iterationCount: 2048n, prf: { algorithm: "hmacWithSHA256", parameters: Null.encode() } };
+  let pbes2 = { keyDerivationFunc: { algorithm: "pkcs5PBKDF2", parameters: PBKDF2Params.encode(pbkdf2) }, encryptionScheme: { algorithm: "aes256cbc", parameters: OctetString.encode(iv) } };
+  let encryptedKey = { encryptionAlgorithm: { algorithm: "pkcs5PBES2", parameters: PBES2Params.encode(pbes2) }, encryptedData };
+  return EncryptedPrivateKeyInfo.encodePEM(encryptedKey, { label: "ENCRYPTED PRIVATE KEY" });
+}

--- a/app/logic/Mail/Encryption/SMIME/PBES2.ts
+++ b/app/logic/Mail/Encryption/SMIME/PBES2.ts
@@ -1,11 +1,12 @@
 import { EncryptedPrivateKeyInfo, KeyDerivationAlgorithm, Null, OctetString, PBES2Params, PBKDF2Params } from "./SMIMEASN1";
+import { tripleDESDecrypt } from "./legacyCiphers";
 import { sanitize } from "../../../../../lib/util/sanitizeDatatypes";
 import { assert } from "../../../util/util";
 
 /**
  * Decrypts data that is protected with a passphrase, using PBES2, RFC 8018.
  * The passphrase is stretched with PBKDF2, and the result is used as the
- * key for AES in CBC mode.
+ * key for AES or Triple DES in CBC mode.
  * @param parameters the parameters of the `pkcs5PBES2` algorithm identifier
  */
 export async function decryptPBES2(data: Uint8Array, parameters: Uint8Array, passphrase: string): Promise<Uint8Array> {
@@ -21,8 +22,13 @@ export async function decryptPBES2(data: Uint8Array, parameters: Uint8Array, pas
   // Cap the iterations, otherwise a malicious key file would freeze the app
   let iterations = sanitize.integerRange(Number(pbkdf2.iterationCount), 1, 10000000);
   let derivation = { name: "PBKDF2", salt: pbkdf2.salt.value, iterations, hash };
-  let passphraseKey = await crypto.subtle.importKey("raw", new TextEncoder().encode(passphrase), "PBKDF2", false, ["deriveKey"]);
+  let passphraseKey = await crypto.subtle.importKey("raw", new TextEncoder().encode(passphrase), "PBKDF2", false, ["deriveBits", "deriveKey"]);
   let iv = OctetString.decode(pbes2.encryptionScheme.parameters);
+  if (pbes2.encryptionScheme.algorithm == "desEDE3CBC") {
+    // WebCrypto does not implement Triple DES
+    let key = new Uint8Array(await crypto.subtle.deriveBits(derivation, passphraseKey, 24 * 8));
+    return tripleDESDecrypt(data, key, iv);
+  }
   let length = sanitize.translate(pbes2.encryptionScheme.algorithm, { aes128cbc: 128, aes192cbc: 192, aes256cbc: 256 });
   let key = await crypto.subtle.deriveKey(derivation, passphraseKey, { name: "AES-CBC", length }, false, ["decrypt"]);
   return new Uint8Array(await crypto.subtle.decrypt({ name: "AES-CBC", iv }, key, data));

--- a/app/logic/Mail/Encryption/SMIME/PKCS12.ts
+++ b/app/logic/Mail/Encryption/SMIME/PKCS12.ts
@@ -21,10 +21,13 @@ export class PKCS12 {
    * Typically the certificate of the key, and the CAs that signed it. */
   certificates: Uint8Array[] = [];
   protected passphrase: string;
+  /** The passphrase in the form that the key derivation needs it */
+  protected passphraseBytes: Uint8Array;
 
   constructor(passphrase: string) {
     assert(typeof passphrase == "string", "Need the passphrase");
     this.passphrase = passphrase;
+    this.passphraseBytes = bmpString(passphrase);
   }
 
   /** Reads the contents of a .p12 file into `keys` and `certificates` */
@@ -66,8 +69,24 @@ export class PKCS12 {
    * This is also where a wrong passphrase shows up. */
   protected verifyMAC(macData: any, authSafe: Uint8Array) {
     let hash = sanitize.translate(macData.mac.digestAlgorithm.algorithm, kHashes);
+    if (this.macMatches(macData, authSafe, hash)) {
+      return;
+    }
+    // An empty passphrase and no passphrase at all are 2 different keys, and
+    // the file does not say which of them the app that wrote it used, so try
+    // the other one as well. This is the only place that can tell them apart.
+    if (!this.passphrase) {
+      this.passphraseBytes = kNoPassphrase;
+      if (this.macMatches(macData, authSafe, hash)) {
+        return;
+      }
+    }
+    throw new Error(gt`Wrong passphrase for this file`);
+  }
+
+  protected macMatches(macData: any, authSafe: Uint8Array, hash: Hash): boolean {
     let key = this.deriveKey(KeyPurpose.MAC, hash.outputLen, macData.macSalt, macData.iterations, hash);
-    assert(!indexedDB.cmp(hmac(hash, key, authSafe), macData.mac.digest), gt`Wrong passphrase for this file`);
+    return !indexedDB.cmp(hmac(hash, key, authSafe), macData.mac.digest);
   }
 
   /** @returns the `SafeContents` of one part of the file, decrypted if needed */
@@ -149,7 +168,7 @@ export class PKCS12 {
     let rounds = sanitize.integerRange(Number(iterations), 1, 10000000);
     let blockLength = hash.blockLen;
     let diversifier = new Uint8Array(blockLength).fill(purpose);
-    let input = concat(repeatToBlocks(salt, blockLength), repeatToBlocks(bmpString(this.passphrase), blockLength));
+    let input = concat(repeatToBlocks(salt, blockLength), repeatToBlocks(this.passphraseBytes, blockLength));
     let derived = new Uint8Array(length);
     for (let pos = 0; pos < length; pos += hash.outputLen) {
       let block = hash(concat(diversifier, input));
@@ -177,6 +196,12 @@ enum KeyPurpose {
 /** The hash functions that a .p12 file may use, by the name of their OID */
 const kHashes = { sha1, sha256, sha384, sha512 };
 type Hash = typeof sha1;
+
+/** Some apps write a file without any passphrase, rather than with an empty
+ * one, and then the passphrase is left out of the key derivation entirely.
+ * That is a different key than the one an empty passphrase gives.
+ * RFC 7292 appendix B.1 */
+const kNoPassphrase = new Uint8Array(0);
 
 /** The passphrase as PKCS#12 uses it: UTF-16, big endian, with a final null.
  * Characters outside the BMP go in as their 2 surrogates,

--- a/app/logic/Mail/Encryption/SMIME/PKCS12.ts
+++ b/app/logic/Mail/Encryption/SMIME/PKCS12.ts
@@ -1,0 +1,220 @@
+import { Any, AuthenticatedSafe, CertBag, EncryptedData, EncryptedPrivateKeyInfo, OctetString, PBEParams, PFX, SafeContents, type AlgorithmIdentifier } from "./SMIMEASN1";
+import { decryptPBES2, encryptPrivateKey } from "./PBES2";
+import { rc2Decrypt, rc4Decrypt, tripleDESDecrypt } from "./legacyCiphers";
+import { sanitize } from "../../../../../lib/util/sanitizeDatatypes";
+import { assert } from "../../../util/util";
+import { gt } from "../../../../l10n/l10n";
+import { hmac } from "@noble/hashes/hmac.js";
+import { sha1 } from "@noble/hashes/legacy.js";
+import { sha256, sha384, sha512 } from "@noble/hashes/sha2.js";
+
+/**
+ * Reads .p12 files, also called .pfx: the private key and the certificates
+ * of an S/MIME identity, protected by a passphrase. Certificate authorities
+ * deliver new certificates in this format, and other mail apps export it.
+ * RFC 7292
+ */
+export class PKCS12 {
+  /** The private keys in the file, in PKCS#8 form */
+  keys: Uint8Array[] = [];
+  /** The certificates in the file, in X.509 DER form.
+   * Typically the certificate of the key, and the CAs that signed it. */
+  certificates: Uint8Array[] = [];
+  protected passphrase: string;
+
+  constructor(passphrase: string) {
+    assert(typeof passphrase == "string", "Need the passphrase");
+    this.passphrase = passphrase;
+  }
+
+  /** Reads the contents of a .p12 file into `keys` and `certificates` */
+  async read(fileContents: Uint8Array): Promise<void> {
+    let pfx = PFX.decode(fileContents, { berToDER: true });
+    assert(pfx.authSafe.contentType == "data", gt`This file uses an unsupported format`);
+    let authSafe = OctetString.decode(pfx.authSafe.content);
+    if (pfx.macData) {
+      this.verifyMAC(pfx.macData, authSafe);
+    }
+    for (let safe of AuthenticatedSafe.decode(authSafe, { berToDER: true })) {
+      await this.readSafeContents(await this.decryptSafe(safe));
+    }
+  }
+
+  /**
+   * Converts what we read to the PEM format that our S/MIME code reads:
+   * first the private key, then the certificates. The key is encrypted
+   * again with the same passphrase, so that it is never stored in the clear.
+   * A file with an empty passphrase gives an unencrypted key, which is the
+   * form that `SMIMEPrivateKey` expects when there is no passphrase.
+   *
+   * A file with several keys is not an S/MIME identity that we could
+   * represent, so only the first key is used. All certificates are kept,
+   * because they form the chain up to the CA.
+   */
+  async toPEM(): Promise<string> {
+    assert(this.keys.length, gt`This file contains no secret key`);
+    let parts = [this.passphrase
+      ? await encryptPrivateKey(this.keys[0], this.passphrase)
+      : Any.encodePEM(this.keys[0], { label: "PRIVATE KEY" })];
+    for (let certificate of this.certificates) {
+      parts.push(Any.encodePEM(certificate, { label: "CERTIFICATE" }));
+    }
+    return parts.join("\n") + "\n";
+  }
+
+  /** Checks that the file was not modified, using the MAC over its contents.
+   * This is also where a wrong passphrase shows up. */
+  protected verifyMAC(macData: any, authSafe: Uint8Array) {
+    let hash = sanitize.translate(macData.mac.digestAlgorithm.algorithm, kHashes);
+    let key = this.deriveKey(KeyPurpose.MAC, hash.outputLen, macData.macSalt, macData.iterations, hash);
+    assert(!indexedDB.cmp(hmac(hash, key, authSafe), macData.mac.digest), gt`Wrong passphrase for this file`);
+  }
+
+  /** @returns the `SafeContents` of one part of the file, decrypted if needed */
+  protected async decryptSafe(safe: any): Promise<Uint8Array> {
+    if (safe.contentType == "data") {
+      return OctetString.decode(safe.content);
+    }
+    assert(safe.contentType == "encryptedData", gt`This file uses an unsupported format`);
+    let { encryptedContentInfo } = EncryptedData.decode(safe.content);
+    return await this.decrypt(encryptedContentInfo.contentEncryptionAlgorithm, encryptedContentInfo.encryptedContent);
+  }
+
+  protected async readSafeContents(safeContents: Uint8Array): Promise<void> {
+    for (let bag of SafeContents.decode(safeContents, { berToDER: true })) {
+      await this.readBag(bag);
+    }
+  }
+
+  /** Reads one key or certificate. Other bags, e.g. CRLs and passwords,
+   * are of no use for an S/MIME identity and are skipped. */
+  protected async readBag(bag: any): Promise<void> {
+    if (bag.bagId == "keyBag") {
+      this.keys.push(bag.bagValue);
+    } else if (bag.bagId == "pkcs8ShroudedKeyBag") {
+      let encryptedKey = EncryptedPrivateKeyInfo.decode(bag.bagValue);
+      this.keys.push(await this.decrypt(encryptedKey.encryptionAlgorithm, encryptedKey.encryptedData));
+    } else if (bag.bagId == "certBag") {
+      let certBag = CertBag.decode(bag.bagValue);
+      if (certBag.certId == "x509Certificate") {
+        this.certificates.push(certBag.certValue);
+      }
+    } else if (bag.bagId == "safeContentsBag") {
+      await this.readSafeContents(bag.bagValue);
+    }
+  }
+
+  /**
+   * Decrypts one part of the file with our passphrase.
+   * Recent files use PBES2, older ones one of the ciphers that PKCS#12
+   * defines itself. Which cipher and key length to use is part of the
+   * algorithm OID, so the parameters hold only the salt and iterations.
+   */
+  protected async decrypt(algorithm: AlgorithmIdentifier, data: Uint8Array): Promise<Uint8Array> {
+    if (algorithm.algorithm == "pkcs5PBES2") {
+      return await decryptPBES2(data, algorithm.parameters, this.passphrase);
+    }
+    let { salt, iterations } = PBEParams.decode(algorithm.parameters);
+    let derive = (purpose: KeyPurpose, length: number) =>
+      this.deriveKey(purpose, length, salt, iterations, sha1);
+    switch (algorithm.algorithm) {
+    case "pbeWithSHAAnd3KeyTripleDESCBC":
+      return tripleDESDecrypt(data, derive(KeyPurpose.Key, 24), derive(KeyPurpose.IV, 8));
+    case "pbeWithSHAAnd2KeyTripleDESCBC":
+      return tripleDESDecrypt(data, derive(KeyPurpose.Key, 16), derive(KeyPurpose.IV, 8));
+    case "pbeWithSHAAnd128BitRC2CBC":
+      return rc2Decrypt(data, derive(KeyPurpose.Key, 16), derive(KeyPurpose.IV, 8), 128);
+    case "pbeWithSHAAnd40BitRC2CBC":
+      return rc2Decrypt(data, derive(KeyPurpose.Key, 5), derive(KeyPurpose.IV, 8), 40);
+    case "pbeWithSHAAnd128BitRC4":
+      return rc4Decrypt(data, derive(KeyPurpose.Key, 16));
+    case "pbeWithSHAAnd40BitRC4":
+      return rc4Decrypt(data, derive(KeyPurpose.Key, 5));
+    default:
+      throw new Error(gt`This file uses an unsupported encryption`);
+    }
+  }
+
+  /**
+   * Turns our passphrase into a key, an IV, or a MAC key.
+   * PKCS#12 uses neither PBKDF2 nor the passphrase as-is, but its own
+   * scheme: the salt and the passphrase are repeated to fill whole hash
+   * blocks and hashed `iterations` times. If that gives fewer bytes than
+   * we need, the result is added to the input, and it is hashed again.
+   * RFC 7292 appendix B
+   * @param length how many bytes to derive
+   */
+  protected deriveKey(purpose: KeyPurpose, length: number, salt: Uint8Array, iterations: bigint, hash: Hash): Uint8Array {
+    // Cap the iterations, otherwise a malicious file would freeze the app
+    let rounds = sanitize.integerRange(Number(iterations), 1, 10000000);
+    let blockLength = hash.blockLen;
+    let diversifier = new Uint8Array(blockLength).fill(purpose);
+    let input = concat(repeatToBlocks(salt, blockLength), repeatToBlocks(bmpString(this.passphrase), blockLength));
+    let derived = new Uint8Array(length);
+    for (let pos = 0; pos < length; pos += hash.outputLen) {
+      let block = hash(concat(diversifier, input));
+      for (let round = 1; round < rounds; round++) {
+        block = hash(block);
+      }
+      derived.set(block.subarray(0, Math.min(block.length, length - pos)), pos);
+      // Add the result, plus 1, to each block of the input, for the next round
+      let addend = repeatToBlocks(block, blockLength).subarray(0, blockLength);
+      for (let start = 0; start < input.length; start += blockLength) {
+        addWithCarry(input.subarray(start, start + blockLength), addend);
+      }
+    }
+    return derived;
+  }
+}
+
+/** Which value we derive from the passphrase. RFC 7292 appendix B.3 */
+enum KeyPurpose {
+  Key = 1,
+  IV = 2,
+  MAC = 3,
+}
+
+/** The hash functions that a .p12 file may use, by the name of their OID */
+const kHashes = { sha1, sha256, sha384, sha512 };
+type Hash = typeof sha1;
+
+/** The passphrase as PKCS#12 uses it: UTF-16, big endian, with a final null.
+ * Characters outside the BMP go in as their 2 surrogates,
+ * which is what the apps that write these files do as well. */
+function bmpString(text: string): Uint8Array {
+  let bytes = new Uint8Array(text.length * 2 + 2);
+  let view = new DataView(bytes.buffer);
+  for (let i = 0; i < text.length; i++) {
+    view.setUint16(i * 2, text.charCodeAt(i));
+  }
+  return bytes;
+}
+
+/** Repeats the data until it fills whole hash blocks */
+function repeatToBlocks(data: Uint8Array, blockLength: number): Uint8Array {
+  if (!data.length) {
+    return data;
+  }
+  let repeated = new Uint8Array(Math.ceil(data.length / blockLength) * blockLength);
+  for (let pos = 0; pos < repeated.length; pos += data.length) {
+    repeated.set(data.subarray(0, repeated.length - pos), pos);
+  }
+  return repeated;
+}
+
+/** Adds `addend` + 1 to `data`, as if both were one big number */
+function addWithCarry(data: Uint8Array, addend: Uint8Array) {
+  let carry = 1;
+  for (let i = data.length - 1; i >= 0; i--) {
+    let sum = data[i] + addend[i] + carry;
+    data[i] = sum;
+    carry = sum >> 8;
+  }
+}
+
+function concat(first: Uint8Array, second: Uint8Array): Uint8Array {
+  let combined = new Uint8Array(first.length + second.length);
+  combined.set(first);
+  combined.set(second, first.length);
+  return combined;
+}

--- a/app/logic/Mail/Encryption/SMIME/SMIMEASN1.ts
+++ b/app/logic/Mail/Encryption/SMIME/SMIMEASN1.ts
@@ -47,16 +47,31 @@ const oids = {
   "1.2.840.113549.1.7.1": "data",
   "1.2.840.113549.1.7.2": "signedData",
   "1.2.840.113549.1.7.3": "envelopedData",
+  "1.2.840.113549.1.7.6": "encryptedData",
   "1.2.840.113549.1.9.1": "E", // emailAddress
   "1.2.840.113549.1.9.3": "contentType",
   "1.2.840.113549.1.9.4": "messageDigest",
   "1.2.840.113549.1.9.5": "signingTime",
   "1.2.840.113549.1.9.15": "smimeCapabilities",
   "1.2.840.113549.1.9.16.1.23": "authEnvelopedData",
+  "1.2.840.113549.1.9.22.1": "x509Certificate",
+  "1.2.840.113549.1.12.1.1": "pbeWithSHAAnd128BitRC4",
+  "1.2.840.113549.1.12.1.2": "pbeWithSHAAnd40BitRC4",
+  "1.2.840.113549.1.12.1.3": "pbeWithSHAAnd3KeyTripleDESCBC",
+  "1.2.840.113549.1.12.1.4": "pbeWithSHAAnd2KeyTripleDESCBC",
+  "1.2.840.113549.1.12.1.5": "pbeWithSHAAnd128BitRC2CBC",
+  "1.2.840.113549.1.12.1.6": "pbeWithSHAAnd40BitRC2CBC",
+  "1.2.840.113549.1.12.10.1.1": "keyBag",
+  "1.2.840.113549.1.12.10.1.2": "pkcs8ShroudedKeyBag",
+  "1.2.840.113549.1.12.10.1.3": "certBag",
+  "1.2.840.113549.1.12.10.1.4": "crlBag",
+  "1.2.840.113549.1.12.10.1.5": "secretBag",
+  "1.2.840.113549.1.12.10.1.6": "safeContentsBag",
   "1.2.840.113549.2.7": "hmacWithSHA1",
   "1.2.840.113549.2.9": "hmacWithSHA256",
   "1.2.840.113549.2.10": "hmacWithSHA384",
   "1.2.840.113549.2.11": "hmacWithSHA512",
+  "1.2.840.113549.3.7": "desEDE3CBC",
   "1.3.6.1.5.5.7.3.4": "emailProtection",
   //"1.3.6.1.5.5.8.1.2": "hmacWithSHA1",
   "1.3.14.3.2.26": "sha1",
@@ -374,7 +389,8 @@ const RecipientInfo = define("RecipientInfo", function() {
   });
 });
 
-const Any = define("Any", function() {
+/** Raw DER, e.g. to keep bytes that we do not need to look into */
+export const Any = define<Uint8Array>("Any", function() {
   this.any();
 });
 
@@ -523,6 +539,72 @@ export const CertificationRequest = define("CertificationRequest", function() {
     this.key("certificationRequestInfo").use(CertificationRequestInfo),
     this.key("signatureAlgorithm").use(AlgorithmIdentifier),
     this.key("signature").bitstr(),
+  );
+});
+
+/* PKCS#12, RFC 7292 */
+
+/** The contents of a .p12 or .pfx file: private keys and certificates,
+ * protected by a passphrase. `macData` guards against tampering. */
+export const PFX = define("PFX", function() {
+  this.seq().obj(
+    this.key("version").int(),
+    this.key("authSafe").use(ContentInfo),
+    this.key("macData").optional().seq().obj(
+      this.key("mac").use(DigestInfo),
+      this.key("macSalt").octstr(),
+      this.key("iterations").def(1n).int(),
+    ),
+  );
+});
+
+/** The `authSafe` of a `PFX`, grouping the bags by how they are protected:
+ * either `data`, i.e. in the clear, or `encryptedData` */
+export const AuthenticatedSafe = define("AuthenticatedSafe", function() {
+  this.seqof(ContentInfo);
+});
+
+/** Content that is encrypted with a passphrase. RFC 5652 section 8 */
+export const EncryptedData = define("EncryptedData", function() {
+  this.seq().obj(
+    this.key("version").int(),
+    this.key("encryptedContentInfo").seq().obj(
+      this.key("contentType").objid(oids),
+      this.key("contentEncryptionAlgorithm").use(AlgorithmIdentifier),
+      this.key("encryptedContent").implicit(0).optional().octstr(),
+    ),
+  );
+});
+
+/** One private key, certificate or CRL, and how it is stored.
+ * `bagValue` depends on `bagId`, e.g. an `EncryptedPrivateKeyInfo`
+ * for a pkcs8ShroudedKeyBag, or a `CertBag` for a certBag. */
+const SafeBag = define("SafeBag", function() {
+  this.seq().obj(
+    this.key("bagId").objid(oids),
+    this.key("bagValue").explicit(0).any(),
+    // Only names and IDs, which we do not need
+    this.key("bagAttributes").optional().setof(Any),
+  );
+});
+
+export const SafeContents = define("SafeContents", function() {
+  this.seqof(SafeBag);
+});
+
+export const CertBag = define("CertBag", function() {
+  this.seq().obj(
+    this.key("certId").objid(oids),
+    this.key("certValue").explicit(0).octstr(),
+  );
+});
+
+/** Parameters of the password-based encryption algorithms
+ * that are specific to PKCS#12, e.g. pbeWithSHAAnd40BitRC2CBC */
+export const PBEParams = define("PBEParams", function() {
+  this.seq().obj(
+    this.key("salt").octstr(),
+    this.key("iterations").int(),
   );
 });
 

--- a/app/logic/Mail/Encryption/SMIME/SMIMEPrivateKey.ts
+++ b/app/logic/Mail/Encryption/SMIME/SMIMEPrivateKey.ts
@@ -1,6 +1,7 @@
 import type { PrivateKey } from "../PrivateKey";
 import { SMIMEPublicKey, splitPEM } from "./SMIMEPublicKey";
-import { KeyDerivationAlgorithm, PrivateKeyInfo, EncryptedPrivateKeyInfo, PBES2Params, PBKDF2Params, RSAPrivateKey, RSAPublicKey, CertificationRequestInfo, DigestInfo, CertificationRequest, Null, OctetString } from "./SMIMEASN1";
+import { Any, PrivateKeyInfo, EncryptedPrivateKeyInfo, RSAPrivateKey, RSAPublicKey, CertificationRequestInfo, DigestInfo, CertificationRequest, Null } from "./SMIMEASN1";
+import { decryptPBES2, encryptPrivateKey } from "./PBES2";
 import { decrypt, padFF } from "./SMIMERSAES";
 import { SMIMEReadProcessor } from "./SMIMEReadProcessor";
 import { sanitize } from "../../../../../lib/util/sanitizeDatatypes";
@@ -38,47 +39,23 @@ export class SMIMEPrivateKey extends SMIMEPublicKey implements PrivateKey {
     return key.n == rawKey.n && key.e == rawKey.e;
   }
 
+  /** Decrypts our private key with our passphrase */
   async decryptKey(): Promise<RSAPrivateKey> {
-    let privateKeyInfo;
-    if (!this.passphrase) {
-      privateKeyInfo = PrivateKeyInfo.decodePEM(this.privateKeyArmored, { label: "PRIVATE KEY" });
+    let pkcs8: Uint8Array;
+    if (this.passphrase) {
+      let encryptedKey = EncryptedPrivateKeyInfo.decodePEM(this.privateKeyArmored, { label: "ENCRYPTED PRIVATE KEY" });
+      if (encryptedKey.encryptionAlgorithm.algorithm != "pkcs5PBES2") {
+        throw new Error("Unsupported private key encryption algorithm");
+      }
+      pkcs8 = await decryptPBES2(encryptedKey.encryptedData, encryptedKey.encryptionAlgorithm.parameters, this.passphrase);
     } else {
-      let cryptoKey = await this.decryptCryptoKey();
-      privateKeyInfo = PrivateKeyInfo.decode(new Uint8Array(await crypto.subtle.exportKey("pkcs8", cryptoKey)));
+      pkcs8 = Any.decodePEM(this.privateKeyArmored, { label: "PRIVATE KEY" });
     }
+    let privateKeyInfo = PrivateKeyInfo.decode(pkcs8);
     if (privateKeyInfo.privateKeyAlgorithm.algorithm != "rsaEncryption") {
       throw new Error("Unsupported private key algorithm");
     }
     return RSAPrivateKey.decode(privateKeyInfo.privateKey);
-  }
-
-  async decryptCryptoKey(): Promise<CryptoKey> {
-    if (!this.passphrase) {
-      let privateKey = PrivateKeyInfo.decodePEM(this.privateKeyArmored, { label: "PRIVATE KEY" });
-      if (privateKey.privateKeyAlgorithm.algorithm != "rsaEncryption") {
-        throw new Error("Unsupported private key algorithm");
-      }
-      return crypto.subtle.importKey("pkcs8", PrivateKeyInfo.encode(privateKey),  { name: "RSASSA-PKCS1-v1_5", hash: "SHA-256" }, true, ["sign"]);
-    }
-    let encryptedKey = EncryptedPrivateKeyInfo.decodePEM(this.privateKeyArmored, { label: "ENCRYPTED PRIVATE KEY" });
-    if (encryptedKey.encryptionAlgorithm.algorithm != "pkcs5PBES2") {
-      throw new Error("Unsupported private key encryption algorithm");
-    }
-    let pbes2 = PBES2Params.decode(encryptedKey.encryptionAlgorithm.parameters);
-    if (pbes2.keyDerivationFunc.algorithm != "pkcs5PBKDF2") {
-      throw new Error("Unsupported private key derivation function");
-    }
-    let length = sanitize.translate(pbes2.encryptionScheme.algorithm, { aes128cbc: 128, aes192cbc: 192, aes256cbc: 256 });
-    let pbkdf2 = PBKDF2Params.decode(pbes2.keyDerivationFunc.parameters);
-    if (pbkdf2.salt.type != "specified") {
-      throw new Error("Unsupported private key derivation salt");
-    }
-    let hash = sanitize.translate(pbkdf2.prf.algorithm, KeyDerivationAlgorithm);
-    // Cap the iterations, otherwise a malicious key file would freeze the app
-    let iterations = sanitize.integerRange(Number(pbkdf2.iterationCount), 1, 10000000);
-    let rawKey = await crypto.subtle.importKey("raw", new TextEncoder().encode(this.passphrase), "PBKDF2", false, ["deriveKey"]);
-    let derivedKey = await crypto.subtle.deriveKey({ name: "PBKDF2", salt: pbkdf2.salt.value, iterations, hash }, rawKey, { name: "AES-CBC", length }, false, ["unwrapKey"]);
-    return crypto.subtle.unwrapKey("pkcs8", encryptedKey.encryptedData, derivedKey, { name: "AES-CBC", iv: OctetString.decode(pbes2.encryptionScheme.parameters) }, { name: "RSASSA-PKCS1-v1_5", hash: "SHA-256" }, true, ["sign"]);
   }
 
   privateKeyAsFile(): File {
@@ -140,21 +117,11 @@ export class SMIMEPrivateKey extends SMIMEPublicKey implements PrivateKey {
    * Factory function. */
   static async createNewPrivateKey(emailAddress: string): Promise<SMIMEPrivateKey> {
     let passphrase = crypto.randomUUID();
-    let salt = new Uint8Array(8);
-    let iv = new Uint8Array(16);
-    crypto.getRandomValues(salt);
-    crypto.getRandomValues(iv);
-    let rawKey = await crypto.subtle.importKey("raw", new TextEncoder().encode(passphrase), "PBKDF2", false, ["deriveKey"]);
-    let derivedKey = await crypto.subtle.deriveKey({ name: "PBKDF2", salt, iterations: 2048, hash: "SHA-256" }, rawKey, { name: "AES-CBC", length: 256 }, false, ["wrapKey"]);
     let { privateKey } = await crypto.subtle.generateKey({ name: "RSASSA-PKCS1-v1_5", modulusLength: 4096, publicExponent: Uint8Array.of(1, 0, 1), hash: "SHA-256" }, true, ["sign"]);
-    let wrappedKey = new Uint8Array(await crypto.subtle.wrapKey("pkcs8", privateKey, derivedKey, { name: "AES-CBC", iv }));
-    let pbkdf2: PBKDF2Params = { salt: { type: "specified", value: salt }, iterationCount: 2048n, prf: { algorithm: "hmacWithSHA256", parameters: Null.encode() } };
-    let pbes2 = { keyDerivationFunc: { algorithm: "pkcs5PBKDF2", parameters: PBKDF2Params.encode(pbkdf2) }, encryptionScheme: { algorithm: "aes256cbc", parameters: OctetString.encode(iv) } };
-    let encryptedKey = { encryptionAlgorithm: { algorithm: "pkcs5PBES2", parameters: PBES2Params.encode(pbes2) }, encryptedData: wrappedKey };
-    let privateKeyInfo = PrivateKeyInfo.decode(new Uint8Array(await crypto.subtle.exportKey("pkcs8", privateKey)));
-    let rsaKey = RSAPrivateKey.decode(privateKeyInfo.privateKey);
+    let privateKeyPKCS8 = new Uint8Array(await crypto.subtle.exportKey("pkcs8", privateKey));
+    let rsaKey = RSAPrivateKey.decode(PrivateKeyInfo.decode(privateKeyPKCS8).privateKey);
     let key = new SMIMEPrivateKey();
-    key.privateKeyArmored = EncryptedPrivateKeyInfo.encodePEM(encryptedKey, { label: "ENCRYPTED PRIVATE KEY" });
+    key.privateKeyArmored = await encryptPrivateKey(privateKeyPKCS8, passphrase);
     key.passphrase = passphrase;
     key.id = rsaKey.n.toString(16).slice(-16);
     key.name = key.defaultName;

--- a/app/logic/Mail/Encryption/SMIME/legacyCiphers.ts
+++ b/app/logic/Mail/Encryption/SMIME/legacyCiphers.ts
@@ -1,0 +1,415 @@
+// Triple DES (FIPS 46-3), RC2 (RFC 2268) and RC4.
+// WebCrypto implements none of them, because they are all outdated, but
+// .p12 files that were written by other mail apps still use them.
+// RFCs are Copyright (c) IETF Trust and their authors.
+// Code components are licenced under the BSD licence.
+
+/* BSD License
+
+Copyright (c) IETF
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice,
+   this list of conditions and the following disclaimer.
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+3. Neither the name of the copyright holder nor the names of its contributors
+   may be used to endorse or promote products derived from this software
+   without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE. */
+
+/**
+ * Decrypts data that was encrypted with Triple DES in CBC mode.
+ * @param key 24 bytes (3 keys) or 16 bytes (2 keys, the third being the first)
+ * @param iv 8 bytes
+ * @returns the plaintext, without the padding
+ */
+export function tripleDESDecrypt(data: Uint8Array, key: Uint8Array, iv: Uint8Array): Uint8Array {
+  if (key.length != 24 && key.length != 16) {
+    throw new Error("Triple DES needs a 16 or 24 byte key");
+  }
+  let schedules = [
+    keySchedule(key.subarray(0, 8)),
+    keySchedule(key.subarray(8, 16)),
+    keySchedule(key.length == 24 ? key.subarray(16, 24) : key.subarray(0, 8)),
+  ];
+  // Undoes E(key3, D(key2, E(key1, plaintext)))
+  return decryptCBC(data, iv, block =>
+    desBlock(desBlock(desBlock(block, schedules[2], true), schedules[1], false), schedules[0], true));
+}
+
+/**
+ * Decrypts data that was encrypted with RC2 in CBC mode.
+ * @param effectiveKeyBits how many bits of the key actually matter,
+ *   e.g. 40 for the deliberately weakened export variant
+ * @param iv 8 bytes
+ * @returns the plaintext, without the padding
+ */
+export function rc2Decrypt(data: Uint8Array, key: Uint8Array, iv: Uint8Array, effectiveKeyBits: number): Uint8Array {
+  let expandedKey = expandRC2Key(key, effectiveKeyBits);
+  return decryptCBC(data, iv, block => rc2Block(block, expandedKey));
+}
+
+/** Decrypts data that was encrypted with RC4.
+ * RC4 is a stream cipher, so this is the same operation as encrypting,
+ * and there is neither an IV nor padding. */
+export function rc4Decrypt(data: Uint8Array, key: Uint8Array): Uint8Array {
+  if (!key.length) {
+    throw new Error("RC4 needs a key");
+  }
+  let state = new Uint8Array(256);
+  for (let i = 0; i < 256; i++) {
+    state[i] = i;
+  }
+  let j = 0;
+  for (let i = 0; i < 256; i++) {
+    j = j + state[i] + key[i % key.length] & 0xFF;
+    [state[i], state[j]] = [state[j], state[i]];
+  }
+  let plaintext = new Uint8Array(data.length);
+  let x = 0;
+  let y = 0;
+  for (let pos = 0; pos < data.length; pos++) {
+    x = x + 1 & 0xFF;
+    y = y + state[x] & 0xFF;
+    [state[x], state[y]] = [state[y], state[x]];
+    plaintext[pos] = data[pos] ^ state[state[x] + state[y] & 0xFF];
+  }
+  return plaintext;
+}
+
+/** Runs a block cipher in CBC mode, where each plaintext block was
+ * XORed with the ciphertext block before it.
+ * @param iv the block that the first block was XORed with
+ * @returns the plaintext, without the padding */
+function decryptCBC(data: Uint8Array, iv: Uint8Array, decryptBlock: (block: Uint8Array) => Uint8Array): Uint8Array {
+  let blockLength = iv.length;
+  if (!data.length || data.length % blockLength) {
+    throw new Error("Ciphertext must be whole blocks");
+  }
+  let plaintext = new Uint8Array(data.length);
+  let previous = iv;
+  for (let pos = 0; pos < data.length; pos += blockLength) {
+    let block = data.subarray(pos, pos + blockLength);
+    let decrypted = decryptBlock(block);
+    for (let i = 0; i < blockLength; i++) {
+      plaintext[pos + i] = decrypted[i] ^ previous[i];
+    }
+    previous = block;
+  }
+  return unpadPKCS7(plaintext, blockLength);
+}
+
+/** Removes the padding that fills up the last block, RFC 5652 section 6.3.
+ * A wrong passphrase practically always shows up here. */
+function unpadPKCS7(plaintext: Uint8Array, blockLength: number): Uint8Array {
+  let padding = plaintext[plaintext.length - 1];
+  if (!padding || padding > blockLength) {
+    throw new Error("Bad padding");
+  }
+  for (let i = plaintext.length - padding; i < plaintext.length; i++) {
+    if (plaintext[i] != padding) {
+      throw new Error("Bad padding");
+    }
+  }
+  return plaintext.subarray(0, plaintext.length - padding);
+}
+
+/* Triple DES */
+
+/** Runs the DES cipher on a single 8 byte block.
+ * Decryption is the same operation, with the subkeys in reverse order. */
+function desBlock(block: Uint8Array, subkeys: Uint8Array[], reverse: boolean): Uint8Array {
+  let bits = permute(bytesToBits(block), kInitialPermutation);
+  let left: Uint8Array = bits.slice(0, 32);
+  let right: Uint8Array = bits.slice(32, 64);
+  for (let round = 0; round < 16; round++) {
+    let mixed = feistel(right, subkeys[reverse ? 15 - round : round]);
+    for (let i = 0; i < 32; i++) {
+      mixed[i] ^= left[i];
+    }
+    left = right;
+    right = mixed;
+  }
+  // The halves are swapped one last time, i.e. the right half comes first
+  let preOutput = new Uint8Array(64);
+  preOutput.set(right, 0);
+  preOutput.set(left, 32);
+  return bitsToBytes(permute(preOutput, kFinalPermutation));
+}
+
+/** The DES round function: expand the half block, mix in the subkey,
+ * and substitute each 6 bits by 4 bits */
+function feistel(right: Uint8Array, subkey: Uint8Array): Uint8Array {
+  let expanded = permute(right, kExpansion);
+  let substituted = new Uint8Array(32);
+  for (let box = 0; box < 8; box++) {
+    let bits = new Uint8Array(6);
+    for (let i = 0; i < 6; i++) {
+      bits[i] = expanded[box * 6 + i] ^ subkey[box * 6 + i];
+    }
+    let row = bits[0] * 2 + bits[5];
+    let column = bits[1] * 8 + bits[2] * 4 + bits[3] * 2 + bits[4];
+    let value = kSubstitutionBoxes[box][row * 16 + column];
+    for (let i = 0; i < 4; i++) {
+      substituted[box * 4 + i] = value >> 3 - i & 1;
+    }
+  }
+  return permute(substituted, kPermutation);
+}
+
+/** Derives the 16 round keys of 48 bits each from an 8 byte DES key.
+ * The parity bits of the key are dropped. */
+function keySchedule(key: Uint8Array): Uint8Array[] {
+  let bits = permute(bytesToBits(key), kKeyPermutation);
+  let left = bits.slice(0, 28);
+  let right = bits.slice(28, 56);
+  let subkeys: Uint8Array[] = [];
+  for (let shift of kKeyShifts) {
+    rotateLeft(left, shift);
+    rotateLeft(right, shift);
+    let combined = new Uint8Array(56);
+    combined.set(left, 0);
+    combined.set(right, 28);
+    subkeys.push(permute(combined, kKeyCompression));
+  }
+  return subkeys;
+}
+
+function rotateLeft(bits: Uint8Array, count: number) {
+  let start = bits.slice(0, count);
+  bits.copyWithin(0, count);
+  bits.set(start, bits.length - count);
+}
+
+/** Reorders bits, as listed in the given table. The table entries are
+ * 1-based positions in the input, just as they are printed in FIPS 46-3. */
+function permute(bits: Uint8Array, table: Uint8Array): Uint8Array {
+  let permuted = new Uint8Array(table.length);
+  for (let i = 0; i < table.length; i++) {
+    permuted[i] = bits[table[i] - 1];
+  }
+  return permuted;
+}
+
+/** Splits bytes into one array entry per bit, most significant bit first */
+function bytesToBits(bytes: Uint8Array): Uint8Array {
+  let bits = new Uint8Array(bytes.length * 8);
+  for (let i = 0; i < bits.length; i++) {
+    bits[i] = bytes[i >> 3] >> 7 - (i & 7) & 1;
+  }
+  return bits;
+}
+
+function bitsToBytes(bits: Uint8Array): Uint8Array {
+  let bytes = new Uint8Array(bits.length >> 3);
+  for (let i = 0; i < bits.length; i++) {
+    bytes[i >> 3] |= bits[i] << 7 - (i & 7);
+  }
+  return bytes;
+}
+
+const kInitialPermutation = Uint8Array.of(
+  58, 50, 42, 34, 26, 18, 10, 2,
+  60, 52, 44, 36, 28, 20, 12, 4,
+  62, 54, 46, 38, 30, 22, 14, 6,
+  64, 56, 48, 40, 32, 24, 16, 8,
+  57, 49, 41, 33, 25, 17, 9, 1,
+  59, 51, 43, 35, 27, 19, 11, 3,
+  61, 53, 45, 37, 29, 21, 13, 5,
+  63, 55, 47, 39, 31, 23, 15, 7);
+
+const kFinalPermutation = Uint8Array.of(
+  40, 8, 48, 16, 56, 24, 64, 32,
+  39, 7, 47, 15, 55, 23, 63, 31,
+  38, 6, 46, 14, 54, 22, 62, 30,
+  37, 5, 45, 13, 53, 21, 61, 29,
+  36, 4, 44, 12, 52, 20, 60, 28,
+  35, 3, 43, 11, 51, 19, 59, 27,
+  34, 2, 42, 10, 50, 18, 58, 26,
+  33, 1, 41, 9, 49, 17, 57, 25);
+
+/** Expands the 32 bit half block to the 48 bits of a round key */
+const kExpansion = Uint8Array.of(
+  32, 1, 2, 3, 4, 5,
+  4, 5, 6, 7, 8, 9,
+  8, 9, 10, 11, 12, 13,
+  12, 13, 14, 15, 16, 17,
+  16, 17, 18, 19, 20, 21,
+  20, 21, 22, 23, 24, 25,
+  24, 25, 26, 27, 28, 29,
+  28, 29, 30, 31, 32, 1);
+
+/** Shuffles the 32 bits that come out of the substitution boxes */
+const kPermutation = Uint8Array.of(
+  16, 7, 20, 21,
+  29, 12, 28, 17,
+  1, 15, 23, 26,
+  5, 18, 31, 10,
+  2, 8, 24, 14,
+  32, 27, 3, 9,
+  19, 13, 30, 6,
+  22, 11, 4, 25);
+
+/** Selects the 56 key bits that are actually used */
+const kKeyPermutation = Uint8Array.of(
+  57, 49, 41, 33, 25, 17, 9,
+  1, 58, 50, 42, 34, 26, 18,
+  10, 2, 59, 51, 43, 35, 27,
+  19, 11, 3, 60, 52, 44, 36,
+  63, 55, 47, 39, 31, 23, 15,
+  7, 62, 54, 46, 38, 30, 22,
+  14, 6, 61, 53, 45, 37, 29,
+  21, 13, 5, 28, 20, 12, 4);
+
+/** Picks the 48 bits of a round key out of the rotated key halves */
+const kKeyCompression = Uint8Array.of(
+  14, 17, 11, 24, 1, 5,
+  3, 28, 15, 6, 21, 10,
+  23, 19, 12, 4, 26, 8,
+  16, 7, 27, 20, 13, 2,
+  41, 52, 31, 37, 47, 55,
+  30, 40, 51, 45, 33, 48,
+  44, 49, 39, 56, 34, 53,
+  46, 42, 50, 36, 29, 32);
+
+/** How far the key halves are rotated before each round */
+const kKeyShifts = Uint8Array.of(1, 1, 2, 2, 2, 2, 2, 2, 1, 2, 2, 2, 2, 2, 2, 1);
+
+/** The 8 substitution boxes, 4 rows of 16 values each */
+const kSubstitutionBoxes = [
+  Uint8Array.of(
+    14, 4, 13, 1, 2, 15, 11, 8, 3, 10, 6, 12, 5, 9, 0, 7,
+    0, 15, 7, 4, 14, 2, 13, 1, 10, 6, 12, 11, 9, 5, 3, 8,
+    4, 1, 14, 8, 13, 6, 2, 11, 15, 12, 9, 7, 3, 10, 5, 0,
+    15, 12, 8, 2, 4, 9, 1, 7, 5, 11, 3, 14, 10, 0, 6, 13),
+  Uint8Array.of(
+    15, 1, 8, 14, 6, 11, 3, 4, 9, 7, 2, 13, 12, 0, 5, 10,
+    3, 13, 4, 7, 15, 2, 8, 14, 12, 0, 1, 10, 6, 9, 11, 5,
+    0, 14, 7, 11, 10, 4, 13, 1, 5, 8, 12, 6, 9, 3, 2, 15,
+    13, 8, 10, 1, 3, 15, 4, 2, 11, 6, 7, 12, 0, 5, 14, 9),
+  Uint8Array.of(
+    10, 0, 9, 14, 6, 3, 15, 5, 1, 13, 12, 7, 11, 4, 2, 8,
+    13, 7, 0, 9, 3, 4, 6, 10, 2, 8, 5, 14, 12, 11, 15, 1,
+    13, 6, 4, 9, 8, 15, 3, 0, 11, 1, 2, 12, 5, 10, 14, 7,
+    1, 10, 13, 0, 6, 9, 8, 7, 4, 15, 14, 3, 11, 5, 2, 12),
+  Uint8Array.of(
+    7, 13, 14, 3, 0, 6, 9, 10, 1, 2, 8, 5, 11, 12, 4, 15,
+    13, 8, 11, 5, 6, 15, 0, 3, 4, 7, 2, 12, 1, 10, 14, 9,
+    10, 6, 9, 0, 12, 11, 7, 13, 15, 1, 3, 14, 5, 2, 8, 4,
+    3, 15, 0, 6, 10, 1, 13, 8, 9, 4, 5, 11, 12, 7, 2, 14),
+  Uint8Array.of(
+    2, 12, 4, 1, 7, 10, 11, 6, 8, 5, 3, 15, 13, 0, 14, 9,
+    14, 11, 2, 12, 4, 7, 13, 1, 5, 0, 15, 10, 3, 9, 8, 6,
+    4, 2, 1, 11, 10, 13, 7, 8, 15, 9, 12, 5, 6, 3, 0, 14,
+    11, 8, 12, 7, 1, 14, 2, 13, 6, 15, 0, 9, 10, 4, 5, 3),
+  Uint8Array.of(
+    12, 1, 10, 15, 9, 2, 6, 8, 0, 13, 3, 4, 14, 7, 5, 11,
+    10, 15, 4, 2, 7, 12, 9, 5, 6, 1, 13, 14, 0, 11, 3, 8,
+    9, 14, 15, 5, 2, 8, 12, 3, 7, 0, 4, 10, 1, 13, 11, 6,
+    4, 3, 2, 12, 9, 5, 15, 10, 11, 14, 1, 7, 6, 0, 8, 13),
+  Uint8Array.of(
+    4, 11, 2, 14, 15, 0, 8, 13, 3, 12, 9, 7, 5, 10, 6, 1,
+    13, 0, 11, 7, 4, 9, 1, 10, 14, 3, 5, 12, 2, 15, 8, 6,
+    1, 4, 11, 13, 12, 3, 7, 14, 10, 15, 6, 8, 0, 5, 9, 2,
+    6, 11, 13, 8, 1, 4, 10, 7, 9, 5, 0, 15, 14, 2, 3, 12),
+  Uint8Array.of(
+    13, 2, 8, 4, 6, 15, 11, 1, 10, 9, 3, 14, 5, 0, 12, 7,
+    1, 15, 13, 8, 10, 3, 7, 4, 12, 5, 6, 11, 0, 14, 9, 2,
+    7, 11, 4, 1, 9, 12, 14, 2, 0, 6, 10, 13, 15, 3, 5, 8,
+    2, 1, 14, 7, 4, 10, 8, 13, 15, 12, 9, 0, 3, 5, 6, 11),
+];
+
+/* RC2 */
+
+/** Decrypts a single 8 byte block, by undoing the mixing and mashing rounds
+ * of the encryption, in reverse order. RFC 2268 section 4. */
+function rc2Block(block: Uint8Array, expandedKey: Uint16Array): Uint8Array {
+  let r = new Uint16Array(4);
+  for (let i = 0; i < 4; i++) {
+    r[i] = block[i * 2] | block[i * 2 + 1] << 8;
+  }
+  let j = 63;
+  for (let round = 0; round < 16; round++) {
+    if (round == 5 || round == 11) {
+      // R-mashing round
+      for (let i = 3; i >= 0; i--) {
+        r[i] -= expandedKey[r[i + 3 & 3] & 63];
+      }
+    }
+    // R-mixing round
+    for (let i = 3; i >= 0; i--) {
+      let rotation = kRC2Rotations[i];
+      r[i] = r[i] >> rotation | r[i] << 16 - rotation;
+      r[i] -= expandedKey[j--] + (r[i + 3 & 3] & r[i + 2 & 3]) + (~r[i + 3 & 3] & r[i + 1 & 3]);
+    }
+  }
+  let plaintext = new Uint8Array(8);
+  for (let i = 0; i < 4; i++) {
+    plaintext[i * 2] = r[i] & 0xFF;
+    plaintext[i * 2 + 1] = r[i] >> 8;
+  }
+  return plaintext;
+}
+
+/** Turns the key into the 64 words that the cipher rounds use.
+ * The effective key length limits how much of the key influences the
+ * result, which is how the 40 bit export variant is weakened.
+ * RFC 2268 section 2. */
+function expandRC2Key(key: Uint8Array, effectiveKeyBits: number): Uint16Array {
+  if (!key.length || key.length > 128) {
+    throw new Error("RC2 needs a key of 1 to 128 bytes");
+  }
+  let expanded = new Uint8Array(128);
+  expanded.set(key);
+  for (let i = key.length; i < 128; i++) {
+    expanded[i] = kPiTable[expanded[i - 1] + expanded[i - key.length] & 0xFF];
+  }
+  let effectiveBytes = effectiveKeyBits + 7 >> 3;
+  let mask = 0xFF >> effectiveBytes * 8 - effectiveKeyBits;
+  expanded[128 - effectiveBytes] = kPiTable[expanded[128 - effectiveBytes] & mask];
+  for (let i = 127 - effectiveBytes; i >= 0; i--) {
+    expanded[i] = kPiTable[expanded[i + 1] ^ expanded[i + effectiveBytes]];
+  }
+  let words = new Uint16Array(64);
+  for (let i = 0; i < 64; i++) {
+    words[i] = expanded[i * 2] | expanded[i * 2 + 1] << 8;
+  }
+  return words;
+}
+
+/** How far each of the 4 words is rotated in a mixing round */
+const kRC2Rotations = [1, 2, 3, 5];
+
+/** A fixed permutation of all byte values, based on the digits of pi */
+const kPiTable = Uint8Array.of(
+  0xd9, 0x78, 0xf9, 0xc4, 0x19, 0xdd, 0xb5, 0xed, 0x28, 0xe9, 0xfd, 0x79, 0x4a, 0xa0, 0xd8, 0x9d,
+  0xc6, 0x7e, 0x37, 0x83, 0x2b, 0x76, 0x53, 0x8e, 0x62, 0x4c, 0x64, 0x88, 0x44, 0x8b, 0xfb, 0xa2,
+  0x17, 0x9a, 0x59, 0xf5, 0x87, 0xb3, 0x4f, 0x13, 0x61, 0x45, 0x6d, 0x8d, 0x09, 0x81, 0x7d, 0x32,
+  0xbd, 0x8f, 0x40, 0xeb, 0x86, 0xb7, 0x7b, 0x0b, 0xf0, 0x95, 0x21, 0x22, 0x5c, 0x6b, 0x4e, 0x82,
+  0x54, 0xd6, 0x65, 0x93, 0xce, 0x60, 0xb2, 0x1c, 0x73, 0x56, 0xc0, 0x14, 0xa7, 0x8c, 0xf1, 0xdc,
+  0x12, 0x75, 0xca, 0x1f, 0x3b, 0xbe, 0xe4, 0xd1, 0x42, 0x3d, 0xd4, 0x30, 0xa3, 0x3c, 0xb6, 0x26,
+  0x6f, 0xbf, 0x0e, 0xda, 0x46, 0x69, 0x07, 0x57, 0x27, 0xf2, 0x1d, 0x9b, 0xbc, 0x94, 0x43, 0x03,
+  0xf8, 0x11, 0xc7, 0xf6, 0x90, 0xef, 0x3e, 0xe7, 0x06, 0xc3, 0xd5, 0x2f, 0xc8, 0x66, 0x1e, 0xd7,
+  0x08, 0xe8, 0xea, 0xde, 0x80, 0x52, 0xee, 0xf7, 0x84, 0xaa, 0x72, 0xac, 0x35, 0x4d, 0x6a, 0x2a,
+  0x96, 0x1a, 0xd2, 0x71, 0x5a, 0x15, 0x49, 0x74, 0x4b, 0x9f, 0xd0, 0x5e, 0x04, 0x18, 0xa4, 0xec,
+  0xc2, 0xe0, 0x41, 0x6e, 0x0f, 0x51, 0xcb, 0xcc, 0x24, 0x91, 0xaf, 0x50, 0xa1, 0xf4, 0x70, 0x39,
+  0x99, 0x7c, 0x3a, 0x85, 0x23, 0xb8, 0xb4, 0x7a, 0xfc, 0x02, 0x36, 0x5b, 0x25, 0x55, 0x97, 0x31,
+  0x2d, 0x5d, 0xfa, 0x98, 0xe3, 0x8a, 0x92, 0xae, 0x05, 0xdf, 0x29, 0x10, 0x67, 0x6c, 0xba, 0xc9,
+  0xd3, 0x00, 0xe6, 0xcf, 0xe1, 0x9e, 0xa8, 0x2c, 0x63, 0x16, 0x01, 0x3f, 0x58, 0xe2, 0x89, 0xa9,
+  0x0d, 0x38, 0x34, 0x1b, 0xab, 0x33, 0xff, 0xb0, 0xbb, 0x48, 0x0c, 0x5f, 0xb9, 0xb1, 0xcd, 0x2e,
+  0xc5, 0xf3, 0xdb, 0x47, 0xe5, 0xa5, 0x9c, 0x77, 0x0a, 0xa6, 0x20, 0x68, 0xfe, 0x7f, 0xc1, 0xad);

--- a/app/test/logic/Mail/Encryption/SMIME/PKCS12.test.ts
+++ b/app/test/logic/Mail/Encryption/SMIME/PKCS12.test.ts
@@ -1,0 +1,449 @@
+import { expect, test, describe } from "vitest";
+import { PKCS12 } from "../../../../../logic/Mail/Encryption/SMIME/PKCS12";
+import { SMIMEPrivateKey } from "../../../../../logic/Mail/Encryption/SMIME/SMIMEPrivateKey";
+import { readKeyFile } from "../../../../../logic/Mail/Encryption/KeyUtils";
+import { Certificate, PrivateKeyInfo, RSAPrivateKey, RSAPublicKey } from "../../../../../logic/Mail/Encryption/SMIME/SMIMEASN1";
+import { base64ToBytes } from "../../../../../../lib/asn1/decoders/pem";
+
+// The browser has these, but Node does not.
+globalThis.indexedDB ??= {
+  cmp(a: Uint8Array, b: Uint8Array): number {
+    let length = Math.min(a.length, b.length);
+    for (let i = 0; i < length; i++) {
+      if (a[i] != b[i]) {
+        return a[i] < b[i] ? -1 : 1;
+      }
+    }
+    return Math.sign(a.length - b.length);
+  },
+} as any;
+
+/**
+ * All fixtures below contain the same 1024 bit key and certificate for
+ * `test@example.com`, and were made with `openssl pkcs12 -export`,
+ * each with the ciphers that one of the common exporters uses.
+ */
+const kPassphrase = "secret";
+const kEmailAddress = "test@example.com";
+
+async function readFixture(fixture: string, passphrase = kPassphrase): Promise<PKCS12> {
+  let p12 = new PKCS12(passphrase);
+  await p12.read(base64ToBytes(fixture.replace(/\s/g, "")));
+  return p12;
+}
+
+/** Checks that we really decrypted the key: a key that came out wrong
+ * would be neither a valid RSA key nor the one in the certificate. */
+function expectKeyOfCertificate(p12: PKCS12) {
+  expect(p12.keys.length).toBe(1);
+  let key = RSAPrivateKey.decode(PrivateKeyInfo.decode(p12.keys[0]).privateKey);
+  expect(key.n).toBe(key.p * key.q);
+  let certificate = Certificate.decode(p12.certificates[0]);
+  let publicKey = RSAPublicKey.decode(certificate.tbsCertificate.publicKey.subjectPublicKey.data);
+  expect(key.n).toBe(publicKey.n);
+  expect(key.e).toBe(publicKey.e);
+}
+
+describe("PKCS#12 import", () => {
+  test("AES, as OpenSSL 3 and current apps write it", async () => {
+    let p12 = await readFixture(kAESFixture);
+    expect(p12.certificates.length).toBe(1);
+    expectKeyOfCertificate(p12);
+  });
+
+  test("PBES2 with Triple DES, which WebCrypto cannot decrypt", async () => {
+    let p12 = await readFixture(kPBES2TripleDESFixture);
+    expectKeyOfCertificate(p12);
+  });
+
+  test("40 bit RC2 and Triple DES, as Windows, macOS and OpenSSL 1 write them", async () => {
+    let p12 = await readFixture(kRC2AndTripleDESFixture);
+    expect(p12.certificates.length).toBe(1);
+    expectKeyOfCertificate(p12);
+  });
+
+  test("Triple DES, including the CA certificate", async () => {
+    let p12 = await readFixture(kTripleDESChainFixture);
+    // The certificate of the key, and the CA that signed it
+    expect(p12.certificates.length).toBe(2);
+    expectKeyOfCertificate(p12);
+  });
+
+  test("2-key Triple DES and 128 bit RC2", async () => {
+    let p12 = await readFixture(kRC2128Fixture);
+    expectKeyOfCertificate(p12);
+  });
+
+  test("RC4", async () => {
+    let p12 = await readFixture(kRC4Fixture);
+    expectKeyOfCertificate(p12);
+  });
+
+  test("Contents that are not encrypted, in a file without a MAC", async () => {
+    let p12 = await readFixture(kPlainFixture);
+    expectKeyOfCertificate(p12);
+  });
+
+  test("Passphrase with non-ASCII characters", async () => {
+    let p12 = await readFixture(kNonASCIIFixture, "Bärchen€");
+    expectKeyOfCertificate(p12);
+  });
+
+  test("An empty passphrase, which .p12 files may have", async () => {
+    let p12 = await readFixture(kEmptyPassphraseFixture, "");
+    expectKeyOfCertificate(p12);
+    // We have no passphrase to protect the key that we store
+    let pem = await p12.toPEM();
+    expect(pem.match(/-----BEGIN [^-]+-----/g))
+      .toEqual(["-----BEGIN PRIVATE KEY-----", "-----BEGIN CERTIFICATE-----"]);
+    let key = await SMIMEPrivateKey.importPrivateKey(pem, "");
+    expect(key.userIDs.contents).toEqual([kEmailAddress]);
+  });
+
+  test("A passphrase that the caller never set is a bug, not an empty one", async () => {
+    expect(() => new PKCS12(undefined as any)).toThrow(/passphrase/i);
+  });
+
+  test("A wrong passphrase is rejected", async () => {
+    await expect(readFixture(kAESFixture, "wrong")).rejects.toThrow(/passphrase/i);
+    await expect(readFixture(kRC2AndTripleDESFixture, "wrong")).rejects.toThrow(/passphrase/i);
+  });
+
+  test("The key and certificates end up in an S/MIME key", async () => {
+    let p12 = await readFixture(kTripleDESChainFixture);
+    let key = await SMIMEPrivateKey.importPrivateKey(await p12.toPEM(), kPassphrase);
+    expect(key.userIDs.contents).toEqual([kEmailAddress]);
+    expect(key.keyLengthInBits).toBe(1024);
+    // The CA certificate, for the chain
+    expect(key.chain.length).toBe(1);
+    // The key must still work after we encrypted it with the passphrase again
+    let rawKey = await key.decryptKey();
+    expect(rawKey.n).toBe(RSAPrivateKey.decode(PrivateKeyInfo.decode(p12.keys[0]).privateKey).n);
+  });
+
+  test("The file that the user picked is read as .p12 or as PEM", async () => {
+    let bytes = base64ToBytes(kRC2AndTripleDESFixture.replace(/\s/g, ""));
+    let pem = await readKeyFile(new File([bytes], "mykey.p12"), kPassphrase);
+    expect(pem.match(/-----BEGIN [^-]+-----/g))
+      .toEqual(["-----BEGIN ENCRYPTED PRIVATE KEY-----", "-----BEGIN CERTIFICATE-----"]);
+    // Key files that are already PEM are passed through
+    expect(await readKeyFile(new File([pem], "mykey.pem"), kPassphrase)).toBe(pem);
+  });
+});
+
+/** PBES2 with AES-256-CBC and PBKDF2, MAC with SHA-256 */
+const kAESFixture = `
+  MIIGrwIBAzCCBmUGCSqGSIb3DQEHAaCCBlYEggZSMIIGTjCCAxIGCSqGSIb3DQEHBqCCAwMwggL/
+  AgEAMIIC+AYJKoZIhvcNAQcBMFcGCSqGSIb3DQEFDTBKMCkGCSqGSIb3DQEFDDAcBAhic+VDJtRW
+  pwICCAAwDAYIKoZIhvcNAgkFADAdBglghkgBZQMEASoEENqxR/eca0M+RsDpX+I3ISuAggKQ6vUo
+  js2r1cdW3LsJ4khprXoG0/b+Lm2VC9Ls3R6bJN3cLOBw9N/OtXPJLuwUi0IfmQW/NDw4L3hg9VT9
+  jwQFJsjPz0AKHnaoPsMSFT80OYEtsHze7T3QBy02ZxAAg/g/4BYV9v4uAizJahWGT/+DaJ0ybiFu
+  XF7+RXq2sf/ozEgaaoWK+c7SxveZWftb7+7pQet+bxwpqypFs2ijx70wJ2AnNQpu/HMkXkcEcDb8
+  8K7lW5lg9a+lT25JnRUuTlvS/IHFixRe2DtHpXWW19S+dLkO6o/lUGmZrs4j7w/PBS7x5MkXdw2n
+  9xmfryZ+x6BQ3rZA6/BNRs2It8pp2UaQHhMhyGdQSvMu26hA7zFQ7HqusHJK8RRPmuqcFbbDHqwJ
+  HFufuIGmWSBbdC2ULkzuLzZxPNNk3Rq1wI/Qm4pgECPAfGmZ6VQblMdoOZK6CuTlX6eWikhOx6Rb
+  1ZX2bfCbB3VsGa3qeMBDKZ8yxEUDxFw3tevPWJ6gBXPHR6bGxuux7x53/zPaYbYLfIHV6FV5pQ9B
+  jiyhNYSN2w8C1jfnCv+sAU9aXjwLloDUJZNh9/5TQPW81V3iJALdgUPE/wKUC60fydq2UBc3bxoC
+  pZqvE9GfSu1AxWOQJYAWoAOO9iknVg3cdcWAvidasUAsuF4RCyM/pDwer9aGbDkRmySNT3vGL8MS
+  siMIbOB+3FQWMWu0oinpU9fnbu3MEHMUs3ssFUxl6V+f5S0S8KTjBq5y/QrLnEwG+eCc4hsijaZs
+  ToYXeT8D0Ijb9xxZBEM5qpYwovQHHmBGdRBf4U2pxPMXBRPtZVqMZNHVYuD/XmVMUnOTqNQDUyCT
+  RBrmBRRFv8DtplD9sdfXwZIi8P/JmJLv1l4wggM0BgkqhkiG9w0BBwGgggMlBIIDITCCAx0wggMZ
+  BgsqhkiG9w0BDAoBAqCCAuEwggLdMFcGCSqGSIb3DQEFDTBKMCkGCSqGSIb3DQEFDDAcBAiynBLX
+  DDYZwwICCAAwDAYIKoZIhvcNAgkFADAdBglghkgBZQMEASoEEP7viGLZa5YnFLeNWNRLE+0EggKA
+  kelOFRzFpi6Z/qIXNfWFheBp/CnlMmOANme36cqR1d7Wd+ZI4fTbYMmOMZfwV/j8z2DoqhDaJaod
+  z6MP8TvuYXDTzsZmYh4XOazYDZ2sob5JO1WNWyrwSi9CFmpz6XtQfy1DU093FSBB6T0etdX/9n4k
+  YvgPRDpPTbrHGcXBFK3FLtM8biPxhv+5H27Y+mPC+aIj66QMRzjWxrjxuqVSDxefUj5ovr2CC3lQ
+  9agZsTEOAXRhB4qL7EJ0cdKLYmq5zAN470V3p0nFmvlPyFmdAuNrk0f+3yWEbvsyf+8JIHIu5RXS
+  /ECMNv+BMVYwVugQIKT+Jt4qD+t9ms3oTto36+zohJH1Bc7FcFgaV5XgsxboOXKBp9WnxY3Ioepb
+  82m3ffG8ZSVjKoVvIwSQ9S0W8io6PrtH/XW31uXp6J6uULuoffIvjXKJfq5l9abqAhlBh5A+i3L8
+  FWqC7Kg2FMP/nqeUZG/IyAOWZ2K+E31nekQJ/A8WDgO6l/o0j1HePDriLwEZZgj00usLgxH1C9w0
+  pajti9Hsh5g30t50EUZOi/PabaXaGeBDPsfGnhONTiXqmsbp8Zxb+ct5nBPLuLlxN7wcDRjUEMCx
+  +ANY9hXi4WSjANIIQpPQECEneYHx77XCnKNrUw3hAQGZ84Z1XeFSENJzcqiAiO+gtUfr+7nSF2HO
+  COqQcyue3zD7lKGC8eBmOIXJzfs9b0/AXnoMBRwztVqvq9tcPxjiUniZiNLqLwSuqYi4NPUwv8Cr
+  /r8yn0NMy/0MlamYTLSqXkWukI5rb/RtwScrXQJAcXx8JqKUF9nAM7cROkTSENI/vLriS3a7mrQy
+  LcHT6ybLgrCCYoHlxjElMCMGCSqGSIb3DQEJFTEWBBQpqFSv5Vo3CkV4uz/S03tks43T6TBBMDEw
+  DQYJYIZIAWUDBAIBBQAEIBXATT+qxru4f7wxcUU0///Z53oD07j5dOfQ8iNJwCrbBAgqx7J7n1OT
+  ZwICCAA=
+`;
+
+/** PBES2 with DES-EDE3-CBC and PBKDF2 */
+const kPBES2TripleDESFixture = `
+  MIIGnQIBAzCCBlMGCSqGSIb3DQEHAaCCBkQEggZAMIIGPDCCAwkGCSqGSIb3DQEHBqCCAvowggL2
+  AgEAMIIC7wYJKoZIhvcNAQcBME4GCSqGSIb3DQEFDTBBMCkGCSqGSIb3DQEFDDAcBAhjoSMhLfWO
+  ZwICCAAwDAYIKoZIhvcNAgkFADAUBggqhkiG9w0DBwQIWoL7w9KY+b2AggKQno/j0aItKU/XZnk1
+  twWGMddUmeTBZR21wf1XwdZxJH38twuyqCsLvaFe5jmVoMlZoZ16NibSSXyfG9XDmlvbt45rXNM3
+  lZmVHawdPZDaroKCQ2fVefhdQcAIz3XFbeOp7JTq4hC9ClvjSwCS62myMtKzUi09KGk0m5DKitAY
+  XlgPPoNLVOkRMnfKEQic5cwswqDgD75X0Mq0vfdpP55ZRu6qnz/hmhwNSjEVusa79rsub3D4nB8Z
+  dYHHIjM4X3T/ePfNn1gSiGa0QoEA8JvSJVUR6iCpuv7IpXaaqwTXIjwleFktxNvstnoiU70K0mvr
+  j1qBlyUOegxZ6vKucNdhibJnnEWQq22AMlsF9W4FVvHL1m4wp3YquQRFHRC7KxgYGv3oQqqQtmk5
+  yfB1xgJfKjgXz4n4oNpkZG9Rus499tk0WqAhlzbUZCiT6Tb7UnG1pC4POh1m5BF+0yvXE0HbkWhw
+  8ju3zIJiQqs9KFGTSLXyNvxtzQ/E3vTCxoIN5kGqF8za9+NPLfeKvrzNFwIiybWFoyLOsg8Gorsg
+  Acyc5aY8dOUE2Ba0trh0uvhLF4A+ZWwGAIZk4ykSdR6JSFegqRm73aCU2h6W9Ex+/JWXWQtWP8N7
+  dor+bLRncZy6HC2tnS/I33R5t/f/wmCQNeCc2AHsuB6YZ5w2Ps2YIkAN/YzxN4ogHrQtXWjQnnMr
+  wUo/vcdHcYfFBnyUAHGlJxP8DkUfKJFiTbiE15nmt2irwEHp/P97hHWIQ0H2zpTcHL42mVI9bzAe
+  DP/EWOdeH61KycFxbTQLbi7PnCDja02HD5CfwVuUUJFOxgZrf3FXBN3wWKoGS3Q0lj9sRKT+OTGW
+  9/1164lxPQ87kal3qykdUp4wggMrBgkqhkiG9w0BBwGgggMcBIIDGDCCAxQwggMQBgsqhkiG9w0B
+  DAoBAqCCAtgwggLUME4GCSqGSIb3DQEFDTBBMCkGCSqGSIb3DQEFDDAcBAgOt8epG8LZVAICCAAw
+  DAYIKoZIhvcNAgkFADAUBggqhkiG9w0DBwQIb2x4o6zK+14EggKA8v/h877+aM43VZg8HXi7M45q
+  9XydZEQj6abbo1U+5Ylgs6patlYUWokKECExY56CeKdTM1coOaer2GVvb/DENTbKfPG/Rtu527Eu
+  2hvXC/BLxC2krV24f1aFMT1u3CNgHS3aqJUYayEzGrc5hncX4Z18qv2rzQ71MqAZs+cuAt1xVj3h
+  diM2sfTKhU+inKmeWAqO3Xty2CjTq/wCCSgCTcNr+4C11EGJojEGLiiCEFc67wek307HqE62jVhe
+  J6T86auwR1CCtjm5AvfubpKOmQW8RxYVE9VALIBxwF+4quMFEUliQOj8u632sfp1Mu43fjicC8UQ
+  QtVxsVqMrxQkibH6mxXZGNWszL2TJN5r1F3XtI2VbGBN1eMQXH+4TAPdAxUXk3DgQbvmAK17k+9l
+  Sn/Ch5Ec2hKKBfKAEuEkanBYQEohH7jbedpAytPfFgqaXy4b5JURgqvKHBeZqawNW/SvTWdrj2OB
+  C5eg/YsscBS1NPUYp/ljWUVmpUhKN6P6S8hUphQhKI6IEioKhtdzBjWBE+K9JYy8by5PGSUWdWt7
+  Wd024Z0fKGayuGY1+h8wQk0FrtRItbi5+qqVriJTzCnUjoehySdtUsx2WRLUySzgRZVqDKjGZFVM
+  N7jTqqxmq/DOm2ab7HKe4shC9DrTIIFqx9yzlaE1Q3l7h92jMeZavObvE5EWL5LsXHETtZt6EP4H
+  0mz1ysbBe1LQI6y+oXIYsAB1vxyNXCN0Z6an0EetTQ8yW44nhMKCyMjphVX2xfTiB6uJDHUN66Ab
+  hLo7JIFXhgTzb9JJHX5JuDeuQIiAkcCbfA/tk0JPS/ZZEoMGGZUQubKrQjMR24Dsv3fBAjElMCMG
+  CSqGSIb3DQEJFTEWBBQpqFSv5Vo3CkV4uz/S03tks43T6TBBMDEwDQYJYIZIAWUDBAIBBQAEIFH+
+  QNlCM3SFp9hXsiRkuixvl7wHj3oYPm22ww1lqN4PBAj9gxABrXSALAICCAA=
+`;
+
+/** pbeWithSHAAnd40BitRC2CBC for the certificate,
+ * pbeWithSHAAnd3KeyTripleDESCBC for the key, MAC with SHA-1 */
+const kRC2AndTripleDESFixture = `
+  MIIGKQIBAzCCBe8GCSqGSIb3DQEHAaCCBeAEggXcMIIF2DCCAtcGCSqGSIb3DQEHBqCCAsgwggLE
+  AgEAMIICvQYJKoZIhvcNAQcBMBwGCiqGSIb3DQEMAQYwDgQIVBbi1RBWzikCAggAgIICkF4BpKiM
+  lgFtNSb4tL2Yfwp90EWLlTcvZ8Db+5taK2uUxcfJjy3mBjvONmInlgg59zsABVm73YDWczHlydz8
+  IUzStjoadRjyKsH0bbnWvTN8woFs904ZouPUO5SMn+M09OMIJj0PJH9o5UoSbMV4KBMO5qcLmci7
+  E3Zs9GfONRcpegkEX1TF3X66VYzrGW4+nZRwjJXV/vcgcwhqCp6FQ398jOCeicAKFQdo468HP5Wg
+  teMsnvJIjeDXOxmcr7UoKnJ1CVyc3/CxYum08VtDbz2fW/8gsN8ODf4dtJQwOerZK/fKHV2XBfyj
+  yO4nCYuGnijmPTwNQ2abgeNqFjt8ZdAih4Vo8PPPr4TFrcQbhue8vzQTHuKy9zhdD+PxLL8BpSmo
+  sxA+kxaJndeGNQ5aitjjW7CCQ9Qo5J5lbIbPqAtFeUHt6rElDQ4yDomg77C+7J28ckrCnBSX2akw
+  wgyEkmcmWC2fECsobWm3l315DxNmzVukbzwODkdhMGsLhYEiKu2KnGzywoXeo1nJPULJTISJsUFL
+  35pXW0QaRF1uI2pRCZcBwxukbb1dKE3wVtPWHPejLBaTcEXjyi+pLrt65wPXYKyYNpwgQg76iucO
+  nBOBZftJmPDCW48YnthZXFxSOUCVO6u6dVyeLeZ+UP3a3e7n0umvRnPtSWFnvaaG+SqXEMrTPYP/
+  GD5jhd22sWrxXyL+oXqS5yUomXIT7cKZqPXJ3/DEiHXYvAVJKeDNeYJH8GqiXTcTi9AbzHvqBVgH
+  uFBr5D9YK6qNpve61wIwG6wIOhoZsEZKC5dR0Dtniw48E3et2lBqplloC/T4hR8a4mbpdV8p/85Y
+  VNH+VJfRjxGhpu3hzIDVC4tJmeTuf1FtMIIC+QYJKoZIhvcNAQcBoIIC6gSCAuYwggLiMIIC3gYL
+  KoZIhvcNAQwKAQKgggKmMIICojAcBgoqhkiG9w0BDAEDMA4ECAeppo6cUIr9AgIIAASCAoCCtU6E
+  O7Vl5ykl12MqpmsKXVdzsLXsdEE4dIh24llRkNWf8EgSpZ3/xNXCSjqLQbDDQMVGGHzMJyw9CXV7
+  3KuJHl4jSNCO6CPHt4e1Ut5/8xXbUW/vfJJjTNoBudRf/GXbqCIBN144tNXqEgK/UIpJ986dsWra
+  MfnhS7AiJvxk/1BpV8l/5aWFRq52j7DvC5OlyaSC8DSr2Tp79/Gpjgh3dBkoc4/3mMj4HNhmVonx
+  xGfleEcas9ZcoyxejX0By5osr7oRF+V+WW5kZakGq3SIfEnob4Xz2iYbB7vj+kYCLU88aa3T0dhs
+  1pEDrYugryBO0+vqrOorFJfSjOMaJY3TR2p5li05+It34B13QkdZg/yF/p/LASslS1WIsEVudTlk
+  0Z8DN+9LQ96LexVKkvFwrW22UUeGzKmnDHs3PaNQkYYoSlAhaKyUEWxkylNl/k4qc89IOLqmXdpy
+  c/3DMeI0FWfywX9Rqo8ixKYRIwBOjagIY8qcsjirEigzHDV4BgTBcicCHR1Jqpq9AwDigwUaV1/3
+  7Kg3beOuZbRogqbkHf9pJsJp5k5r5FmnoA/uKkbn/5YZRpOH/8Z8tSVqXN/7zDptsG0cMhPM7xls
+  GJV/itQFKdE+2KzqcdaCt7JPFevyAe9i03tDj79ce4bO+egHdrQewhJiiyLsVnoUiDDJh7Ot1oID
+  hSDgURBcjxf1wyAhq/RG2W7+AA0fuQ7gof1HEb/q8cay9TMvNoAoDORBBgxLRciR+f2KA4ijh/3p
+  CTWawP2gqCTDRnbjrKmCQofw5JLXJIvXr17c4Jq4+cRXeWz//vEI8tkGW5ki9vA9l46hO/8ogydy
+  CTGzoJ0B1ygsMSUwIwYJKoZIhvcNAQkVMRYEFCmoVK/lWjcKRXi7P9LTe2SzjdPpMDEwITAJBgUr
+  DgMCGgUABBTn0X+edNyvSf9tMVP9Zc6YaWP4XgQIXRJ06sev09sCAggA
+`;
+
+/** pbeWithSHAAnd3KeyTripleDESCBC throughout, with 2 certificates */
+const kTripleDESChainFixture = `
+  MIIIWQIBAzCCCB8GCSqGSIb3DQEHAaCCCBAEgggMMIIICDCCBQcGCSqGSIb3DQEHBqCCBPgwggT0
+  AgEAMIIE7QYJKoZIhvcNAQcBMBwGCiqGSIb3DQEMAQMwDgQItOl75nUQO9QCAggAgIIEwKT6h7eQ
+  feAOZhb8mJd47yDy9fW3VzZk+DfppHFNg5mmep3FvLmDTSGYV3LKPTCkSB2QtXkeRXrKVBHB7wGY
+  u/nVh3cEflWAlqT8nf6ryy4bZUBLSHQv7fH+iIcJfqX5z9AWcEekaL2ifUOkZIUXjL3tCBICIaA5
+  JEccnpD7ZJ7oUDCXJmniaWasnzOULhkcqPOXDRa2eDubOrQ46qmotpqRY+hcUahRBYP6JGqGvMM4
+  hqCSVmCyEfz4qK7VhJ8LUv6gIuW6uRai2Jmlja0+KY3J1ULez7Eg4hdceTs/StF62Fz9Ys3Yz1pY
+  2uP5WcjYkqBHcQ41RgXRfjcugVBf4JNWB8uWR43AOGvSmRWHYjz1+cY1KNErf6vptLakPg2I+wtG
+  3SS1sC0CwdIbL2QF6YX4jVKmo61ZdJCkd50MzQm7xTSPew+zrRijcnwVZIgyewwRy/Box1EGkTo+
+  Ecf3nx6u6w9S2HrgW+2PIne4rLb4jp+URAyTQwWdvVOxZ2y5BSQ4VfeESCtKS/Vji/ucG0HCGAxR
+  k5UW5+lrxKuQQ/5NblwMbvdbYZ3FY524y+mYfLh64kyHkVSOwsw2wum0iFzAqlplrGyo7KEQTtCc
+  b4C87k71U7p75bxwUynTovlhCIbppAcGX9O0/0QV0qXAbx9zjwmjsEN9WC411uezZxotD4Iq3Lfc
+  NuVzOhLS5lcOgR5M583Lior6gF1D43Oznh2Wys+on/Lwp+2BzJ6YEvWKOh7PNQ4cUM/T6zsqNrGO
+  7c8cm25Ylattsh9vTzO1Mb3+wXEoCFYRe5+2yHsmS0Yq/6fg6gv3Z1irV6yg5592dS7ky3rZGlcB
+  h730teruuWco4SanTPAhsWA+quzxq5LhEMN+ZHJcccTaKPAdjtc9WFMCMNDydBqw9v2ZlG5fZFsA
+  jAtI+FVAw2oGqP8cu3bfW6nhgrVmABaUh/r8f2DFI3nHthNVbpKwpbyPQBruHtHsyyAVqxXc0fPv
+  Y8NI4NLubpWG3Oc6m/Xl3UxYB0byVCEz1xofHdQu4q4LWskhHvkQqPTW/kyWw3fuUJ09Fn3aw2Oe
+  RG0NiaH2hSYxk+l2XGnzhIU3VHQC8vXxxq7ZpxY12ziQvPsUvsxq7glYDqasCSFbBme4jqtB1OW6
+  KYYgvNR0eNX1xcnDKoNvVQpId9rvPHMjW93jQUhwo6zbEwOn7KRjPnU3OEVcBnOJz7EubzTXfIH2
+  pdIpX1Ux7YD127SOky1yGO520KZr7827YnV0zn/TM56bhU6A/vz4mj274q0U8zLhx/CUxTuft8kL
+  BzrPW/pXcAMvxsfet+LT2Dm5J/oVn524TVaNoWOndpV4eYSy2CRNbHzdsyaMCoCs9/ZhaB0SpF2H
+  o3Crt6eUcU4n6H6b9xOSRja+mPzOR6OudI9oXgvyN372oidopzn6M1bDKR3Lk31Qf67L0YcMZQGZ
+  E84DC/64PkEBt1tScxztZXcV07qUUCwmJFynRNAAzhpKyw/3TpsLLlvEynftgCCHs88Uj/WfdzME
+  JSny9ZWFSNfpGdzQuABXiRQiXwyOVuNLW4xaZlK+csSRENINh9zTJYOhUSsdEIoUOOsoHS/8zKBo
+  xyhz/XowD0HRUVxa9KcwggL5BgkqhkiG9w0BBwGgggLqBIIC5jCCAuIwggLeBgsqhkiG9w0BDAoB
+  AqCCAqYwggKiMBwGCiqGSIb3DQEMAQMwDgQIBGnJZukitrUCAggABIICgBNrX5pee+tRp6UuhwU1
+  VOh5+U1170pmzCvZMthEPMY6BdgUKhLl5DYsQVrKY6HVaP+HBe8GdubsfA7+AjKTB/RlvJPYlFq3
+  azWmb4AfgoHeNBARlqxXm6OdarirrPxWFjf2l8kTAhe9wQvJHUCxpkQZaXoE5B2z2CbPe2qffGUf
+  CJMv0l5omr0R6EIRS6qNL3BoXyYqx2ZZbEcnrJ5N6gRX4pRdI9r7dQDHB9jBg9iMHdeQdL+AX2OP
+  C3uyTnDHNVIbpywPjxT2zpBhgXFcDoS1FmKFwdRc3h+qyBV2Lih39ac2FeH61GrSjcyNTuIKhtrJ
+  VfcLRzOkUJysS9HuJoXzsgJBEiE+ob3Q//Py0nmLzK7NidYMv76UOTnPDlwD7pSXSjUnsVr0cpnZ
+  mIpO3KEkMPFVIr9xmg7jBKBBbuxho/GSj+1n4U9K3wLzL7DjEDIoMZD9Cosu2chR2mAmaiVJWJWw
+  DSczCR5W/gLgjULJDeI73d21BrRK4iY+GJpYoomSEzfeB60jgZMPTwavmO9XIOb+avNQIRarsOhV
+  9WaGHisdQ2FMGHDYWb6CaAOwcSsiVZQJlQHeAWjwK0nhMyMl+EClQI7tSsN0XvzD+y+Ry2EW2PMf
+  rdBIgbjPusMgbuCwkv9yblPzlp0rtNGczCOe52ZHGe3t80zElftNjacDadFdNHbzmwdUM1FUiaTC
+  s40DivXsBgc3tmyeD8A9DmZVvGpiWet7iF34ptsbSlcXoJ6qUf2fSYgqE6S1o9CPtis5gyvYvL9b
+  EAdjJsQJdhni0uR5RMLmrjmbdIsan+ikxhoPS6tj6jJGFngr7b6d/EIAAQ+R+tleqdtkl/ZlhqIx
+  JTAjBgkqhkiG9w0BCRUxFgQUKahUr+VaNwpFeLs/0tN7ZLON0+kwMTAhMAkGBSsOAwIaBQAEFPKM
+  cKU81QDv97Net38MmYKZoviZBAhwAxESlWr9oAICCAA=
+`;
+
+/** pbeWithSHAAnd128BitRC2CBC for the certificate,
+ * pbeWithSHAAnd2KeyTripleDESCBC for the key */
+const kRC2128Fixture = `
+  MIIGKQIBAzCCBe8GCSqGSIb3DQEHAaCCBeAEggXcMIIF2DCCAtcGCSqGSIb3DQEHBqCCAsgwggLE
+  AgEAMIICvQYJKoZIhvcNAQcBMBwGCiqGSIb3DQEMAQUwDgQI2CPRvvDfztwCAggAgIICkFqP202w
+  v79CI6OKzG7JcVkjMtc4zweBnEjtmRB/Dt4eqemztrCMtymLKzlInVj7EaElTeYrLxyK3BSuO9eu
+  jBvH4pk22le/9bao56sd46H5vmLb3i14xdi257TARejxR0QkRN2bpWhoY42TFW6KolwZTWGco5k/
+  Zn0CPuKSUyNtZrvmypdNVSHZ5CdvUqjy+VTrMRNZil7wKRfCf51yWuPRh0GRlvH5r5Gim6gLzOmj
+  1UkL/mfJEFYCLPU+a2DAN/ZwG7+rccylaAgnFQXNQMyNqJVfdwNhx0h4EOUc9ypCvfcKBnH2+AgX
+  EWawlM8a8ZdzMG4UAHEDa8DrpC1NuhWRvgEaiXTsI1mi02g495fVMga7SSGpo5MJSlMT2WKdxc7M
+  mEUX1892acCfTLXctpZTYREr5oSvPULth0WEjLYsx8prpsx/FQElGdmsVd7olYybv0RjWl3Vyidr
+  onZHywI5teAvgVMFMS5H//TC/oJ9S0IwdB4Od84+zVHNuT3ftx3gC3i6erR38IMOokia4hVOZWR3
+  Y2E2u8vZv+89X2wE2oAToLFkGO3Xqegpv4qT9ocC3d0XQ3MhwjmyZmeikxcu5Oek5zjvPfBdplFk
+  vJ5xnOEAGZGeM9n1CcPhtNkd/8MP2aa6DpK+uD/7RFRmrKqalXEnDF/o6I67QXsFD2fvEUgHniVt
+  HCv058HyfnSGoKITOS1y9A6IaNryfDFsoEtOFp7xC6a5PjwTZA42YcM0jlCtl9gLdJjycmYGpaE4
+  RbCDMST9QE9hEM1/CC+jB79Na/gkz6/rnlkCSeTKs1dG/l8nv7CjkyTrdtCegZz5jZOqdALhFiiU
+  RC+FLcaWHLnMq8unjM299MkhWHvbekqtMIIC+QYJKoZIhvcNAQcBoIIC6gSCAuYwggLiMIIC3gYL
+  KoZIhvcNAQwKAQKgggKmMIICojAcBgoqhkiG9w0BDAEEMA4ECL7EpmSwzW94AgIIAASCAoDb0oA+
+  BVufrQEP6fX7SbhcJkSq9b4DysUsvMczOcQ3vqw1jCMJg25nucys8ALHT0j8u4My802ciybYbCEG
+  DDQP+0MqEToVXr7qmS98JocviPJfKRnW6SO41tQV3ltzRpGtYBjW6UUohDiAoIW7K8NlWGvp7Htx
+  X1tMAy1ZpZfCgxiQcOlaC7kZjpOOZcJmR/KBX7vmolrlTHbYC61nlf+p4S2S7ibH0bndkpaw12D2
+  dWZ4ybaTVqWt3tqqE83s2+zpao+tXi8zOvKjqknghhdAg/+6jJoZkeJ8q8u3rL5/ZqGtL+0rWwrj
+  Jk9KWPY5BI5zhSkfRrVjBtjBUi0UAQMc0+rwu18RRAE2bKcxhcXmTha52lRkkb8pwfxY/qD8sise
+  XqTbdgtsb0ror7yfhsY+V5XW+f8kbjq4jxaATKBRj9QGISDtoktM0+dErI/f04JJM4qeRhZU23iH
+  YfPBsTRFJAoQ1fj0nW+yyo6CcujecTmfsFttX5c1XDc38XBO+iWjaiFkjCZ1bgb+eqwaXEh5JDu+
+  XuCLacncj6d6+Sgt+coGUF2G4a6Cf0j5lb46762dHyQjnqDJaW9b6LumcH6i04rNgoA7PPti6v9i
+  rtJ8fFGmKJ4teASCt1S2W+hqxv721Nr16BSE5n/izQZVnxOBuT5NcevUNZaCbq/wz7YsWIx9YVye
+  OLfn4vljPenPNm+8baX5N5HZSL+zdH0Jkjg3RcZ2R0DUwegi/p1xxDm3noD4i8WZkynt2VTnXF7y
+  ycP5Z/U4CzqknwvTVjBsTXN8/C8Ph8EwBk3qlpDGVhYFU9N0SzN9hS0LKrpVpRmwxlzSIN6l12dL
+  w60WEvjGYryaMSUwIwYJKoZIhvcNAQkVMRYEFCmoVK/lWjcKRXi7P9LTe2SzjdPpMDEwITAJBgUr
+  DgMCGgUABBQkFO3YRbewM6t7X7EcIt7lkXX4TAQIj+EHz12u2a0CAggA
+`;
+
+/** pbeWithSHAAnd40BitRC4 for the certificate,
+ * pbeWithSHAAnd128BitRC4 for the key */
+const kRC4Fixture = `
+  MIIGHwIBAzCCBeUGCSqGSIb3DQEHAaCCBdYEggXSMIIFzjCCAtIGCSqGSIb3DQEHBqCCAsMwggK/
+  AgEAMIICuAYJKoZIhvcNAQcBMBwGCiqGSIb3DQEMAQIwDgQIemuznNq5kGkCAggAgIICi25H+zXm
+  o/frBwdS8IxPTwxWCDwtdpP9ncEdUtIPaa/FccjC6eYo8RS0xJa1hvwTOfIFVfJscrq1qXn+pm4k
+  u9cQZdhq50mDA9lv4zkoY6BqoGOELbLiBxOjbAvvu20cAqmba6c4sn72+r6n8JSQ1s3cSy+opwO7
+  jftDLhPjCdTW3usHqhngPNW/+gS6Ymksc9jyUXI3IvfI6+24DHphKnPbB9cxXh/YhBB7QNfdCWUx
+  rFjE+1Fdvo1kuVHGU3UTG3b4N4pLL7Xz51tELwP2ztyxv9T6aMELlra1ZsmkfpzMgYTqut849Llc
+  q9RDSQW8iIvZ/MwlfTvUUJqfxuGS1XXWmlLNYDbD+JVDqNeyI707sK9xGqqSKag44ph7MRzMt8P5
+  WSDXXVYNODmUX0AcmzuZFExWUff8/+1V9f/JU+WFMuWdV3rdi+atihYOfbjHl0vTC/93378BAN8o
+  IvTcST8VCadNIn/UGmQyQzmeitEkuTP/fCeseKb7E/B2NY2mCDGq9VcJ/Roce6L5MWdZyqc1ggsz
+  b3cVsW5bO7WV7TiR+Qv9YzkHv1QbnyRH6iW5ALQ9w1P3aM/SKYc3g2LG1FH+RMP1/7AYwHoYokfi
+  hoPwHpER2mOBOuoizwSQah/7VbMSJSM5JIH5ruZsslVaKjEJfpxv22nSgOMVhUnlF/2FHENBtr5D
+  Qn4lgRHoIePV5t7GKn5EtXB1zQReN6qe4NPvRQx2qiTjx7mzK0rL5+uZxvTJgYRqMGvFzNGkXgi3
+  EaNsILvbPlGFkksV85+u794ulp2dDkWz2J74bjHBGU4mnx1JUQgm9aJH4tbi5mFh44sccZzfZ1KK
+  HjqWA81rqTtD+uX0cRAwgt98UzCCAvQGCSqGSIb3DQEHAaCCAuUEggLhMIIC3TCCAtkGCyqGSIb3
+  DQEMCgECoIICoTCCAp0wHAYKKoZIhvcNAQwBATAOBAgM0Na5IGpCTwICCAAEggJ75CoRXs4V2Ufq
+  lz91hA81PpcWpRA1iYif7pybIHYdRJEPRXZIjoP8eQQl8dEYGVKHjYZf18pdr6fcdybD1axpweWh
+  E9GWiAc4UKdQRnmWvTg/cUZD2w4tBzS7tGtkxjbFFWXhWfw6gEkEYm3NGpaG6rDBzD7SuhqijVVu
+  VQIiom5ITm+Chp1fquwcDLbtT5HEhV0ogC22dWicKiLfmjlKkx7HDfG3cjVjjinEeKo6TqTavmXg
+  mzybO3zXCo8G/Eadj6LMoPa9fw+7ttX7cp53jvBk+vQdQYjI20+gq0d8gYYmcPQp6iJaolYNTi0P
+  lALlXK1TtZdtP5oZ6IqyHQ3ZNQWje7sh5i1RO7BJ1XtzhLtB/ndG/9eRWgV4Z5gaM3PKbYuaAZru
+  EiYM07/ZfYMb7takMx6hsco0KbWWG6PXaonIDhikmAd8VjxY0yL3ciI/zbepQy+OsSwXu9O9fmpl
+  Bm4XTPcCiphXAUEYUul5qoTDedzcq3AVSX2NXxDxwDBf/UWKjS08sQXWGYdCaSLcqRRISd3ZcEzs
+  DJb9u2RaJxxm1eFkeClY7NwhusacFEMV01nOy8BBcdDit9mYvl4d7/V/S6svro5rI1r9uxFPl9TE
+  TA00K80ymKFK12OmvY+9mVEvDCmo1ZmjEYs4r++ErwPlE63ehy5G9D3vqGN2afMRWOWki4kCklsu
+  VDAmZ+zkFpYDfE57nEapkANAh2zt+2aM9RDPOkM2gtbIl/rdBzNOrjwGtI7WLpYi60KT3BhLKJM8
+  VUtKijJyf73h1aoKe9pTRsIDdrT9zE4C+B3gSBtoCq1eNt6aKTy6gidA/W5vo0deMowufFEpg8Ax
+  JTAjBgkqhkiG9w0BCRUxFgQUKahUr+VaNwpFeLs/0tN7ZLON0+kwMTAhMAkGBSsOAwIaBQAEFIW8
+  Es83qBlVTmAv90hUIlx5zHqkBAiazx88Y7+ZrQICCAA=
+`;
+
+/** A keyBag and a certBag, both in the clear, and no macData */
+const kPlainFixture = `
+  MIIFkgIBAzCCBYsGCSqGSIb3DQEHAaCCBXwEggV4MIIFdDCCAp4GCSqGSIb3DQEHAaCCAo8EggKL
+  MIIChzCCAoMGCyqGSIb3DQEMCgEDoIICSzCCAkcGCiqGSIb3DQEJFgGgggI3BIICMzCCAi8wggGY
+  oAMCAQICFCsdOT1Tsn7gQIjwjK3twBLxKoczMA0GCSqGSIb3DQEBCwUAMBIxEDAOBgNVBAMMB1Rl
+  c3QgQ0EwHhcNMjYwODE4MTkxMDA3WhcNMzYwODE1MTkxMDA3WjA1MRIwEAYDVQQDDAlUZXN0IFVz
+  ZXIxHzAdBgkqhkiG9w0BCQEWEHRlc3RAZXhhbXBsZS5jb20wgZ8wDQYJKoZIhvcNAQEBBQADgY0A
+  MIGJAoGBAMMpdIJgx5Eh6fPdy3ltmVVsTo6CT01qdfOl3jCHLi3OVyhQQ4PPRhwClwX2DhS58Bgx
+  FOSbHm4P1xzM+fIWmreJF70cdehNLEtYIaxRhesJlSYpeNIQ54LVNort2Ucb6SQgEHVC0FUGZ3TW
+  yH2t4QcWDs1hOGLWYBnQGDJV2sMfAgMBAAGjXzBdMBsGA1UdEQQUMBKBEHRlc3RAZXhhbXBsZS5j
+  b20wHQYDVR0OBBYEFG9pz0D5sX7A4qNRgVacZ+sPzJJFMB8GA1UdIwQYMBaAFOKgRTpCoxBU3xtA
+  9NKPthoaAWuiMA0GCSqGSIb3DQEBCwUAA4GBAE3HcUa0OpBYanmdBesB2EzB4ShK4putValT5Ht0
+  lq+k4Oq7mwZntBlkKplxcwAWEYduBLMeL35qcklGyl5bWRvlyg23LE8u7wT+kzrpSFTPfHDuM/on
+  cb44i3ZOi4gwOv5OlNvF5VMsXXBMRDVyBoRIeG2erGeW4P8+Th95bT21MSUwIwYJKoZIhvcNAQkV
+  MRYEFCmoVK/lWjcKRXi7P9LTe2SzjdPpMIICzgYJKoZIhvcNAQcBoIICvwSCArswggK3MIICswYL
+  KoZIhvcNAQwKAQGgggJ7MIICdwIBADANBgkqhkiG9w0BAQEFAASCAmEwggJdAgEAAoGBAMMpdIJg
+  x5Eh6fPdy3ltmVVsTo6CT01qdfOl3jCHLi3OVyhQQ4PPRhwClwX2DhS58BgxFOSbHm4P1xzM+fIW
+  mreJF70cdehNLEtYIaxRhesJlSYpeNIQ54LVNort2Ucb6SQgEHVC0FUGZ3TWyH2t4QcWDs1hOGLW
+  YBnQGDJV2sMfAgMBAAECgYEAkhkljDixDTfLMPF30kY2xFkZEdwBS94HwMcJ52A7NLVET/yOHk17
+  mZpivmatsdxkHWgY0O5CwHgBPCFCd3Vuiemlo9cmoXV8GvjIgZWxRJSHIJOW2N6zG1hEOg0UI3E5
+  OEo/zOgY+SeNPq14gTKpwJxDB+OggM4H9UtwGdNQTXkCQQDuzosYXC9K69BQQv3ViZUSDHm/sKjH
+  kMQzqhvny+1d8f0EvjHhy8IOuuY+I6+oSHTCI8QshEWQe4V0q92vNTErAkEA0TZ91aW+j2VKiQiY
+  hqWV0hH5WUpybJt90lV14OTR1mcvhVm6tbY1fVYKnnioNMhV70Z7AxlqCuZEuSbkuQtz3QJBAIhS
+  2Ayb81Ntsole9NCFrdeTz5yiGHd0KMzlevCj9Wj/z1R5zrf7PVhzUSR/8rK6SgzZpg9TovKL0O99
+  fRub3ekCQBsiaievm4uVo5kqWD3+c/QPCLwf/78+W49QLj3A78ZTE8LD5Id03nMnGbF8DLTr1tl1
+  1raMMUjAnOE2viuR5LECQEm6qaBnzXqmy5KI+Yo3yiF9aVMHhzbJsKN/mwVGRk+2Vu+KZWqsdITY
+  PdL6Hy7+vTLGnAOgeNWPdfTeR4h9+kUxJTAjBgkqhkiG9w0BCRUxFgQUKahUr+VaNwpFeLs/0tN7
+  ZLON0+k=
+`;
+
+/** AES again, but the passphrase is empty, as `-passout pass:` writes it.
+ * The MAC and the contents are still there, both keyed off the empty
+ * passphrase, so this exercises the key derivation, not a shortcut. */
+const kEmptyPassphraseFixture = `
+  MIIGrwIBAzCCBmUGCSqGSIb3DQEHAaCCBlYEggZSMIIGTjCCAxIGCSqGSIb3DQEH
+  BqCCAwMwggL/AgEAMIIC+AYJKoZIhvcNAQcBMFcGCSqGSIb3DQEFDTBKMCkGCSqG
+  SIb3DQEFDDAcBAjHULyp7g88ZQICCAAwDAYIKoZIhvcNAgkFADAdBglghkgBZQME
+  ASoEEBbyfOJtd/Ob9uA1lAuAW6yAggKQ+getg304tXCR+giSFaTmRQjHyFTlhgDp
+  wuJTgI3QlY9PHZ/zcJl0e4FhD9SA6Bd32aOFiGkzo2Yyrzv/KgPEMzd7pp7B6LR2
+  LThu2n3BdMhXbHAcRjiPN0TcTG9+JvxTJG9vkxHmc7MIp+92wGud8IVvwcSW/rxY
+  wnMGDscZTHL9j+D8cnildtvMPJJD/WJATQE8srfoj+Vv0n6woIPsxlWhWInBf5XF
+  aMgiSP9IxDDNOT06RWNmmkD0z9m+gGbDOv5YhV5KOXdi+IVIyjtsGYYriVWdlJTn
+  ZZloUc49FAZYM96m14r7lcfRKMzieKM7VOjsNcjX5u/Z3bc/KaegqEjbn55XwPLL
+  lyNY7FA9fuPoi9Qdhm/YV3QXqDAu+ShI/SSiktMu7X/4lkdxZ88lorcYDOEkpOep
+  LPyIVJ+XPxNTXBkaNEPCKmTDFP7tExOHwYSfbKOjmM+DfuY5OD1Li1/9Od3+nq/u
+  sREp7xOPNkRR/c5K7d0tyVSdl7Yf25mROPDMNMjTuikwMOqdBEQzhR7svnvZXOMm
+  /85kwe8xRwdxmiFqdZBFanc1Hhng0ebi1OMV+4fccLDMna+MK4MfGoNB5tZem8/W
+  KduBZmmGtsIRHH816cNVjWNk2xgic8ANwAw2D0ooDRgn2leo/RH92rpbtHqoGFXA
+  pKjVOLLmfGdcNFoDkv8/fjO1oyFQ7+LZ8pvhr2S8YcgHl02uf4T9ICw1UoRwuiBA
+  v0gNJ8IyhwWmtC3codkcfw7ggs1GuJPwXSMyEn5wMaNkXcDwap131bS5ZUGmZmIT
+  E6IqBOgClgukUNkmNmm6giekqErD6ywlWXZ6+Lgmiw7d9+CPVg4RQvFI7K0ujWwl
+  2WOCr4zRYYAwggM0BgkqhkiG9w0BBwGgggMlBIIDITCCAx0wggMZBgsqhkiG9w0B
+  DAoBAqCCAuEwggLdMFcGCSqGSIb3DQEFDTBKMCkGCSqGSIb3DQEFDDAcBAhnxFnb
+  aJrlzQICCAAwDAYIKoZIhvcNAgkFADAdBglghkgBZQMEASoEEOa7qxx7sl/zYc9r
+  /Xf/Y/YEggKAbV3rvC2ewZb0rf6WhfK9IM2sQfMdRa0CWQbEjJ9CREzuY3X8lejL
+  Zj+pCrjvb8f/0wl7N/MIHFiRs9AQJzGRMhVqOqVLu36QMVNUpdVXuWhTc9xUGSc0
+  Q3vZvl1oVOrsHc945T6yjPN9v5sgzSiNEOB+Vll3QWxhGbMAviathZrDTw6FzU6N
+  yHQm4g5XHNfaXJV102VMNuJUUCeHajKB+b2P6JCq5gTLiVIlb+OAJir2X8m0Bv1X
+  pwE5c0MUgNfpGBxMfYiAjskWyzcs9gB/qhl63cjLqBwj6nN3RWS0dT7UOqUMwfuW
+  Ww/dNuDqCK4Djod3/xeckGR/qj4uQmGbHr1500nTWG4qwx/V86apAmBULWvHahJP
+  MQ13ipSrfcfN7CxbBBme+oU7xxtWaVzUoQUFys3S/m7ArqtwtfSdS2euGQ+PLbEx
+  GCA0k1Zy4iqpx3kj/K8GeYUbYgJ75mERZi/LbfMOmEHZ1uVnjVI0oDhFTlsDcLBj
+  JbIKNh5yW0yQHIvQzh8xP8KXe//frCvH/vkPio5mtYVBnmtFRWBsrGkhU3SOVYTq
+  4alxgX4cOTQaUnTVXAjWctkILxb5ZhChCvE6VPVE9PAI9JwYals4zmLWKZGwvqx+
+  +Zsoi0k+4XDUCmjx1zuTzrNi6hNmf/TPtZik3H/oirEC/GXUMPRWfEOs1h7ImMx+
+  5U8+hblvz9QavWXpent80a5x93Y4VfqGRiodJrGkYTnRN0+r2fOQtblnkdUcY3RW
+  3TUscqnBotzX3IO3nlYWHVQvY1k69ehP/X3ksgWJV+RI8/uN+ZjNxGEoiT9umcPW
+  ceUPbhtKlSTZvCaCOSDrM6WxNGKfoHFzjDElMCMGCSqGSIb3DQEJFTEWBBQpqFSv
+  5Vo3CkV4uz/S03tks43T6TBBMDEwDQYJYIZIAWUDBAIBBQAEIEe6U/xHhszXFgAT
+  xd4i9ibrK6dOoxmfxqXsDhVfGdPQBAhCa7Fc4FL1RgICCAA=
+`;
+
+/** AES again, but the passphrase is "Bärchen€" */
+const kNonASCIIFixture = `
+  MIIGrwIBAzCCBmUGCSqGSIb3DQEHAaCCBlYEggZSMIIGTjCCAxIGCSqGSIb3DQEHBqCCAwMwggL/
+  AgEAMIIC+AYJKoZIhvcNAQcBMFcGCSqGSIb3DQEFDTBKMCkGCSqGSIb3DQEFDDAcBAhewdghksdq
+  vAICCAAwDAYIKoZIhvcNAgkFADAdBglghkgBZQMEASoEEGPUvlln0/VykS+loZ0XYFmAggKQibdM
+  Zcz7sZNEm+bLtBSL6bBLoCeuPlT01CBk8ol2bgTiTcoAVs8B3tU/5r9k2zjgbGDdXIUfbQkfPJz3
+  sksQXCVQZlgOQzD6VTVsmdRe+yRfUFLA3vB1EURD14bt646Ci8fkQAQyc38O4Unz9DIAxPqceFkI
+  BwKetgC7qeMQ0TIELIjePRXHZGyUUlmjY6raH7ANQZ/5f5J5ztTFE05Ah49v92VbjcW2LDziw4Vn
+  MHFyMQrRlLjKcjWm6qLwXc7tMVL+BO96P5kqWP4T7Hk1boWVSzx/BLiBCPfpFV7wRAqS9pKmCBXq
+  Rl1ScjkTNwfUKbXwlOymzaP061ap2e7E7MdYT8Egqfb9TgZOgdjXOsq+A9hmLTiMXJd42q0QS2bi
+  u+Z9qjZu6FvalQ6HUjHMqlyoT6cI76djAIuY2rHrPs+08hFG17JU91m2PWxXl8YDmmd7lZnuGlx5
+  kLDjCxrJQysb7aW8zt3MNEaJ9nBz7o6sYMEaw8qQTo5MOioytOPSKV00ApgU0YKo/NfjBJvX1u1p
+  xuvDjixuFA56jcCR9+mQz0E/pY2W0bCgCZhnC3KkgAWBg5LiXzBrJcd3E9vISGEmL+d4uJsf9ow8
+  zpPvxTTAfH6UgBAseOGtUb0KVaDd9D9B+cf5t0txQSfilodu1fUl49k6WQoOELGVKO766bMdt+/d
+  m8/JDZJdQbo5q3UA2NRnIj6U1JMmlIGnQgWlN73VANkopwdJkptMfYxr7G8VQSFWLSQejoNVOevR
+  JvFz0CDHPPDDUSmOW7pDh860v/QzBg6des27OLY2mqN5u1n52t/weGAhs2LA3maAOQxczKpXunVk
+  zk8p0uQunYzW0xxw0gIjbY2SaQjoOE1vJH8wggM0BgkqhkiG9w0BBwGgggMlBIIDITCCAx0wggMZ
+  BgsqhkiG9w0BDAoBAqCCAuEwggLdMFcGCSqGSIb3DQEFDTBKMCkGCSqGSIb3DQEFDDAcBAiMfzh4
+  B62yygICCAAwDAYIKoZIhvcNAgkFADAdBglghkgBZQMEASoEEF6dVmGoHBkpRXlmECz9Ls8EggKA
+  urxL7b8Oa2/f88Np/Yl2Hb5ArlQGlbEzp9j0umdvGDg99gR6bAjtbAxCsVwY8x4uTQ4gwn2Z0g4t
+  EkNLjsvsl6Xh213txblewr1qQ1AY5hFOejTEQ0aTY74dIx57Ere8HDgfhWt8308jAvMg85gdI4Tv
+  srMRaiRIyrJrts6yx6GC7Y47s7cQjYKApBPWSa5nMxeAbkTXhHUeOK9BXrjUEj1LjfigFb6di8oZ
+  mcNvg5pWa/eFB7xXg14rkHIFnWHLsjjg6Y1OAPBHb68W4AyHoy/YSJ5aXXOHWMl9DU8SGPwKwOwL
+  BLhufTs4aDMwTYZ6Dd4iL6Q7qbh6RBQbuXLGTWt+11zvPMvAuafFH7ubQGxTkGcecDUKCfNzPbso
+  tbKhedJRlLOW/RWZDEdJRFKB1JVpUwIkv2RLpJqaYqtA9WleKoylUzGn5lKuR92fxCM8B3xrNdCf
+  jVvCuoASZ/c1ujnyEe+DSCVUY4830ZGtkc9qTNhusYJIOZX+avZ6ob3eAAmJX+DawEJoyJh0XhCb
+  dRpkZd38DunaZn2SIRzZ4xQqQOSz07D2pLJ2nBo7SEp8z5pgNsBVWUsuz4D1GjKwRfjJcJe6B1al
+  WzT7c3jtUAmg6A/Xwjf5SEutFJcsfka3Xp0K9xE9hyg9p6zXJNkjZCrMzJVll7qigKNhcsO5BmGE
+  SbGLVI+9IW4mae9v1krNQawa2XYT/wntH/y3khUUd7n4x4EbXC1rnEAByvUnyATT1wzE9Sn/tem2
+  8SlwW6DbLXZrTIz0jt6ZehayrbxQNKNKpcjOETKzhRS8JKVy+WNCYFKd5Y8N98GDg2NZ7XvKhsfg
+  KZy2RUHj5/VrSII3nTElMCMGCSqGSIb3DQEJFTEWBBQpqFSv5Vo3CkV4uz/S03tks43T6TBBMDEw
+  DQYJYIZIAWUDBAIBBQAEIMOQVNfefG9JyovOHPisJ6rBDMXtHzOl8Gwc74CmRb/0BAjFqBS7Apf1
+  ywICCAA=
+`;

--- a/app/test/logic/Mail/Encryption/SMIME/PKCS12.test.ts
+++ b/app/test/logic/Mail/Encryption/SMIME/PKCS12.test.ts
@@ -100,6 +100,11 @@ describe("PKCS#12 import", () => {
     expect(key.userIDs.contents).toEqual([kEmailAddress]);
   });
 
+  test("No passphrase at all, which is a different key than an empty one", async () => {
+    let p12 = await readFixture(kNoPassphraseFixture, "");
+    expectKeyOfCertificate(p12);
+  });
+
   test("A passphrase that the caller never set is a bug, not an empty one", async () => {
     expect(() => new PKCS12(undefined as any)).toThrow(/passphrase/i);
   });
@@ -411,6 +416,49 @@ const kEmptyPassphraseFixture = `
   ceUPbhtKlSTZvCaCOSDrM6WxNGKfoHFzjDElMCMGCSqGSIb3DQEJFTEWBBQpqFSv
   5Vo3CkV4uz/S03tks43T6TBBMDEwDQYJYIZIAWUDBAIBBQAEIEe6U/xHhszXFgAT
   xd4i9ibrK6dOoxmfxqXsDhVfGdPQBAhCa7Fc4FL1RgICCAA=
+`;
+
+/** The same file, but written without any passphrase instead of with an
+ * empty one, so its MAC leaves the passphrase out of the key derivation.
+ * The MAC comes from `openssl kdf PKCS12KDF` with an empty `hexpass`,
+ * and `openssl pkcs12 -passin pass:` reads the file. */
+const kNoPassphraseFixture = `
+  MIIGrwIBAzCCBmUGCSqGSIb3DQEHAaCCBlYEggZSMIIGTjCCAxIGCSqGSIb3DQEH
+  BqCCAwMwggL/AgEAMIIC+AYJKoZIhvcNAQcBMFcGCSqGSIb3DQEFDTBKMCkGCSqG
+  SIb3DQEFDDAcBAjHULyp7g88ZQICCAAwDAYIKoZIhvcNAgkFADAdBglghkgBZQME
+  ASoEEBbyfOJtd/Ob9uA1lAuAW6yAggKQ+getg304tXCR+giSFaTmRQjHyFTlhgDp
+  wuJTgI3QlY9PHZ/zcJl0e4FhD9SA6Bd32aOFiGkzo2Yyrzv/KgPEMzd7pp7B6LR2
+  LThu2n3BdMhXbHAcRjiPN0TcTG9+JvxTJG9vkxHmc7MIp+92wGud8IVvwcSW/rxY
+  wnMGDscZTHL9j+D8cnildtvMPJJD/WJATQE8srfoj+Vv0n6woIPsxlWhWInBf5XF
+  aMgiSP9IxDDNOT06RWNmmkD0z9m+gGbDOv5YhV5KOXdi+IVIyjtsGYYriVWdlJTn
+  ZZloUc49FAZYM96m14r7lcfRKMzieKM7VOjsNcjX5u/Z3bc/KaegqEjbn55XwPLL
+  lyNY7FA9fuPoi9Qdhm/YV3QXqDAu+ShI/SSiktMu7X/4lkdxZ88lorcYDOEkpOep
+  LPyIVJ+XPxNTXBkaNEPCKmTDFP7tExOHwYSfbKOjmM+DfuY5OD1Li1/9Od3+nq/u
+  sREp7xOPNkRR/c5K7d0tyVSdl7Yf25mROPDMNMjTuikwMOqdBEQzhR7svnvZXOMm
+  /85kwe8xRwdxmiFqdZBFanc1Hhng0ebi1OMV+4fccLDMna+MK4MfGoNB5tZem8/W
+  KduBZmmGtsIRHH816cNVjWNk2xgic8ANwAw2D0ooDRgn2leo/RH92rpbtHqoGFXA
+  pKjVOLLmfGdcNFoDkv8/fjO1oyFQ7+LZ8pvhr2S8YcgHl02uf4T9ICw1UoRwuiBA
+  v0gNJ8IyhwWmtC3codkcfw7ggs1GuJPwXSMyEn5wMaNkXcDwap131bS5ZUGmZmIT
+  E6IqBOgClgukUNkmNmm6giekqErD6ywlWXZ6+Lgmiw7d9+CPVg4RQvFI7K0ujWwl
+  2WOCr4zRYYAwggM0BgkqhkiG9w0BBwGgggMlBIIDITCCAx0wggMZBgsqhkiG9w0B
+  DAoBAqCCAuEwggLdMFcGCSqGSIb3DQEFDTBKMCkGCSqGSIb3DQEFDDAcBAhnxFnb
+  aJrlzQICCAAwDAYIKoZIhvcNAgkFADAdBglghkgBZQMEASoEEOa7qxx7sl/zYc9r
+  /Xf/Y/YEggKAbV3rvC2ewZb0rf6WhfK9IM2sQfMdRa0CWQbEjJ9CREzuY3X8lejL
+  Zj+pCrjvb8f/0wl7N/MIHFiRs9AQJzGRMhVqOqVLu36QMVNUpdVXuWhTc9xUGSc0
+  Q3vZvl1oVOrsHc945T6yjPN9v5sgzSiNEOB+Vll3QWxhGbMAviathZrDTw6FzU6N
+  yHQm4g5XHNfaXJV102VMNuJUUCeHajKB+b2P6JCq5gTLiVIlb+OAJir2X8m0Bv1X
+  pwE5c0MUgNfpGBxMfYiAjskWyzcs9gB/qhl63cjLqBwj6nN3RWS0dT7UOqUMwfuW
+  Ww/dNuDqCK4Djod3/xeckGR/qj4uQmGbHr1500nTWG4qwx/V86apAmBULWvHahJP
+  MQ13ipSrfcfN7CxbBBme+oU7xxtWaVzUoQUFys3S/m7ArqtwtfSdS2euGQ+PLbEx
+  GCA0k1Zy4iqpx3kj/K8GeYUbYgJ75mERZi/LbfMOmEHZ1uVnjVI0oDhFTlsDcLBj
+  JbIKNh5yW0yQHIvQzh8xP8KXe//frCvH/vkPio5mtYVBnmtFRWBsrGkhU3SOVYTq
+  4alxgX4cOTQaUnTVXAjWctkILxb5ZhChCvE6VPVE9PAI9JwYals4zmLWKZGwvqx+
+  +Zsoi0k+4XDUCmjx1zuTzrNi6hNmf/TPtZik3H/oirEC/GXUMPRWfEOs1h7ImMx+
+  5U8+hblvz9QavWXpent80a5x93Y4VfqGRiodJrGkYTnRN0+r2fOQtblnkdUcY3RW
+  3TUscqnBotzX3IO3nlYWHVQvY1k69ehP/X3ksgWJV+RI8/uN+ZjNxGEoiT9umcPW
+  ceUPbhtKlSTZvCaCOSDrM6WxNGKfoHFzjDElMCMGCSqGSIb3DQEJFTEWBBQpqFSv
+  5Vo3CkV4uz/S03tks43T6TBBMDEwDQYJYIZIAWUDBAIBBQAEIJ5sfPs7yqOh6998
+  Hsr30kgoBuoZMcxqTOzcMYWtp5oGBAhCa7Fc4FL1RgICCAA=
 `;
 
 /** AES again, but the passphrase is "Bärchen€" */


### PR DESCRIPTION
Fixes #1383 

2 commits:
1. S/MIME: Move the private key encryption to its own file — pure refactor: the
  duplicated PBES2 code in decryptCryptoKey() and createNewPrivateKey() moved to
  SMIME/pbes2.ts; both decryptKey() and decryptCryptoKey() now read the key through one
  decryptPKCS8() that checks the key algorithm on both paths.
2. S/MIME: Import the private key from a .p12 file - #1383 —
    - SMIME/PKCS12.ts: RFC 7292 reader — MAC verification (also the wrong-passphrase
  check), the PKCS#12-specific key derivation, all bag types incl. nested safe-contents,
  and toPEM() which re-encrypts the key with the same passphrase and appends every
  certificate, so the CA chain comes along and the key is never stored in the clear.
    - SMIME/legacyCiphers.ts: Triple DES (2- and 3-key), RC2 (40/128 bit) and RC4.
  WebCrypto and @noble implement none of them, and real .p12 files need them — Windows,
  macOS and OpenSSL 1 write RC2-40 + 3DES; only OpenSSL 3 and recent apps write AES.
    - KeyUtils.readKeyFile() + the Settings import UI: the picked file is read as bytes, a
  leading 0x30 (DER) routes to the PKCS#12 reader, anything else is decoded as text exactly
  as before; .p12/.pfx added to the file picker.

  Checks run: 28 tests pass in logic/Mail/Encryption (17 pre-existing S/MIME + 11 new). The
  new tests cover 7 openssl-generated fixtures — AES/PBES2, PBES2+3DES, RC2-40+3DES, 3DES
  with CA chain, RC2-128+2-key-3DES, RC4, unencrypted bags without MAC, non-ASCII
  passphrase — plus wrong-passphrase rejection and the end-to-end path into
  SMIMEPrivateKey. Triple DES was cross-checked against Node's OpenSSL, RC2 against all 8
  RFC 2268 vectors, RC4 against the standard vector, and each fixture's PEM output was read
  back by openssl pkey/openssl x509 with the public key matching the original.
  svelte-check reports 217 errors — identical to the baseline I measured before the change.
  The rest of the suite's failures (VCard, SQL, WebDAV, XMPP …) fail identically in the
  untouched checkout.
 
  Not verified: the change has not been run in the real app UI, only unit-tested — worth
  a manual import before landing. Also worth noting: the app now has a working 3DES
  implementation, which is what commit 96ddede20 said we lacked for decrypting
  3DES-encrypted S/MIME mail; wiring it into SMIMEReadProcessor would be a separate, easy
  follow-up.