### PR TITLE
Accounts: Dependent accounts log in, before they start up

### DIFF
--- a/app/frontend/Settings/AccountSubAccounts.svelte
+++ b/app/frontend/Settings/AccountSubAccounts.svelte
@@ -110,7 +110,7 @@
     newAccount.mainAccount = account;
     getAppGlobalListForAccount(newAccount).add(newAccount);
     await newAccount.save();
-    await newAccount.syncOnStartup();
+    await newAccount.loginAndStartup(false);
   }
 </script>
 

--- a/app/logic/Abstract/Account.ts
+++ b/app/logic/Abstract/Account.ts
@@ -87,11 +87,15 @@ export class Account extends Observable {
   /**
    * Convenience method for accounts to use to start up dependent accounts.
    * This should be called after the account has finished its own startup.
+   * They log in first, e.g. for their own notification stream. Their `login()`
+   * returns right away, given that we are logged in already.
    */
   protected async startupDependentAccounts() {
     for (let dependent of this.dependentAccounts()) {
-      dependent.dependentStartupOnce.runOnce(() => dependent.syncOnStartup())
-        .catch(dependent.errorCallback);
+      dependent.dependentStartupOnce.runOnce(async () => {
+        await dependent.login(false);
+        await dependent.syncOnStartup();
+      }).catch(dependent.errorCallback);
     }
   }
 
@@ -141,7 +145,7 @@ export class Account extends Observable {
   /** Logs in and runs the initial sync, like the app start does.
    * For the Login and Get Mail buttons and the account setup. */
   async loginAndStartup(interactive: boolean): Promise<void> {
-    if (this.isDependentAccount) {
+    if (this.isDependentAccount && !this.mainAccount.isLoggedIn) {
       await this.mainAccount.loginAndStartup(interactive); // it starts us up
       return;
     }

--- a/app/logic/Calendar/EWS/EWSCalendar.ts
+++ b/app/logic/Calendar/EWS/EWSCalendar.ts
@@ -38,9 +38,10 @@ export class EWSCalendar extends ExchangeCalendar implements EWSSubscribable {
     await this.account.unsubscribeNotifications(this);
   }
 
-  async syncOnStartup(): Promise<void> {
-    await super.syncOnStartup();
+  async login(interactive: boolean): Promise<void> {
+    await super.login(interactive);
     if (this.username != this.account.username) {
+      // Folders of the main user are covered by its `SubscribeToAllFolders`
       await this.account.subscribeToNotificationsForSubaccount(this);
     }
   }

--- a/app/logic/Contacts/EWS/EWSAddressbook.ts
+++ b/app/logic/Contacts/EWS/EWSAddressbook.ts
@@ -39,9 +39,10 @@ export class EWSAddressbook extends ExchangeAddressbook implements EWSSubscribab
     await this.account.unsubscribeNotifications(this);
   }
 
-  async syncOnStartup(): Promise<void> {
-    await super.syncOnStartup();
+  async login(interactive: boolean): Promise<void> {
+    await super.login(interactive);
     if (this.username != this.account.username) {
+      // Folders of the main user are covered by its `SubscribeToAllFolders`
       await this.account.subscribeToNotificationsForSubaccount(this);
     }
   }

--- a/app/logic/Mail/EWS/EWSAccount.ts
+++ b/app/logic/Mail/EWS/EWSAccount.ts
@@ -119,6 +119,7 @@ export class EWSAccount extends ExchangeMailAccount implements EWSSubscribable {
     await this.loginRunOnce.runOnce(async () => {
       if (this.mainAccount) {
         await this.mainAccount.login(interactive);
+        await (this.mainAccount as EWSAccount).subscribeToNotificationsForSubaccount(this);
         return;
       }
       await ensureLicensed(); // Not in generic `Account`, to keep license code in the proprietary parts
@@ -134,8 +135,7 @@ export class EWSAccount extends ExchangeMailAccount implements EWSSubscribable {
       try {
         await super.syncOnStartup();
         if (this.isDependentAccount) {
-          await (this.mainAccount as EWSAccount).subscribeToNotificationsForSubaccount(this);
-          return;
+          return; // `login()` subscribed us to the notifications
         }
         if (!appGlobal.searchOnlyAddressbooks.some(ab => ab.mainAccount == this)) {
           appGlobal.searchOnlyAddressbooks.add(new EWSGAL(this));
@@ -1099,7 +1099,7 @@ export class EWSAccount extends ExchangeMailAccount implements EWSSubscribable {
     account.identities.add(identity);
     await account.save();
     appGlobal.emailAccounts.add(account);
-    await account.syncOnStartup();
+    await account.loginAndStartup(false);
     return account;
   }
 
@@ -1137,7 +1137,7 @@ export class EWSAccount extends ExchangeMailAccount implements EWSSubscribable {
     addressbook.username = person.emailAddress;
     addressbook.folderID = folderID;
     appGlobal.addressbooks.add(addressbook);
-    await addressbook.syncOnStartup();
+    await addressbook.loginAndStartup(false);
     return addressbook;
   }
 
@@ -1176,7 +1176,7 @@ export class EWSAccount extends ExchangeMailAccount implements EWSSubscribable {
     calendar.folderID = folderID;
     calendar.useForInvitations = true;
     appGlobal.calendars.add(calendar);
-    await calendar.syncOnStartup();
+    await calendar.loginAndStartup(false);
     return calendar;
   }
 

--- a/app/logic/Mail/JMAP/JMAPAccount.ts
+++ b/app/logic/Mail/JMAP/JMAPAccount.ts
@@ -847,7 +847,7 @@ export class JMAPAccount extends MailAccount {
     account.identities.add(identity);
     await account.save();
     appGlobal.emailAccounts.add(account);
-    await account.syncOnStartup();
+    await account.loginAndStartup(false);
     return account;
   }
 

--- a/app/test/logic/startup.test.ts
+++ b/app/test/logic/startup.test.ts
@@ -31,7 +31,7 @@ test("The app start logs in, then starts up, once", async () => {
   expect(errors).toEqual([]);
   expect(remote.calls).toEqual(["login", "startup"]);
   expect(local.calls).toEqual(["login", "startup"]);
-  expect(dependent.calls).toEqual(["startup"]); // by its main account
+  expect(dependent.calls).toEqual(["login", "startup"]); // by its main account
 });
 
 test("When the network comes back, only the accounts that are logged out start again", async () => {
@@ -43,16 +43,26 @@ test("When the network comes back, only the accounts that are logged out start a
   expect(errors).toEqual([]);
   expect(remote.calls).toEqual(["login", "startup", "login", "startup"]);
   expect(local.calls).toEqual(["login", "startup"]);
-  expect(dependent.calls).toEqual(["startup", "startup"]);
+  expect(dependent.calls).toEqual(["login", "startup", "login", "startup"]);
 });
 
-test("The Login button of a shared mailbox logs in the main account, which starts up both", async () => {
+test("The Login button of a logged out shared mailbox logs in the main account, which starts up both", async () => {
+  remote.loggedIn = false;
+
   await dependent.loginAndStartup(true);
   await sleep(0.01); // `startupDependentAccounts()` does not wait for them
 
   expect(errors).toEqual([]);
   expect(remote.calls).toEqual(["login", "startup", "login", "startup", "login", "startup"]);
-  expect(dependent.calls).toEqual(["startup", "startup", "startup"]);
+  expect(dependent.calls).toEqual(["login", "startup", "login", "startup", "login", "startup"]);
+});
+
+test("The Login button of a shared mailbox starts up only that mailbox, when the main account is logged in", async () => {
+  await dependent.loginAndStartup(true);
+
+  expect(errors).toEqual([]);
+  expect(remote.calls).toEqual(["login", "startup", "login", "startup", "login", "startup"]);
+  expect(dependent.calls).toEqual(["login", "startup", "login", "startup", "login", "startup", "login", "startup"]);
 });
 
 /** `login()` only logs in. The caller runs `syncOnStartup()`. */


### PR DESCRIPTION
"If the dependent account needs its own stream listener, it should do that in `login()`", as defined in
<https://github.com/mustang-im/mustang/pull/1292#issuecomment-4963453696>.

The shared mailboxes, calendars and address books of an Exchange account subscribed to their notification stream in `startup()`. The startup is the initial sync, and the caller may skip it and issue a single call instead, so the stream is then missing. It belongs to the connection, i.e. to `login()`.

Dependent accounts never had their `login()` called: the main account starts them up, and their own `login()` only forwards to the main account, which already logged in. So `startupDependentAccounts()` now calls both, in the order that the definition gives.

For the same reason, `loginAndStartup()` of a dependent account forwards to the main account only when that is not logged in yet. Otherwise, e.g. for the Login button of a shared mailbox whose account works, it logs in and starts up only that one account, instead of running the startup of every account again.