### PR TITLE
Outgoing invitations: Send the VTIMEZONE for Outlook

### DIFF
--- a/app/logic/Calendar/ICal/ICalGenerator.ts
+++ b/app/logic/Calendar/ICal/ICalGenerator.ts
@@ -1,5 +1,7 @@
 import type { Event } from "../Event";
 import { InvitationResponse, ParticipationStatus, type iCalMethod } from "../Invitation/InvitationStatus";
+import { VTimezone } from "./VTimezone";
+import { myTimezone } from "../../../frontend/Util/date";
 import { appName } from "../../build";
 import { sanitize } from "../../../../lib/util/sanitizeDatatypes";
 import { assert, blobToBase64 } from "../../util/util";
@@ -16,12 +18,33 @@ export async function getICal(event: Event, method?: iCalMethod): Promise<string
   }
   lines.push(["VERSION", "2.0"]);
   lines.push(["PRODID", `-//Beonex//${appName}//EN`]);
+  addVTimezones(lines, event);
   await addVEvent(lines, event);
   for (let exception of event.exceptions) {
     await addVEvent(lines, exception);
   }
   lines.push(["END", "VCALENDAR"]);
   return lines.map(line2ical).join("");
+}
+
+/**
+ * Spells out the daylight saving time rules of every timezone that the event
+ * uses. Outlook and Exchange do not understand the `TZID` names and would
+ * otherwise show the event at the wrong time, RFC 5545 3.6.5.
+ */
+function addVTimezones(lines: (string | string[])[], event: Event): void {
+  let timezones = new Set([event, ...event.exceptions]
+    .filter(occurrence => !occurrence.allDay)
+    .map(timezoneOf)
+    .filter(timezone => timezone != "UTC")); // written as UTC times, without `TZID`
+  for (let timezone of timezones) {
+    lines.push(...new VTimezone(timezone, event.startTime).toICalLines());
+  }
+}
+
+/** The timezone in which the times of the event are meant */
+function timezoneOf(event: Event): string {
+  return event.timezone || myTimezone();
 }
 
 async function addVEvent(lines: (string | string[])[], event: Event): Promise<void> {
@@ -64,7 +87,7 @@ async function addVEvent(lines: (string | string[])[], event: Event): Promise<vo
       lines.push(["RECURRENCE-ID", "VALUE", "DATE", date2ical(event.recurrenceStartTime)]);
     }
   } else {
-    let timezone = event.timezone || Intl.DateTimeFormat().resolvedOptions().timeZone;
+    let timezone = timezoneOf(event);
     if (timezone == "UTC") {
       lines.push(["DTSTART", "VALUE", "DATE-TIME", utc2ical(event.startTime)]);
       lines.push(["DTEND", "VALUE", "DATE-TIME", utc2ical(event.endTime)]);
@@ -88,7 +111,7 @@ async function addVEvent(lines: (string | string[])[], event: Event): Promise<vo
   }
   if (event.recurrenceRule) {
     lines.push(event.recurrenceRule.getCalString(event.allDay) + "\r\n");
-    let timezone = event.timezone || Intl.DateTimeFormat().resolvedOptions().timeZone;
+    let timezone = timezoneOf(event);
     for (let exclusion of event.exclusions) {
       if (event.allDay) {
         lines.push(["EXDATE", "VALUE", "DATE", date2ical(exclusion)]);

--- a/app/logic/Calendar/ICal/VTimezone.ts
+++ b/app/logic/Calendar/ICal/VTimezone.ts
@@ -141,8 +141,9 @@ function utcOffsetChanges(timezone: string, year: number): Date[] {
  * @param before must have a different UTC offset than `after` */
 function findUTCOffsetChange(before: Date, after: Date, timezone: string): Date {
   let offsetBefore = utcOffset(before, timezone);
-  while (after.getTime() - before.getTime() > 1) {
-    let middle = new Date(Math.round((before.getTime() + after.getTime()) / 2));
+  // The timezone database changes the offset only at full minutes
+  while (after.getTime() - before.getTime() > k1MinuteMS) {
+    let middle = new Date(Math.round((before.getTime() + after.getTime()) / 2 / k1MinuteMS) * k1MinuteMS);
     if (utcOffset(middle, timezone) == offsetBefore) {
       before = middle;
     } else {

--- a/app/logic/Calendar/ICal/VTimezone.ts
+++ b/app/logic/Calendar/ICal/VTimezone.ts
@@ -183,9 +183,8 @@ function dayOfNthWeekday(year: number, month: number, nth: number, weekday: numb
     let firstWeekday = new Date(Date.UTC(year, month - 1, 1)).getUTCDay();
     return 1 + (weekday - firstWeekday + 7) % 7 + (nth - 1) * 7;
   }
-  let lastDay = new Date(Date.UTC(year, month, 0)).getUTCDate();
-  let lastWeekday = new Date(Date.UTC(year, month - 1, lastDay)).getUTCDay();
-  return lastDay - (lastWeekday - weekday + 7) % 7;
+  let lastDay = new Date(Date.UTC(year, month, 0));
+  return lastDay.getUTCDate() - (lastDay.getUTCDay() - weekday + 7) % 7;
 }
 
 /** iCal date-time in local time, e.g. "19700329T020000".

--- a/app/logic/Calendar/ICal/VTimezone.ts
+++ b/app/logic/Calendar/ICal/VTimezone.ts
@@ -162,7 +162,7 @@ function utcOffset(time: Date, timezone: string): number {
 
 /** The year at `time` in `timezone`, which may differ from the year here */
 function yearIn(time: Date, timezone: string): number {
-  return new Date(time.getTime() + utcOffset(time, timezone) * k1MinuteMS).getUTCFullYear();
+  return Number(time.toLocaleDateString("lt", { timeZone: timezone, year: "numeric" }));
 }
 
 /** Which weekday of the month `local` is, e.g. 2 for the 2nd Sunday

--- a/app/logic/Calendar/ICal/VTimezone.ts
+++ b/app/logic/Calendar/ICal/VTimezone.ts
@@ -1,0 +1,201 @@
+import { iCalWeekday } from "../RecurrenceRule";
+import { k1MinuteMS } from "../../../frontend/Util/date";
+
+/**
+ * The daylight saving time rules of a timezone, as iCal `VTIMEZONE`,
+ * RFC 5545 3.6.5.
+ *
+ * Outlook and Exchange do not understand the IANA timezone names that we
+ * write in `TZID`, but take the offsets from the `VTIMEZONE` alone.
+ * Without it, Outlook uses the base offset of the timezone and shows every
+ * event during summer time 1 hour off, and Exchange uses the timezone of the
+ * mailbox instead. They understand only one yearly change to and from daylight
+ * saving time, and read only `TZID`, `DTSTART`, `RRULE`, `TZOFFSETFROM` and
+ * `TZOFFSETTO`, so we write nothing else. An unparsable `VTIMEZONE` makes
+ * Exchange reject the entire invitation, so stay conservative here.
+ */
+export class VTimezone {
+  /** IANA timezone name, e.g. "Europe/Berlin" */
+  readonly timezone: string;
+  /** The `STANDARD` part, and the `DAYLIGHT` part,
+   * if the timezone has daylight saving time */
+  readonly observances: TimezoneObservance[] = [];
+
+  /**
+   * @param timezone IANA timezone name, e.g. "Europe/Berlin"
+   * @param when Which rules to write. As we can express only one change per
+   *   year, we use the rules of the year in which the event happens.
+   */
+  constructor(timezone: string, when: Date) {
+    this.timezone = timezone;
+    let changes = utcOffsetChanges(timezone, yearIn(when, timezone));
+    let offsets = changes.map(change => utcOffset(change, timezone));
+    if (changes.length != 2 || offsets[0] == offsets[1]) {
+      // No daylight saving time, or changes that a yearly rule cannot express,
+      // e.g. Africa/Casablanca, which changes for Ramadan.
+      // The offset during the event is the best that we can do.
+      let offset = utcOffset(when, timezone);
+      this.observances.push(new TimezoneObservance(false, offset, offset, null));
+      return;
+    }
+    let standardOffset = Math.min(...offsets);
+    let daylightOffset = Math.max(...offsets);
+    this.observances.push(
+      new TimezoneObservance(false, daylightOffset, standardOffset, changes[offsets.indexOf(standardOffset)]),
+      new TimezoneObservance(true, standardOffset, daylightOffset, changes[offsets.indexOf(daylightOffset)]));
+  }
+
+  toICalLines(): (string | string[])[] {
+    let lines: (string | string[])[] = [
+      ["BEGIN", "VTIMEZONE"],
+      ["TZID", this.timezone],
+    ];
+    for (let observance of this.observances) {
+      lines.push(...observance.toICalLines());
+    }
+    lines.push(["END", "VTIMEZONE"]);
+    return lines;
+  }
+}
+
+/** The `STANDARD` or the `DAYLIGHT` part of a `VTIMEZONE`, RFC 5545 3.6.5.1 */
+class TimezoneObservance {
+  /** Summer time (`DAYLIGHT`), or winter time (`STANDARD`) */
+  readonly isDaylight: boolean;
+  /** UTC offset in minutes, before the change */
+  readonly offsetFrom: number;
+  /** UTC offset in minutes, after the change */
+  readonly offsetTo: number;
+  /** When this part starts, as local time in the UTC fields of the `Date` */
+  readonly start: Date;
+  /** The yearly repetition of the change, without the `RRULE:` prefix.
+   * null, if the timezone has no daylight saving time. */
+  readonly recurrenceRule: string | null = null;
+
+  /** @param change When the offset changes, or null for no daylight saving time */
+  constructor(isDaylight: boolean, offsetFrom: number, offsetTo: number, change: Date | null) {
+    this.isDaylight = isDaylight;
+    this.offsetFrom = offsetFrom;
+    this.offsetTo = offsetTo;
+    if (!change) {
+      this.start = new Date(Date.UTC(kStartYear, 0, 1));
+      return;
+    }
+    // The local time at the change is still the one before it, RFC 5545 3.6.5
+    let local = new Date(change.getTime() + offsetFrom * k1MinuteMS);
+    let month = local.getUTCMonth() + 1;
+    let weekday = local.getUTCDay();
+    let nth = nthWeekdayOfMonth(local);
+    this.recurrenceRule = `FREQ=YEARLY;BYMONTH=${month};BYDAY=${nth}${iCalWeekday[weekday]}`;
+    // Start in the past, so that the rule also covers events before this year
+    this.start = new Date(Date.UTC(kStartYear, local.getUTCMonth(),
+      dayOfNthWeekday(kStartYear, month, nth, weekday),
+      local.getUTCHours(), local.getUTCMinutes(), local.getUTCSeconds()));
+  }
+
+  toICalLines(): (string | string[])[] {
+    let part = this.isDaylight ? "DAYLIGHT" : "STANDARD";
+    let lines: (string | string[])[] = [
+      ["BEGIN", part],
+      // Local time, never UTC: Exchange reads even a `Z` value as local time
+      ["DTSTART", localtime2ical(this.start)],
+      ["TZOFFSETFROM", offset2ical(this.offsetFrom)],
+      ["TZOFFSETTO", offset2ical(this.offsetTo)],
+    ];
+    if (this.recurrenceRule) {
+      // `RRULE` contains ";"s, which must not be escaped as normal text values
+      lines.push("RRULE:" + this.recurrenceRule + "\r\n");
+    }
+    lines.push(["END", part]);
+    return lines;
+  }
+}
+
+/** The `DTSTART` year of the rules. Before any event that we might send,
+ * and the year in which the timezone database starts. */
+const kStartYear = 1970;
+
+/**
+ * When the UTC offset of `timezone` changes during `year`,
+ * e.g. to and from daylight saving time.
+ * We compare the months, so 2 changes within the same month go unnoticed,
+ * which then leaves us with the fixed offset during the event.
+ */
+function utcOffsetChanges(timezone: string, year: number): Date[] {
+  let changes: Date[] = [];
+  let start = new Date(Date.UTC(year, 0, 1));
+  let startOffset = utcOffset(start, timezone);
+  for (let month = 1; month <= 12; month++) {
+    let end = new Date(Date.UTC(year, month, 1));
+    let endOffset = utcOffset(end, timezone);
+    if (endOffset != startOffset) {
+      changes.push(findUTCOffsetChange(start, end, timezone));
+    }
+    start = end;
+    startOffset = endOffset;
+  }
+  return changes;
+}
+
+/** The exact moment when the UTC offset of `timezone` changes
+ * @param before must have a different UTC offset than `after` */
+function findUTCOffsetChange(before: Date, after: Date, timezone: string): Date {
+  let offsetBefore = utcOffset(before, timezone);
+  while (after.getTime() - before.getTime() > 1) {
+    let middle = new Date(Math.round((before.getTime() + after.getTime()) / 2));
+    if (utcOffset(middle, timezone) == offsetBefore) {
+      before = middle;
+    } else {
+      after = middle;
+    }
+  }
+  return after;
+}
+
+/** How many minutes the local time in `timezone` is ahead of UTC, at `time` */
+function utcOffset(time: Date, timezone: string): number {
+  // "lt" locale has date format YYYY-MM-DD hh:mm:ss,
+  // which we can easily read as UTC.
+  let local = new Date(time.toLocaleString("lt", { timeZone: timezone }).replace(" ", "T") + "Z");
+  return Math.round((local.getTime() - time.getTime()) / k1MinuteMS);
+}
+
+/** The year at `time` in `timezone`, which may differ from the year here */
+function yearIn(time: Date, timezone: string): number {
+  return new Date(time.getTime() + utcOffset(time, timezone) * k1MinuteMS).getUTCFullYear();
+}
+
+/** Which weekday of the month `local` is, e.g. 2 for the 2nd Sunday
+ * and -1 for the last Sunday, as `BYDAY` counts them.
+ * `local` has the local time in its UTC fields. */
+function nthWeekdayOfMonth(local: Date): number {
+  let day = local.getUTCDate();
+  let lastDay = new Date(Date.UTC(local.getUTCFullYear(), local.getUTCMonth() + 1, 0)).getUTCDate();
+  return day + 7 > lastDay ? -1 : Math.ceil(day / 7);
+}
+
+/** The day of the month of e.g. the 2nd Sunday (`nth` 2, `weekday` 0)
+ * or the last Sunday (`nth` -1), the reverse of `nthWeekdayOfMonth()`
+ * @param month 1 = January */
+function dayOfNthWeekday(year: number, month: number, nth: number, weekday: number): number {
+  if (nth > 0) {
+    let firstWeekday = new Date(Date.UTC(year, month - 1, 1)).getUTCDay();
+    return 1 + (weekday - firstWeekday + 7) % 7 + (nth - 1) * 7;
+  }
+  let lastDay = new Date(Date.UTC(year, month, 0)).getUTCDate();
+  let lastWeekday = new Date(Date.UTC(year, month - 1, lastDay)).getUTCDay();
+  return lastDay - (lastWeekday - weekday + 7) % 7;
+}
+
+/** iCal date-time in local time, e.g. "19700329T020000".
+ * `date` has the local time in its UTC fields. */
+function localtime2ical(date: Date): string {
+  return date.toISOString().replace(/-|:|\..../g, "").slice(0, -1);
+}
+
+/** UTC offset in iCal format, e.g. "+0200" */
+function offset2ical(minutes: number): string {
+  let sign = minutes < 0 ? "-" : "+";
+  minutes = Math.abs(minutes);
+  return sign + String(Math.floor(minutes / 60)).padStart(2, "0") + String(minutes % 60).padStart(2, "0");
+}

--- a/app/test/logic/Calendar/ICal/VTimezone.test.ts
+++ b/app/test/logic/Calendar/ICal/VTimezone.test.ts
@@ -1,0 +1,241 @@
+// app first, to resolve the import cycle around Abstract/Account.ts
+import { appGlobal } from "../../../../logic/app";
+import { Event } from "../../../../logic/Calendar/Event";
+import { getICal } from "../../../../logic/Calendar/ICal/ICalGenerator";
+import { k1HourMS, k1MinuteMS } from "../../../../frontend/Util/date";
+import { expect, test } from "vitest";
+
+/** The `VTIMEZONE`s that Google Calendar and Outlook write for these timezones */
+const kExpected: Record<string, string[]> = {
+  "Europe/Berlin": [
+    "BEGIN:VTIMEZONE",
+    "TZID:Europe/Berlin",
+    "BEGIN:STANDARD",
+    "DTSTART:19701025T030000",
+    "TZOFFSETFROM:+0200",
+    "TZOFFSETTO:+0100",
+    "RRULE:FREQ=YEARLY;BYMONTH=10;BYDAY=-1SU",
+    "END:STANDARD",
+    "BEGIN:DAYLIGHT",
+    "DTSTART:19700329T020000",
+    "TZOFFSETFROM:+0100",
+    "TZOFFSETTO:+0200",
+    "RRULE:FREQ=YEARLY;BYMONTH=3;BYDAY=-1SU",
+    "END:DAYLIGHT",
+    "END:VTIMEZONE",
+  ],
+  "America/New_York": [
+    "BEGIN:VTIMEZONE",
+    "TZID:America/New_York",
+    "BEGIN:STANDARD",
+    "DTSTART:19701101T020000",
+    "TZOFFSETFROM:-0400",
+    "TZOFFSETTO:-0500",
+    "RRULE:FREQ=YEARLY;BYMONTH=11;BYDAY=1SU",
+    "END:STANDARD",
+    "BEGIN:DAYLIGHT",
+    "DTSTART:19700308T020000",
+    "TZOFFSETFROM:-0500",
+    "TZOFFSETTO:-0400",
+    "RRULE:FREQ=YEARLY;BYMONTH=3;BYDAY=2SU",
+    "END:DAYLIGHT",
+    "END:VTIMEZONE",
+  ],
+  // Summer time during our winter
+  "Australia/Sydney": [
+    "BEGIN:VTIMEZONE",
+    "TZID:Australia/Sydney",
+    "BEGIN:STANDARD",
+    "DTSTART:19700405T030000",
+    "TZOFFSETFROM:+1100",
+    "TZOFFSETTO:+1000",
+    "RRULE:FREQ=YEARLY;BYMONTH=4;BYDAY=1SU",
+    "END:STANDARD",
+    "BEGIN:DAYLIGHT",
+    "DTSTART:19701004T020000",
+    "TZOFFSETFROM:+1000",
+    "TZOFFSETTO:+1100",
+    "RRULE:FREQ=YEARLY;BYMONTH=10;BYDAY=1SU",
+    "END:DAYLIGHT",
+    "END:VTIMEZONE",
+  ],
+  // No daylight saving time, and a half hour offset
+  "Asia/Kolkata": [
+    "BEGIN:VTIMEZONE",
+    "TZID:Asia/Kolkata",
+    "BEGIN:STANDARD",
+    "DTSTART:19700101T000000",
+    "TZOFFSETFROM:+0530",
+    "TZOFFSETTO:+0530",
+    "END:STANDARD",
+    "END:VTIMEZONE",
+  ],
+};
+
+test.each(Object.keys(kExpected))("VTIMEZONE for %s", async timezone => {
+  let iCal = await getICal(eventIn(timezone));
+  expect(iCal).toContain(kExpected[timezone].join("\r\n"));
+});
+
+test("Uses the rules of the year of the event", async () => {
+  // The USA changed the dates of the daylight saving time in 2007
+  let iCal = await getICal(eventIn("America/New_York", new Date(Date.UTC(2005, 5, 15, 12))));
+  expect(iCal).toContain("RRULE:FREQ=YEARLY;BYMONTH=4;BYDAY=1SU");
+  expect(iCal).toContain("RRULE:FREQ=YEARLY;BYMONTH=10;BYDAY=-1SU");
+});
+
+test("VTIMEZONE comes before the event that uses it", async () => {
+  let iCal = await getICal(eventIn("Europe/Berlin"));
+  expect(iCal.indexOf("BEGIN:VTIMEZONE")).toBeLessThan(iCal.indexOf("BEGIN:VEVENT"));
+  expect(iCal).toContain("DTSTART;VALUE=DATE-TIME;TZID=Europe/Berlin:");
+});
+
+test("No VTIMEZONE where we write no TZID", async () => {
+  let utc = eventIn("UTC");
+  expect(await getICal(utc)).not.toContain("VTIMEZONE");
+
+  let allDay = eventIn("Europe/Berlin");
+  allDay.allDay = true;
+  expect(await getICal(allDay)).not.toContain("VTIMEZONE");
+});
+
+test("Each timezone only once, despite exceptions", async () => {
+  let event = eventIn("Europe/Berlin");
+  let exception = eventIn("Europe/Berlin");
+  exception.recurrenceStartTime = event.startTime;
+  event.exceptions.add(exception);
+  let iCal = await getICal(event);
+  expect(iCal.match(/BEGIN:VTIMEZONE/g)).toHaveLength(1);
+  expect(iCal.match(/BEGIN:VEVENT/g)).toHaveLength(2);
+});
+
+/**
+ * Reading the times back out of our `VTIMEZONE`, the way that Outlook does,
+ * must give the same times as the real timezone, all year long.
+ */
+const kTimezones = [
+  "Europe/Berlin", "Europe/London", "Europe/Lisbon", "Europe/Athens",
+  "America/New_York", "America/Chicago", "America/Los_Angeles", "America/Santiago",
+  "Australia/Sydney", "Australia/Lord_Howe", "Pacific/Auckland", "Asia/Jerusalem",
+  "Asia/Kolkata", "Asia/Tokyo", "America/Phoenix",
+];
+const kYear = 2026;
+test.each(kTimezones)("Times in %s are correct all year", async timezone => {
+  let iCal = await getICal(eventIn(timezone, new Date(Date.UTC(kYear, 5, 15, 12))));
+  let observances = parseVTimezone(iCal, timezone);
+  for (let day = 1; day <= 365; day++) {
+    let time = new Date(Date.UTC(kYear, 0, day, 12));
+    expect(`${time.toISOString()} ${offsetFromObservances(observances, time)}`)
+      .toBe(`${time.toISOString()} ${utcOffset(time, timezone)}`);
+  }
+});
+
+function eventIn(timezone: string, startTime = new Date(Date.UTC(kYear, 5, 15, 12))): Event {
+  let event = new Event();
+  event.calUID = "b0d1c2e3-0000-0000-0000-000000000001";
+  event.title = "Test event";
+  event.timezone = timezone;
+  event.startTime = startTime;
+  event.endTime = new Date(startTime.getTime() + k1HourMS);
+  return event;
+}
+
+interface Observance {
+  /** Local time when the change happens, e.g. "19700329T020000" */
+  start: string;
+  /** In minutes */
+  offsetFrom: number;
+  offsetTo: number;
+  /** e.g. "FREQ=YEARLY;BYMONTH=3;BYDAY=-1SU" */
+  recurrenceRule: string | null;
+}
+
+/** Reads back the `STANDARD` and `DAYLIGHT` parts of the `VTIMEZONE` for `timezone` */
+function parseVTimezone(iCal: string, timezone: string): Observance[] {
+  let component = iCal.slice(iCal.indexOf(`TZID:${timezone}\r\n`));
+  component = component.slice(0, component.indexOf("END:VTIMEZONE"));
+  let observances: Observance[] = [];
+  let current: Observance | null = null;
+  for (let line of component.split("\r\n")) {
+    if (line == "BEGIN:STANDARD" || line == "BEGIN:DAYLIGHT") {
+      current = { start: null, offsetFrom: null, offsetTo: null, recurrenceRule: null };
+      observances.push(current);
+    } else if (!current) {
+      continue;
+    } else if (line.startsWith("DTSTART:")) {
+      current.start = line.slice("DTSTART:".length);
+    } else if (line.startsWith("TZOFFSETFROM:")) {
+      current.offsetFrom = parseOffset(line.slice("TZOFFSETFROM:".length));
+    } else if (line.startsWith("TZOFFSETTO:")) {
+      current.offsetTo = parseOffset(line.slice("TZOFFSETTO:".length));
+    } else if (line.startsWith("RRULE:")) {
+      current.recurrenceRule = line.slice("RRULE:".length);
+    }
+  }
+  expect(observances.length).toBeGreaterThan(0);
+  return observances;
+}
+
+/** @param offset e.g. "+0530" @returns minutes */
+function parseOffset(offset: string): number {
+  expect(offset).toMatch(/^[+-]\d{4}$/);
+  return (offset.startsWith("-") ? -1 : 1) *
+    (parseInt(offset.slice(1, 3)) * 60 + parseInt(offset.slice(3, 5)));
+}
+
+/** The UTC offset at `time`, according to the observances, in minutes.
+ * Uses the change that happened last before `time`, like Outlook does. */
+function offsetFromObservances(observances: Observance[], time: Date): number {
+  if (!observances[0].recurrenceRule) {
+    return observances[0].offsetTo;
+  }
+  let last = null;
+  for (let year of [time.getUTCFullYear() - 1, time.getUTCFullYear()]) {
+    for (let observance of observances) {
+      let change = changeTime(observance, year);
+      if (change <= time.getTime() && (!last || change > last.change)) {
+        last = { change, offset: observance.offsetTo };
+      }
+    }
+  }
+  return last.offset;
+}
+
+/** When the change of `observance` happens in `year`, in UTC */
+function changeTime(observance: Observance, year: number): number {
+  let [, month, nth, weekday] = /BYMONTH=(\d+);BYDAY=(-?\d+)(\w\w)/.exec(observance.recurrenceRule);
+  let day = dayOfNthWeekday(year, parseInt(month), parseInt(nth), kWeekdays.indexOf(weekday));
+  let local = Date.UTC(year, parseInt(month) - 1, day,
+    parseInt(observance.start.slice(9, 11)),
+    parseInt(observance.start.slice(11, 13)),
+    parseInt(observance.start.slice(13, 15)));
+  return local - observance.offsetFrom * k1MinuteMS;
+}
+
+const kWeekdays = ["SU", "MO", "TU", "WE", "TH", "FR", "SA"];
+
+/** The day of the month of e.g. the 2nd Sunday, by counting all Sundays
+ * @param month 1 = January
+ * @param nth -1 = the last one */
+function dayOfNthWeekday(year: number, month: number, nth: number, weekday: number): number {
+  let days: number[] = [];
+  for (let day = 1; day <= 31; day++) {
+    let date = new Date(Date.UTC(year, month - 1, day));
+    if (date.getUTCMonth() == month - 1 && date.getUTCDay() == weekday) {
+      days.push(day);
+    }
+  }
+  return nth > 0 ? days[nth - 1] : days.at(nth);
+}
+
+/** How many minutes the local time in `timezone` is ahead of UTC, at `time`,
+ * from the timezone database, as the yardstick for our own calculation */
+function utcOffset(time: Date, timezone: string): number {
+  let offset = new Intl.DateTimeFormat("en-US", { timeZone: timezone, timeZoneName: "longOffset" })
+    .format(time).replace(/.*GMT/, "");
+  if (!offset) { // "GMT" alone, for UTC
+    return 0;
+  }
+  return (offset.startsWith("-") ? -1 : 1) *
+    (parseInt(offset.slice(1, 3)) * 60 + parseInt(offset.slice(4, 6)));
+}


### PR DESCRIPTION
We wrote only IANA timezones.
RFC 5545 3.6.5 requires the VTIMEZONE for every TZID.

Outlook does not know the IANA timezone names, but matches them against a list of well-known timezones, and gets only the base offset from it, because it reads the daylight saving time solely from the VTIMEZONE. It therefore shows every event during summer time 1 hour too early. Exchange ignores the name entirely and falls back to the timezone of the mailbox, so it converts the invitation wrongly before Outlook even sees it. Both bugs hide in winter, when base offset and real offset agree.

We derive the rules from the timezone database via `Intl`, for the year in which the event happens, and write only what Outlook and Exchange read: DTSTART, RRULE, TZOFFSETFROM and TZOFFSETTO, in local time.