### PR TITLE
Incoming invitation: Adds duplicate events

### DIFF
--- a/app/logic/Calendar/Invitation/IncomingInvitation.ts
+++ b/app/logic/Calendar/Invitation/IncomingInvitation.ts
@@ -36,9 +36,17 @@ export class IncomingInvitation {
   calEvent(): Event | null {
     // First find a standalone event or master.
     let event = this.calendar.events.find(event => event.calUID == this.event.calUID && !event.recurrenceStartTime);
+    if (!this.event.recurrenceStartTime) {
+      return event;
+    }
     // If this is an occurrence, find it now.
     // It may have been cancelled and excluded from the calendar already.
-    return this.event.recurrenceStartTime ? event?.getOccurrenceByDate(this.event.recurrenceStartTime, false) : event;
+    if (event) {
+      return event.getOccurrenceByDate(this.event.recurrenceStartTime, false);
+    }
+    // Without the master, `ICalIncomingInvitation` added the occurrence as a standalone event
+    return this.calendar.events.find(event => event.calUID == this.event.calUID &&
+      event.recurrenceStartTime?.getTime() == this.event.recurrenceStartTime.getTime());
     // TODO What if you were only invited to a single exception?
   }
 


### PR DESCRIPTION
EWS incoming invitations: when the user receives an email with an calendar invitation
and clicks [Confirm], he sometimes gets the event twice in his EWS calendar. In some
cases, it's even twice in the EWS *and* twice in the local calendar.