### PR TITLE
OWA: Fix contact photos

### DIFF
--- a/app/logic/Contacts/OWA/OWAPerson.ts
+++ b/app/logic/Contacts/OWA/OWAPerson.ts
@@ -62,7 +62,7 @@ export class OWAPerson extends ExchangePerson {
    * Fall back to the email address, which knows the contact as well,
    * @see `OWAAddressbook.listGroups()` */
   protected static itemIDFromJSON(json: any): string {
-    let contact = json.Attributions?.find(attribution => sanitize.boolean(attribution.IsWritable, false) && attribution.SourceId);
+    let contact = json.AttributionsArray?.find(attribution => sanitize.boolean(attribution.IsWritable, false) && attribution.SourceId);
     return sanitize.nonemptystring(contact?.SourceId.Id ?? json.EmailAddress?.ItemId?.Id, "");
   }
 
@@ -84,6 +84,7 @@ export class OWAPerson extends ExchangePerson {
       let response = await this.addressbook.callOWA(request);
       this.name = sanitize.nonemptystring(response.DisplayName, "");
       this.personaID = sanitize.nonemptystring(response.PersonaId.Id);
+      this.itemID = OWAPerson.itemIDFromJSON(response);
       this.fields = fields;
     }
     await this.savePictureToServer();
@@ -97,7 +98,7 @@ export class OWAPerson extends ExchangePerson {
       return;
     }
     if (!this.itemID) {
-      // We just created the contact, and got only its persona back
+      // This probably shouldn't happen, since we sync the itemID on login.
       let response = await this.addressbook.callOWA(owaGetPersonaRequest(this.personaID));
       this.itemID = OWAPerson.itemIDFromJSON(response.Persona);
     }

--- a/app/logic/Mail/OWA/Request/OWAAttachmentRequests.ts
+++ b/app/logic/Mail/OWA/Request/OWAAttachmentRequests.ts
@@ -4,11 +4,8 @@ import type { Attachment } from "../../../Abstract/Attachment";
 export function owaGetAttachmentsRequest(attachmentIDs: string[]): OWARequest {
   return new OWARequest("GetAttachment", {
     __type: "GetAttachmentRequest:#Exchange",
-    AttachmentShape: {
-      __type: "AttachmentResponseShape:#Exchange",
-    },
     AttachmentIds: attachmentIDs.map(attachmentID => ({
-      __type: "RequestAttachmentId:#Exchange",
+      __type: "AttachmentId:#Exchange",
       Id: attachmentID,
     })),
   });
@@ -36,7 +33,7 @@ export function owaDeleteAttachmentsRequest(attachmentIDs: string[]): OWARequest
   return new OWARequest("DeleteAttachment", {
     __type: "DeleteAttachmentRequest:#Exchange",
     AttachmentIds: attachmentIDs.map(attachmentID => ({
-      __type: "RequestAttachmentId:#Exchange",
+      __type: "AttachmentId:#Exchange",
       Id: attachmentID,
     })),
   });

--- a/app/test/logic/Contacts/OWA/picture.test.ts
+++ b/app/test/logic/Contacts/OWA/picture.test.ts
@@ -29,7 +29,7 @@ function personaJSON(personaID = kPersonaID, itemID = kItemID): any {
     GivenName: "Alice",
     Surname: "Example",
     EmailAddresses: [{ EmailAddress: "alice@example.com" }],
-    Attributions: [{
+    AttributionsArray: [{
       Id: "0",
       SourceId: { Id: itemID },
       DisplayName: "Outlook",
@@ -140,7 +140,7 @@ test("reads the picture of the contact", async () => {
 
 test("finds the contact of a persona without attributions", async () => {
   let persona = personaJSON();
-  delete persona.Attributions;
+  delete persona.AttributionsArray;
   persona.EmailAddress = { EmailAddress: "alice@example.com", ItemId: { Id: kItemID } };
   addressbook = newAddressbook(kAttachmentID, persona);
 


### PR DESCRIPTION
- Unable to save a photo, because we couldn't find the contact's item ID
- Unable to delete a photo, because the request was malformed
- Unable to fetch a photo, bceause the request was malformed