### PR TITLE
S/MIME: Eagerly update signing certificate trust level

### DIFF
--- a/app/logic/Mail/Encryption/SMIME/SMIMEVerify.ts
+++ b/app/logic/Mail/Encryption/SMIME/SMIMEVerify.ts
@@ -78,10 +78,12 @@ export async function verifySignedData(signedData: any, content: Uint8Array): Pr
     return null;
   }
   let signer = new SMIMEPublicKey();
-  while (cert && signer.addCertificate(cert)) {
+  while (cert && await signer.addCertificate(cert)) {
     cert = certificates.find(chain =>
       sameName(chain.tbsCertificate.subject, cert.tbsCertificate.issuer));
   };
+  // Update the signer's trustLevel if possible.
+  await signer.keyStatus();
   return signer;
 }
 


### PR DESCRIPTION
The certificate now immediately shows up with the correct trust level in the UI instead of when the user clicks it.

Also fixes a bug in my previous PR which would have prevented it from properly detecting a self-signed certificate.