### PR TITLE
Calendar: EWS, OWA, ActiveSync: All-day recurrence exceptions were dropped

### DIFF
--- a/app/logic/Calendar/ActiveSync/ActiveSyncCalendar.ts
+++ b/app/logic/Calendar/ActiveSync/ActiveSyncCalendar.ts
@@ -146,7 +146,7 @@ export class ActiveSyncCalendar extends ExchangeCalendar implements ActiveSyncPi
           // Exceptions must be handled after the master event has been saved.
           for (let exception of ensureArray(item.ApplicationData.Exceptions?.Exception)) {
             if (exception.Deleted != "1") {
-              let exceptionTime = fromCompact(sanitize.nonemptystring(exception.ExceptionId || exception.ExceptionStartTime), event.allDay && this.account.protocolVersion == "16.1");
+              let exceptionTime = event.toLocalMidnight(fromCompact(sanitize.nonemptystring(exception.ExceptionId || exception.ExceptionStartTime), event.allDay && this.account.protocolVersion == "16.1"));
               let existing = event.exceptions.find(event => event.recurrenceStartTime.getTime() == exceptionTime.getTime());
               if (existing) {
                 existing.fromWBXML(exception);

--- a/app/logic/Calendar/ActiveSync/ActiveSyncEvent.ts
+++ b/app/logic/Calendar/ActiveSync/ActiveSyncEvent.ts
@@ -79,7 +79,7 @@ export class ActiveSyncEvent extends ExchangeEvent {
       this.recurrenceRule = this.newRecurrenceRuleFromWBXML(wbxmljs.Recurrence);
       for (let exception of ensureArray(wbxmljs.Exceptions?.Exception)) {
         if (exception.Deleted == "1") {
-          this.makeExclusionLocally(fromCompact(sanitize.nonemptystring(exception.ExceptionId || exception.ExceptionStartTime), this.allDay && this.calendar.account.protocolVersion == "16.1"));
+          this.makeExclusionLocally(this.toLocalMidnight(fromCompact(sanitize.nonemptystring(exception.ExceptionId || exception.ExceptionStartTime), this.allDay && this.calendar.account.protocolVersion == "16.1")));
         }
       }
     } else {

--- a/app/logic/Calendar/EWS/EWSCalendar.ts
+++ b/app/logic/Calendar/EWS/EWSCalendar.ts
@@ -264,7 +264,11 @@ export class EWSCalendar extends ExchangeCalendar implements EWSSubscribable {
             event.fromXML(item);
             await event.saveLocally();
           } else {
-            event = parentEvent?.getOccurrenceByDate(sanitize.date(item.RecurrenceId)) as EWSEvent || this.newEvent();
+            if (parentEvent) {
+              // `toLocalMidnight()`, because the master converted its own times, too
+              event = parentEvent.getOccurrenceByDate(parentEvent.toLocalMidnight(sanitize.date(item.RecurrenceId))) as EWSEvent;
+            }
+            event ??= this.newEvent();
             event.fromXML(item);
             // For a modified occurrence, this already adds the event to `this.events`
             await event.saveLocally();

--- a/app/logic/Calendar/EWS/EWSEvent.ts
+++ b/app/logic/Calendar/EWS/EWSEvent.ts
@@ -90,7 +90,7 @@ export class EWSEvent extends ExchangeEvent {
       this.recurrenceRule = this.newRecurrenceRuleFromXML(xmljs.Recurrence);
       if (xmljs.DeletedOccurrences?.DeletedOccurrence) {
         for (let deletion of ensureArray(xmljs.DeletedOccurrences.DeletedOccurrence)) {
-          this.makeExclusionLocally(sanitize.date(deletion.Start));
+          this.makeExclusionLocally(this.toLocalMidnight(sanitize.date(deletion.Start)));
         }
       }
     } else {

--- a/app/logic/Calendar/EWS/ExchangeEvent.ts
+++ b/app/logic/Calendar/EWS/ExchangeEvent.ts
@@ -1,14 +1,48 @@
 import { Event } from "../Event";
 
 export class ExchangeEvent extends Event {
+  /** The time zone in which the server sent the times of this all-day event.
+   * `setAllDayTimeToLocalMidnight()` clears `timezone`, but occurrence dates
+   * that the server sends still need the same conversion as the event times. */
+  allDayTimezone: string | null = null;
+
   // Except for ActiveSync 16.x, whose all-day events are special-cased in
   // fromCompact(), Exchange provides a time zone and the time in UTC that
   // would be midnight in that time zone, but we need them to use local time.
   protected setAllDayTimeToLocalMidnight() {
-    if (this.allDay && this.timezone) {
-      this.startTime = new Date(this.startTime.toLocaleDateString('lt', { timeZone: this.timezone }) + "T00:00:00");
-      this.endTime = new Date(this.endTime.toLocaleDateString('lt', { timeZone: this.timezone }) + "T00:00:00");
+    if (!this.allDay) {
+      this.allDayTimezone = null;
+      return;
+    }
+    if (this.timezone) {
+      this.allDayTimezone = this.timezone;
       this.timezone = null;
     }
+    this.startTime = this.toLocalMidnight(this.startTime);
+    this.endTime = this.toLocalMidnight(this.endTime);
+    // Must match the start time, otherwise it no longer matches the
+    // recurrence that we generate from the start time.
+    if (this.recurrenceStartTime) {
+      this.recurrenceStartTime = this.toLocalMidnight(this.recurrenceStartTime);
+    }
+  }
+
+  /** Converts a time that the server sent for an all-day event - the UTC time
+   * that would be midnight in `allDayTimezone` - to local midnight.
+   * Times of other events are already correct and stay unchanged.
+   * Use this for all occurrence dates that the server sends, e.g. the
+   * recurrence ID of a modified occurrence and deleted occurrences. */
+  toLocalMidnight(date: Date): Date {
+    if (!this.allDayTimezone) {
+      return date;
+    }
+    return new Date(date.toLocaleDateString('lt', { timeZone: this.allDayTimezone }) + "T00:00:00");
+  }
+
+  /** ActiveSync sends the exceptions of an all-day event without the time zone
+   * of the master, so pass it on to the instances. */
+  protected copyFromRecurrenceMaster(original: ExchangeEvent) {
+    super.copyFromRecurrenceMaster(original);
+    this.allDayTimezone = original.allDayTimezone;
   }
 }

--- a/app/logic/Calendar/OWA/OWACalendar.ts
+++ b/app/logic/Calendar/OWA/OWACalendar.ts
@@ -136,7 +136,12 @@ export class OWACalendar extends ExchangeCalendar {
     }
     for (let item of items) {
       try {
-        let event = this.getEventByItemID(sanitize.nonemptystring(item.ItemId.Id)) || parentEvent?.getOccurrenceByDate(sanitize.date(item.RecurrenceId)) as OWAEvent || this.newEvent();
+        let event = this.getEventByItemID(sanitize.nonemptystring(item.ItemId.Id));
+        if (!event && parentEvent) {
+          // `toLocalMidnight()`, because the master converted its own times, too
+          event = parentEvent.getOccurrenceByDate(parentEvent.toLocalMidnight(sanitize.date(item.RecurrenceId))) as OWAEvent;
+        }
+        event ??= this.newEvent();
         event.fromJSON(item);
         await event.saveLocally();
         events.add(event);

--- a/app/logic/Calendar/OWA/OWAEvent.ts
+++ b/app/logic/Calendar/OWA/OWAEvent.ts
@@ -86,7 +86,7 @@ export class OWAEvent extends ExchangeEvent {
       this.recurrenceRule = this.newRecurrenceRuleFromJSON(json.Recurrence);
       if (json.DeletedOccurrences) {
         for (let deletion of json.DeletedOccurrences) {
-          this.makeExclusionLocally(sanitize.date(deletion.Start));
+          this.makeExclusionLocally(this.toLocalMidnight(sanitize.date(deletion.Start)));
         }
       }
     } else {

--- a/app/test/logic/Calendar/EWS/allDayRecurrence.test.ts
+++ b/app/test/logic/Calendar/EWS/allDayRecurrence.test.ts
@@ -1,0 +1,73 @@
+// app first, to resolve the import cycle around Abstract/Account.ts
+import "../../../../logic/app";
+import { Calendar } from "../../../../logic/Calendar/Calendar";
+import { EWSEvent } from "../../../../logic/Calendar/EWS/EWSEvent";
+import { expect, test } from "vitest";
+
+/* Exchange sends the times of an all-day event as the UTC time that would be
+ * midnight in the event's time zone, and we convert them to local midnight.
+ * The occurrence dates of a recurrence need the same conversion, otherwise
+ * they no longer match the recurrence that we generate from the start time,
+ * and the sync logged "occurrence date not in recurrence" and dropped the
+ * modified occurrence. Happens only when the event has a different time zone
+ * than the machine, which is why the tests use New Zealand. */
+const kTimezone = "New Zealand Standard Time"; // UTC+13 in March
+// Daily, 2024-03-15 to 2024-03-19, with 2024-03-17 moved to 2024-03-18
+const kMaster = {
+  ItemId: { Id: "master" },
+  UID: "series",
+  Subject: "Daily all-day event",
+  Start: "2024-03-14T11:00:00Z",
+  End: "2024-03-15T11:00:00Z",
+  IsAllDayEvent: "true",
+  StartTimeZoneId: kTimezone,
+  Recurrence: {
+    DailyRecurrence: { Interval: "1" },
+    NumberedRecurrence: { StartDate: "2024-03-15+13:00", NumberOfOccurrences: "5" },
+  },
+};
+const kModifiedOccurrence = {
+  ItemId: { Id: "occurrence" },
+  UID: "series",
+  Subject: "Daily all-day event",
+  RecurrenceId: "2024-03-16T11:00:00Z",
+  Start: "2024-03-17T11:00:00Z",
+  End: "2024-03-18T11:00:00Z",
+  IsAllDayEvent: "true",
+  StartTimeZoneId: kTimezone,
+};
+
+function newMaster(): EWSEvent {
+  let calendar = new Calendar();
+  calendar.name = "Test";
+  let master = new EWSEvent(calendar as any);
+  master.fromXML(kMaster);
+  return master;
+}
+
+test("All-day event times are the local midnight of the event time zone", () => {
+  let master = newMaster();
+  expect(master.allDay).toBe(true);
+  expect(master.startTime.getTime()).toBe(new Date("2024-03-15T00:00:00").getTime());
+  expect(master.timezone).toBe(null);
+  expect(master.allDayTimezone).toBe("Pacific/Auckland");
+});
+
+test("Modified occurrence of an all-day event is found in the recurrence", () => {
+  let master = newMaster();
+  // What `EWSCalendar.getEvents()` looks up the occurrence by
+  let recurrenceStartTime = master.toLocalMidnight(new Date(kModifiedOccurrence.RecurrenceId));
+  expect(recurrenceStartTime.getTime()).toBe(new Date("2024-03-17T00:00:00").getTime());
+  expect(master.recurrenceRule.getIndexOfOccurrence(recurrenceStartTime)).toBe(2);
+  expect(master.getOccurrenceByDate(recurrenceStartTime)).toBeTruthy();
+});
+
+test("Modified occurrence of an all-day event replaces its instance", () => {
+  let master = newMaster();
+  let instance = master.getOccurrenceByDate(master.toLocalMidnight(new Date(kModifiedOccurrence.RecurrenceId)));
+  let exception = new EWSEvent(master.calendar, master);
+  exception.fromXML(kModifiedOccurrence);
+  // Otherwise the master generates an instance for the same occurrence again
+  expect(exception.recurrenceStartTime.getTime()).toBe(instance.recurrenceStartTime.getTime());
+  expect(exception.startTime.getTime()).toBe(new Date("2024-03-18T00:00:00").getTime());
+});


### PR DESCRIPTION
Opus 5:

Exchange sends the times of an all-day event as the UTC time that would be midnight in the event's time zone, and setAllDayTimeToLocalMidnight() converts them to local midnight. The occurrence dates that the server sends
- the recurrence ID of a modified occurrence, and the deleted occurrences - need the same conversion, or they no longer match the recurrence that we generate from the converted start time.

The sync then logged "occurrence date not in recurrence" and dropped the modified occurrence, and deleted occurrences kept being shown. Happens only when the event has a different time zone than the machine.