### PR TITLE
S/MIME: Interop fixes #1379

### DIFF
--- a/app/logic/Mail/EMail.ts
+++ b/app/logic/Mail/EMail.ts
@@ -182,15 +182,18 @@ export class EMail extends Message {
    * in the AutoCrypt header for PGP - so this is the only place where we
    * have it for senders who are not in the addressbook.
    * Only keys that were issued for the `From:` address describe the sender.
+   * A signature by any other key does not tell us who wrote the message,
+   * so it does not count as signed at all.
    * @param signer null, if the signature did not verify */
   rememberSigner(signer: PublicKey | null) {
+    let emailAddress = this.from?.emailAddress?.toLowerCase();
+    if (signer && !signer.userIDs.some(userID => userID.toLowerCase() == emailAddress)) {
+      console.log("signature ignored: the key is for", signer.userIDs.join(", "), "but the sender is", emailAddress);
+      signer = null;
+    }
     this.signedKey = signer;
     this.signedByKeyID = signer?.id ?? null;
     if (!signer) {
-      return;
-    }
-    let emailAddress = this.from?.emailAddress?.toLowerCase();
-    if (!emailAddress || !signer.userIDs.some(userID => userID.toLowerCase() == emailAddress)) {
       return;
     }
     let known = this.from.encryptionPublicKey;

--- a/app/logic/Mail/Encryption/KeyUtils.ts
+++ b/app/logic/Mail/Encryption/KeyUtils.ts
@@ -94,7 +94,7 @@ export function getPublicKeyForPersonUID<T extends PublicKey>(uid: PersonUID, ke
 }
 
 function isUsableKey<T extends PublicKey>(key: PublicKey | null, keyType?: new () => T): key is T {
-  return !!key && !key.obsolete && (!keyType || key instanceof keyType);
+  return !!key && !key.obsolete && key.usableForEncryption() && (!keyType || key instanceof keyType);
 }
 
 /** For composer, which own key to use for signing the outgoing email */

--- a/app/logic/Mail/Encryption/MIME.ts
+++ b/app/logic/Mail/Encryption/MIME.ts
@@ -51,7 +51,7 @@ export function parseHeaderParameters(headerValue: string | null | undefined): R
  * Generic function, unrelated to encryption.
  * postal-mime unfortunately doesn't parse parameters.
  *
- * Assumes CRLF
+ * Accepts both CRLF and bare LF line endings
  *
  * @param mime The entire MIME message. May contain other multipart structures.
  * @param contentType Value of the Content-Type header for this particular part
@@ -73,7 +73,10 @@ export function parseMIMEDirectSubpartsBytes(mime: Uint8Array, contentType: stri
   assert(parameters.$main.startsWith("multipart/"), "Need multipart/* Content-Type, but got " + contentType);
   let boundary = parameters.boundary;
   assert(boundary, "No boundary found in Content-Type header " + contentType);
-  let delimiter = Uint8Array.from("\r\n--" + boundary, c => c.charCodeAt(0));
+  // Bare LF, as NSS writes it, must work as well. The signature of a
+  // `multipart/signed` is over the exact bytes of the part, so the caller
+  // must be able to hand them on unchanged.
+  let delimiter = Uint8Array.from("\n--" + boundary, c => c.charCodeAt(0));
   let parts: Uint8Array[] = [];
   let pos = indexOfBytes(mime, delimiter, 0); // Skip content before the first part
   assert(pos >= 0, "Start boundary not found");
@@ -86,10 +89,11 @@ export function parseMIMEDirectSubpartsBytes(mime: Uint8Array, contentType: stri
       assert(end[0] == 0x2D && end[1] == 0x2D, "End boundary not found");
       break;
     }
-    parts.push(mime.subarray(start, pos));
+    // The line ending before the boundary belongs to the delimiter
+    parts.push(mime.subarray(start, mime[pos - 1] == 0x0D ? pos - 1 : pos));
   }
   // Remove newline after boundary
-  return parts.map(part => part[0] == 0x0D && part[1] == 0x0A ? part.subarray(2) : part);
+  return parts.map(part => part.subarray(part[0] == 0x0D ? 2 : 1));
 }
 
 function indexOfBytes(haystack: Uint8Array, needle: Uint8Array, from: number): number {

--- a/app/logic/Mail/Encryption/PublicKey.ts
+++ b/app/logic/Mail/Encryption/PublicKey.ts
@@ -85,6 +85,12 @@ export class PublicKey extends Observable {
     return batches.join(" ");
   }
 
+  /** Whether we may encrypt to this key. Certificates can be issued for
+   * signing only, and then encrypting to them would not reach the owner. */
+  usableForEncryption(): boolean {
+    return true;
+  }
+
   publicKeyAsFile(): File {
     // Implement using this.keyAsFile()
     throw new AbstractFunction();

--- a/app/logic/Mail/Encryption/SMIME/SMIMEASN1.ts
+++ b/app/logic/Mail/Encryption/SMIME/SMIMEASN1.ts
@@ -109,6 +109,9 @@ const oids = {
   // RFC 5035: which certificate the signer used
   "1.2.840.113549.1.9.16.2.12": "signingCertificate",
   "1.2.840.113549.1.9.16.2.47": "signingCertificateV2",
+  // RFC 5280: what a certificate may be used for
+  "2.5.29.30": "nameConstraints",
+  "2.5.29.37.0": "anyExtendedKeyUsage",
 };
 
 export type WebCryptoAlgorithm = "SHA-1" | "SHA-256" | "SHA-384" | "SHA-512";
@@ -307,6 +310,48 @@ const GeneralName = define("GeneralName", function() {
 
 export const SubjectAlternativeName = define("SubjectAlternativeName", function() {
   this.seqof(GeneralName);
+});
+
+/** Whether the certificate may issue other certificates, and how many more
+ * certificates may follow it in the chain. RFC 5280 section 4.2.1.9 */
+export interface BasicConstraints {
+  cA: boolean;
+  pathLenConstraint?: bigint;
+}
+export const BasicConstraints = define<BasicConstraints>("BasicConstraints", function() {
+  this.seq().obj(
+    this.key("cA").bool().def(false),
+    this.key("pathLenConstraint").optional().int(),
+  );
+});
+
+/** What the key may be used for, one bit per usage, starting with
+ * digitalSignature as the highest bit. RFC 5280 section 4.2.1.3 */
+export const KeyUsage = define<BitString>("KeyUsage", function() {
+  this.bitstr();
+});
+
+/** What the certificate may be used for, e.g. `emailProtection`.
+ * RFC 5280 section 4.2.1.12 */
+export const ExtKeyUsage = define<(string | number[])[]>("ExtKeyUsage", function() {
+  this.seqof(Oid);
+});
+
+const GeneralSubtree = define("GeneralSubtree", function() {
+  this.seq().obj(
+    this.key("base").use(GeneralName),
+    this.key("minimum").optional().implicit(0).int(),
+    this.key("maximum").optional().implicit(1).int(),
+  );
+});
+
+/** The names that a CA certificate may issue certificates for, e.g. a company
+ * CA that is limited to its own email domain. RFC 5280 section 4.2.1.10 */
+export const NameConstraints = define("NameConstraints", function() {
+  this.seq().obj(
+    this.key("permittedSubtrees").optional().implicit(0).seqof(GeneralSubtree),
+    this.key("excludedSubtrees").optional().implicit(1).seqof(GeneralSubtree),
+  );
 });
 
 /** The part of a certificate that is (to be) signed */

--- a/app/logic/Mail/Encryption/SMIME/SMIMEASN1.ts
+++ b/app/logic/Mail/Encryption/SMIME/SMIMEASN1.ts
@@ -170,6 +170,16 @@ export const UTCTime = define<number>("UTCTime", function() {
   this.utctime();
 });
 
+/** A point in time, in either of the 2 encodings that X.509 and CMS allow.
+ * RFC 5280 section 4.1.2.5, RFC 5652 section 11.3. */
+export interface Time {
+  type: "utctime" | "gentime";
+  value: number;
+}
+export const Time = define<Time>("Time", function() {
+  this.choice({ utctime: this.utctime(), gentime: this.gentime() });
+});
+
 /** An algorithm */
 export interface AlgorithmIdentifier {
   algorithm: string | number[];
@@ -302,7 +312,7 @@ export interface TBSCertificate {
   serialNumber: bigint,
   signature: AlgorithmIdentifier,
   issuer: AttributeValue[],
-  validity: Record<"notBefore" | "notAfter", { type: "utctime" | "gentime", value: number }>,
+  validity: Record<"notBefore" | "notAfter", Time>,
   subject: AttributeValue[],
   publicKey: SubjectPublicKeyInfo,
   issuerUniqueId?: BitString,
@@ -316,8 +326,8 @@ export const TBSCertificate = define<TBSCertificate>("TBSCertificate", function(
     this.key("signature").use(AlgorithmIdentifier),
     this.key("issuer").seqof(AttributeValue),
     this.key("validity").seq().obj(
-      this.key("notBefore").choice({ utctime: this.utctime(), gentime: this.gentime() }),
-      this.key("notAfter").choice({ utctime: this.utctime(), gentime: this.gentime() }),
+      this.key("notBefore").use(Time),
+      this.key("notAfter").use(Time),
     ),
     this.key("subject").seqof(AttributeValue),
     this.key("publicKey").use(SubjectPublicKeyInfo),

--- a/app/logic/Mail/Encryption/SMIME/SMIMEASN1.ts
+++ b/app/logic/Mail/Encryption/SMIME/SMIMEASN1.ts
@@ -106,6 +106,9 @@ const oids = {
   "2.16.840.1.101.3.4.2.1": "sha256",
   "2.16.840.1.101.3.4.2.2": "sha384",
   "2.16.840.1.101.3.4.2.3": "sha512",
+  // RFC 5035: which certificate the signer used
+  "1.2.840.113549.1.9.16.2.12": "signingCertificate",
+  "1.2.840.113549.1.9.16.2.47": "signingCertificateV2",
 };
 
 export type WebCryptoAlgorithm = "SHA-1" | "SHA-256" | "SHA-384" | "SHA-512";
@@ -594,6 +597,39 @@ export const SignedData = define("SignedData", function() {
       this.key("crls").implicit(1).optional().setof(Any),
       this.key("signerInfos").setof(SignerInfo),
     ),
+  );
+});
+
+/** The signer names the certificate that he used, by its hash, in a signed
+ * attribute, so that nobody can swap it for another certificate of the same
+ * owner. RFC 5035 section 5. `issuerSerial` and `policies` are not needed,
+ * because the hash already identifies the certificate exactly. */
+const ESSCertID = define("ESSCertID", function() {
+  this.seq().obj(
+    this.key("certHash").octstr(), // always SHA-1, in this version
+    this.key("issuerSerial").optional().any(),
+  );
+});
+
+export const SigningCertificate = define("SigningCertificate", function() {
+  this.seq().obj(
+    this.key("certs").seqof(ESSCertID),
+    this.key("policies").optional().any(),
+  );
+});
+
+const ESSCertIDv2 = define("ESSCertIDv2", function() {
+  this.seq().obj(
+    this.key("hashAlgorithm").use(AlgorithmIdentifier).def({ algorithm: "sha256" }),
+    this.key("certHash").octstr(),
+    this.key("issuerSerial").optional().any(),
+  );
+});
+
+export const SigningCertificateV2 = define("SigningCertificateV2", function() {
+  this.seq().obj(
+    this.key("certs").seqof(ESSCertIDv2),
+    this.key("policies").optional().any(),
   );
 });
 

--- a/app/logic/Mail/Encryption/SMIME/SMIMEASN1.ts
+++ b/app/logic/Mail/Encryption/SMIME/SMIMEASN1.ts
@@ -378,7 +378,7 @@ const RecipientInfo = define("RecipientInfo", function() {
           this.key("issuer").seqof(AttributeValue),
           this.key("serialNumber").int(),
         ),
-        subjectKeyIdentifier: this.implicit(0).octstr(), // TODO
+        subjectKeyIdentifier: this.implicit(0).octstr(),
       }),
       this.key("keyEncryptionAlgorithm").use(AlgorithmIdentifier),
       this.key("encryptedKey").octstr(),

--- a/app/logic/Mail/Encryption/SMIME/SMIMEASN1.ts
+++ b/app/logic/Mail/Encryption/SMIME/SMIMEASN1.ts
@@ -71,6 +71,7 @@ const oids = {
   "1.2.840.113549.2.9": "hmacWithSHA256",
   "1.2.840.113549.2.10": "hmacWithSHA384",
   "1.2.840.113549.2.11": "hmacWithSHA512",
+  "1.2.840.113549.3.2": "rc2CBC",
   "1.2.840.113549.3.7": "desEDE3CBC",
   "1.3.6.1.5.5.7.3.4": "emailProtection",
   //"1.3.6.1.5.5.8.1.2": "hmacWithSHA1",
@@ -446,6 +447,15 @@ export const EnvelopedData = define("EnvelopedData", function() {
       ),
       this.key("unprotectedAttrs").implicit(1).optional().use(Attributes),
     ),
+  );
+});
+
+/** The parameters of the RC2-CBC cipher. `rc2ParameterVersion` encodes
+ * the effective key length. RFC 3370 section 5.2. */
+export const RC2CBCParameters = define("RC2CBCParameters", function() {
+  this.seq().obj(
+    this.key("rc2ParameterVersion").int(),
+    this.key("iv").octstr(),
   );
 });
 

--- a/app/logic/Mail/Encryption/SMIME/SMIMEASN1.ts
+++ b/app/logic/Mail/Encryption/SMIME/SMIMEASN1.ts
@@ -44,6 +44,7 @@ const oids = {
   "1.2.840.113549.1.1.7": "rsaESOAEP",
   "1.2.840.113549.1.1.8": "mgf1",
   "1.2.840.113549.1.1.9": "pSpecified",
+  "1.2.840.113549.1.1.10": "rsassaPss",
   "1.2.840.113549.1.1.11": "sha256WithRSAEncryption",
   "1.2.840.113549.1.1.12": "sha384WithRSAEncryption",
   "1.2.840.113549.1.1.13": "sha512WithRSAEncryption",
@@ -246,6 +247,23 @@ export const ECDSASigValue = define<ECDSASigValue>("ECDSASigValue", function() {
   this.seq().obj(
     this.key("r").int(),
     this.key("s").int(),
+  );
+});
+
+/** The parameters of an RSASSA-PSS signature. RFC 4055 section 3.1.
+ * The defaults are all SHA-1, which we do not accept. */
+export interface RSASSAPSSParams {
+  hashAlgorithm: AlgorithmIdentifier;
+  maskGenAlgorithm: AlgorithmIdentifier;
+  saltLength: bigint;
+  trailerField: bigint;
+}
+export const RSASSAPSSParams = define<RSASSAPSSParams>("RSASSAPSSParams", function() {
+  this.seq().obj(
+    this.key("hashAlgorithm").explicit(0).use(AlgorithmIdentifier).def({ algorithm: "sha1" }),
+    this.key("maskGenAlgorithm").explicit(1).use(AlgorithmIdentifier).def({ algorithm: "mgf1" }),
+    this.key("saltLength").explicit(2).int().def(20n),
+    this.key("trailerField").explicit(3).int().def(1n),
   );
 });
 

--- a/app/logic/Mail/Encryption/SMIME/SMIMEASN1.ts
+++ b/app/logic/Mail/Encryption/SMIME/SMIMEASN1.ts
@@ -361,11 +361,13 @@ export const PBKDF2Params = define<PBKDF2Params>("PBKDF2Params", function() {
 });
 
 /* CMS */
+/** The parameters of RSA-OAEP. Senders leave out what has the default
+ * value, so OpenSSL sends an empty sequence for SHA-1. RFC 4055 section 4.1 */
 export const RSAESOAEPParams = define("RSAESOAEPParams", function() {
   this.seq().obj(
-    this.key("hashFunc").explicit(0).use(AlgorithmIdentifier),
-    this.key("maskGenFunc").explicit(1).use(AlgorithmIdentifier),
-    this.key("pSourceFunc").explicit(2).use(AlgorithmIdentifier),
+    this.key("hashFunc").explicit(0).use(AlgorithmIdentifier).def({ algorithm: "sha1" }),
+    this.key("maskGenFunc").explicit(1).use(AlgorithmIdentifier).def({ algorithm: "mgf1" }),
+    this.key("pSourceFunc").explicit(2).use(AlgorithmIdentifier).def({ algorithm: "pSpecified" }),
   );
 });
 

--- a/app/logic/Mail/Encryption/SMIME/SMIMEASN1.ts
+++ b/app/logic/Mail/Encryption/SMIME/SMIMEASN1.ts
@@ -34,6 +34,11 @@ import { define } from "../../../../../lib/asn1/api";
 
 /** Object identifiers */
 const oids = {
+  "1.2.840.10045.2.1": "ecPublicKey",
+  "1.2.840.10045.3.1.7": "secp256r1",
+  "1.2.840.10045.4.3.2": "ecdsaWithSHA256",
+  "1.2.840.10045.4.3.3": "ecdsaWithSHA384",
+  "1.2.840.10045.4.3.4": "ecdsaWithSHA512",
   "1.2.840.113549.1.1.1": "rsaEncryption",
   "1.2.840.113549.1.1.5": "sha1WithRSAEncryption",
   "1.2.840.113549.1.1.7": "rsaESOAEP",
@@ -76,6 +81,8 @@ const oids = {
   "1.3.6.1.5.5.7.3.4": "emailProtection",
   //"1.3.6.1.5.5.8.1.2": "hmacWithSHA1",
   "1.3.14.3.2.26": "sha1",
+  "1.3.132.0.34": "secp384r1",
+  "1.3.132.0.35": "secp521r1",
   "2.1.0.1.1": "printstr",
   "2.5.4.3": "CN", // commonName
   "2.5.4.6": "C", // country
@@ -100,7 +107,7 @@ const oids = {
   "2.16.840.1.101.3.4.2.3": "sha512",
 };
 
-type WebCryptoAlgorithm = "SHA-1" | "SHA-256" | "SHA-384" | "SHA-512";
+export type WebCryptoAlgorithm = "SHA-1" | "SHA-256" | "SHA-384" | "SHA-512";
 
 /** Converts a digest (hashing) algorithm name to WebCrypto. */
 export const DigestAlgorithm: Record<string, WebCryptoAlgorithm> = {
@@ -116,6 +123,17 @@ export const SignatureAlgorithm: Record<string, WebCryptoAlgorithm> = {
   sha256WithRSAEncryption: "SHA-256",
   sha384WithRSAEncryption: "SHA-384",
   sha512WithRSAEncryption: "SHA-512",
+  ecdsaWithSHA256: "SHA-256",
+  ecdsaWithSHA384: "SHA-384",
+  ecdsaWithSHA512: "SHA-512",
+}
+
+/** The elliptic curves whose signatures we can verify, and the bit length of
+ * their coordinates. Their WebCrypto name is "P-" and that bit length. */
+export const NamedCurve: Record<string, number> = {
+  secp256r1: 256,
+  secp384r1: 384,
+  secp521r1: 521,
 }
 
 /** Extracts the WebCrypto hash algorithm used by a key derivation algorithm. */
@@ -191,7 +209,7 @@ export const RDNSequence = define<AttributeValue[]>("RDNSequence", function() {
 });
 
 export interface SubjectPublicKeyInfo {
-  algorithmIdenfitier: AlgorithmIdentifier;
+  algorithmIdentifier: AlgorithmIdentifier;
   subjectPublicKey: BitString;
 }
 export const SubjectPublicKeyInfo = define<SubjectPublicKeyInfo>("SubjectPublicKeyInfo", function() {
@@ -214,6 +232,20 @@ export const RSAPublicKey = define<RSAPublicKey>("RSAPublicKey", function() {
   this.seq().obj(
     this.key("n").int(),
     this.key("e").int(),
+  );
+});
+
+/** The signature value of an ECDSA signature, in certificates and in CMS.
+ * RFC 5480 section 2. WebCrypto instead wants r and s concatenated,
+ * each as a fixed-size number of the size of the curve. */
+export interface ECDSASigValue {
+  r: bigint;
+  s: bigint;
+}
+export const ECDSASigValue = define<ECDSASigValue>("ECDSASigValue", function() {
+  this.seq().obj(
+    this.key("r").int(),
+    this.key("s").int(),
   );
 });
 

--- a/app/logic/Mail/Encryption/SMIME/SMIMEPrivateKey.ts
+++ b/app/logic/Mail/Encryption/SMIME/SMIMEPrivateKey.ts
@@ -1,6 +1,6 @@
 import type { PrivateKey } from "../PrivateKey";
 import { SMIMEPublicKey, splitPEM } from "./SMIMEPublicKey";
-import { Any, PrivateKeyInfo, EncryptedPrivateKeyInfo, RSAPrivateKey, RSAPublicKey, CertificationRequestInfo, DigestInfo, CertificationRequest, Null } from "./SMIMEASN1";
+import { Any, PrivateKeyInfo, EncryptedPrivateKeyInfo, RSAPrivateKey, RSAPublicKey, SubjectPublicKeyInfo, CertificationRequestInfo, DigestInfo, CertificationRequest, Null } from "./SMIMEASN1";
 import { decryptPBES2, encryptPrivateKey } from "./PBES2";
 import { decrypt, padFF } from "./SMIMERSAES";
 import { sanitize } from "../../../../../lib/util/sanitizeDatatypes";
@@ -33,7 +33,13 @@ export class SMIMEPrivateKey extends SMIMEPublicKey implements PrivateKey {
     }
   }
 
-  async matches(key: RSAPublicKey): Promise<boolean> {
+  /** Whether the given certificate belongs to our private key,
+   * which is always an RSA key */
+  async matches(publicKey: SubjectPublicKeyInfo): Promise<boolean> {
+    if (publicKey.algorithmIdentifier.algorithm != "rsaEncryption") {
+      return false;
+    }
+    let key = RSAPublicKey.decode(publicKey.subjectPublicKey.data);
     let rawKey = await this.decryptKey();
     return key.n == rawKey.n && key.e == rawKey.e;
   }

--- a/app/logic/Mail/Encryption/SMIME/SMIMEPrivateKey.ts
+++ b/app/logic/Mail/Encryption/SMIME/SMIMEPrivateKey.ts
@@ -40,21 +40,24 @@ export class SMIMEPrivateKey extends SMIMEPublicKey implements PrivateKey {
 
   /** Decrypts our private key with our passphrase */
   async decryptKey(): Promise<RSAPrivateKey> {
-    let pkcs8: Uint8Array;
-    if (this.passphrase) {
-      let encryptedKey = EncryptedPrivateKeyInfo.decodePEM(this.privateKeyArmored, { label: "ENCRYPTED PRIVATE KEY" });
-      if (encryptedKey.encryptionAlgorithm.algorithm != "pkcs5PBES2") {
-        throw new Error("Unsupported private key encryption algorithm");
-      }
-      pkcs8 = await decryptPBES2(encryptedKey.encryptedData, encryptedKey.encryptionAlgorithm.parameters, this.passphrase);
-    } else {
-      pkcs8 = Any.decodePEM(this.privateKeyArmored, { label: "PRIVATE KEY" });
-    }
-    let privateKeyInfo = PrivateKeyInfo.decode(pkcs8);
+    let privateKeyInfo = PrivateKeyInfo.decode(await this.decryptKeyPKCS8());
     if (privateKeyInfo.privateKeyAlgorithm.algorithm != "rsaEncryption") {
       throw new Error("Unsupported private key algorithm");
     }
     return RSAPrivateKey.decode(privateKeyInfo.privateKey);
+  }
+
+  /** Decrypts our private key with our passphrase, in the PKCS#8 form
+   * that `crypto.subtle.importKey()` reads */
+  async decryptKeyPKCS8(): Promise<Uint8Array> {
+    if (!this.passphrase) {
+      return Any.decodePEM(this.privateKeyArmored, { label: "PRIVATE KEY" });
+    }
+    let encryptedKey = EncryptedPrivateKeyInfo.decodePEM(this.privateKeyArmored, { label: "ENCRYPTED PRIVATE KEY" });
+    if (encryptedKey.encryptionAlgorithm.algorithm != "pkcs5PBES2") {
+      throw new Error("Unsupported private key encryption algorithm");
+    }
+    return await decryptPBES2(encryptedKey.encryptedData, encryptedKey.encryptionAlgorithm.parameters, this.passphrase);
   }
 
   privateKeyAsFile(): File {

--- a/app/logic/Mail/Encryption/SMIME/SMIMEPublicKey.ts
+++ b/app/logic/Mail/Encryption/SMIME/SMIMEPublicKey.ts
@@ -109,10 +109,11 @@ export class SMIMEPublicKey extends PublicKey {
     }
     // This checks only that each certificate is validly signed by the next one
     // up to a trusted root. It does not verify basicConstraints (CA:TRUE) or
-    // keyUsage/extKeyUsage (emailProtection). Identity is bound elsewhere, by
-    // matching the signer's stored key ID against `email.from`, so a rogue leaf
-    // cannot sign as another identity today. Do not start trusting the chain
-    // itself for identity binding without adding those X.509 path checks first.
+    // keyUsage/extKeyUsage (emailProtection). Identity is bound elsewhere, in
+    // `EMail.rememberSigner()`, by matching the email addresses of the signer
+    // certificate against `email.from`, so a rogue leaf cannot sign as another
+    // identity today. Do not start trusting the chain itself for identity
+    // binding without adding those X.509 path checks first.
     let cert = Certificate.decodePEM(this.certificate, { label: "CERTIFICATE" });
     for (let key of this.chain) {
       if (key.obsolete) {

--- a/app/logic/Mail/Encryption/SMIME/SMIMEPublicKey.ts
+++ b/app/logic/Mail/Encryption/SMIME/SMIMEPublicKey.ts
@@ -1,6 +1,6 @@
 import { PublicKey } from "../PublicKey";
 import { EncryptionSystem, TrustLevel, trustOrder } from "../enums";
-import { DigestAlgorithm, SignatureAlgorithm, AlgorithmIdentifier, Certificate, RSAPublicKey, SubjectAlternativeName, SubjectPublicKeyInfo, NamedCurve, ECDSASigValue, RSASSAPSSParams, Oid, RDNSequence, TBSCertificate, DigestInfo, type WebCryptoAlgorithm } from "./SMIMEASN1";
+import { DigestAlgorithm, SignatureAlgorithm, AlgorithmIdentifier, Certificate, RSAPublicKey, SubjectAlternativeName, SubjectPublicKeyInfo, NamedCurve, ECDSASigValue, RSASSAPSSParams, Oid, RDNSequence, TBSCertificate, DigestInfo, BasicConstraints, KeyUsage, ExtKeyUsage, NameConstraints, type WebCryptoAlgorithm } from "./SMIMEASN1";
 import { BlockType, unpadPKCS, decrypt, encrypt, padFF, Uint8ArrayFromHex, Uint8ArrayToHex } from "./SMIMERSAES";
 import { appGlobal } from "../../../app";
 import { sanitize } from "../../../../../lib/util/sanitizeDatatypes";
@@ -107,14 +107,10 @@ export class SMIMEPublicKey extends PublicKey {
     if (!this.certificate) {
       return KeyStatus.NoCertificate;
     }
-    // This checks only that each certificate is validly signed by the next one
-    // up to a trusted root. It does not verify basicConstraints (CA:TRUE) or
-    // keyUsage/extKeyUsage (emailProtection). Identity is bound elsewhere, in
-    // `EMail.rememberSigner()`, by matching the email addresses of the signer
-    // certificate against `email.from`, so a rogue leaf cannot sign as another
-    // identity today. Do not start trusting the chain itself for identity
-    // binding without adding those X.509 path checks first.
+    // Identity is bound elsewhere, in `EMail.rememberSigner()`, by matching
+    // the email addresses of the signer certificate against `email.from`.
     let cert = Certificate.decodePEM(this.certificate, { label: "CERTIFICATE" });
+    let depth = 0; // how many certificates are below this issuer in the chain
     for (let key of this.chain) {
       if (key.obsolete) {
         console.log("obsolete certificate in chain");
@@ -124,7 +120,25 @@ export class SMIMEPublicKey extends PublicKey {
       if (!await verifySignature(cert, signer)) {
         return KeyStatus.ChainInvalid;
       }
+      // RFC 5280 section 6.1: only a CA may issue certificates, only as deep
+      // as its `pathLenConstraint` allows, and only for the names that it is
+      // limited to. Trusted roots are exempt: the user vouches for them.
+      let extension = signer.tbsCertificate.extensions?.find(ext => ext.extnID == "basicConstraints");
+      let { cA, pathLenConstraint } = extension ? BasicConstraints.decode(extension.extnValue) : { cA: false };
+      if (!cA || pathLenConstraint != null && pathLenConstraint < depth) {
+        console.log("certificate in chain may not issue this certificate");
+        return KeyStatus.ChainInvalid;
+      }
+      if (!allowsKeyUsage(signer, KeyUsageBit.KeyCertSign)) {
+        console.log("certificate in chain may not sign certificates");
+        return KeyStatus.ChainInvalid;
+      }
+      if (!allowsEMailAddresses(signer, this.userIDs)) {
+        console.log("certificate is for an address that its CA may not issue");
+        return KeyStatus.ChainInvalid;
+      }
       cert = signer;
+      depth++;
     }
     for (let type of ["bundled", "system", "extra"]) {
       for (let ca of await lazyGetCACertificates(type)) {
@@ -286,6 +300,61 @@ export async function verifyRSAPSS(publicKey: SubjectPublicKeyInfo, signature: U
   return await crypto.subtle.verify({ name: "RSA-PSS", saltLength: Number(params.saltLength) }, key, signature as BufferSource, content as BufferSource);
 }
 
+/** Whether the certificate allows this use of its key.
+ * A certificate that does not say allows all of them.
+ * RFC 5280 section 4.2.1.3 */
+export function allowsKeyUsage(cert: Certificate, usage: KeyUsageBit): boolean {
+  let extension = cert.tbsCertificate.extensions?.find(ext => ext.extnID == "keyUsage");
+  if (!extension) {
+    return true;
+  }
+  let allowed = KeyUsage.decode(extension.extnValue);
+  return !!(allowed.data[usage >> 3] & 0x80 >> (usage & 7));
+}
+
+/** Whether the certificate allows this purpose, e.g. `emailProtection`.
+ * A certificate that does not say allows all of them.
+ * RFC 5280 section 4.2.1.12 */
+export function allowsPurpose(cert: Certificate, purpose: string): boolean {
+  let extension = cert.tbsCertificate.extensions?.find(ext => ext.extnID == "extKeyUsage");
+  if (!extension) {
+    return true;
+  }
+  return ExtKeyUsage.decode(extension.extnValue)
+    .some(allowed => allowed == purpose || allowed == "anyExtendedKeyUsage");
+}
+
+/** Whether the email addresses are all within the subtrees that this CA
+ * certificate may issue certificates for. RFC 5280 section 4.2.1.10 */
+function allowsEMailAddresses(cert: Certificate, emailAddresses: ArrayColl<string>): boolean {
+  let extension = cert.tbsCertificate.extensions?.find(ext => ext.extnID == "nameConstraints");
+  if (!extension) {
+    return true;
+  }
+  let constraints: any;
+  try {
+    constraints = NameConstraints.decode(extension.extnValue);
+  } catch (ex) {
+    // Subtree types that we do not implement, e.g. directoryName, fail to
+    // decode. They do not limit the email addresses anyway.
+    console.error(ex);
+    return true;
+  }
+  let emailSubtrees = (subtrees: any[]) => sanitize.array(subtrees, [])
+    .filter(subtree => subtree.base.type == "rfc822Name")
+    .map(subtree => sanitize.string(subtree.base.value, "").toLowerCase());
+  // A subtree is a complete address, a host, or `.domain` for its subdomains
+  let matches = (address: string, subtree: string) =>
+    subtree.includes("@") ? address == subtree :
+      subtree.startsWith(".") ? address.endsWith(subtree) :
+        address.endsWith("@" + subtree);
+  let permitted = emailSubtrees(constraints.permittedSubtrees);
+  let excluded = emailSubtrees(constraints.excludedSubtrees);
+  return emailAddresses.every(address =>
+    (!permitted.length || permitted.some(subtree => matches(address, subtree))) &&
+    !excluded.some(subtree => matches(address, subtree)));
+}
+
 let promiseGetCACertificates: Record<string, Promise<Certificate[]> | undefined> = {};
 function lazyGetCACertificates(type: string): Promise<Certificate[]> {
   return promiseGetCACertificates[type] ??= getCACertificatesLazy(type);
@@ -303,6 +372,15 @@ async function getCACertificatesLazy(type: string): Promise<Certificate[]> {
     }
   }
   return certificates;
+}
+
+/** The bit for each use in the `keyUsage` extension.
+ * RFC 5280 section 4.2.1.3 */
+export enum KeyUsageBit {
+  DigitalSignature = 0,
+  NonRepudiation = 1,
+  KeyEncipherment = 2,
+  KeyCertSign = 5,
 }
 
 export enum KeyStatus {

--- a/app/logic/Mail/Encryption/SMIME/SMIMEPublicKey.ts
+++ b/app/logic/Mail/Encryption/SMIME/SMIMEPublicKey.ts
@@ -1,7 +1,7 @@
 import { PublicKey } from "../PublicKey";
 import { EncryptionSystem, TrustLevel, trustOrder } from "../enums";
-import { DigestAlgorithm, SignatureAlgorithm, Certificate, RSAPublicKey, SubjectAlternativeName, RDNSequence, TBSCertificate, DigestInfo } from "./SMIMEASN1";
-import { BlockType, unpadPKCS, decrypt, encrypt, padFF, Uint8ArrayToHex } from "./SMIMERSAES";
+import { DigestAlgorithm, SignatureAlgorithm, Certificate, RSAPublicKey, SubjectAlternativeName, SubjectPublicKeyInfo, NamedCurve, ECDSASigValue, Oid, RDNSequence, TBSCertificate, DigestInfo, type WebCryptoAlgorithm } from "./SMIMEASN1";
+import { BlockType, unpadPKCS, decrypt, encrypt, padFF, Uint8ArrayFromHex, Uint8ArrayToHex } from "./SMIMERSAES";
 import { appGlobal } from "../../../app";
 import { sanitize } from "../../../../../lib/util/sanitizeDatatypes";
 import { ArrayColl } from "svelte-collections";
@@ -30,24 +30,32 @@ export class SMIMEPublicKey extends PublicKey {
     return certificateCommonName(cert) ?? "";
   }
 
-  async matches(key: RSAPublicKey): Promise<boolean> {
+  /** Whether the given certificate holds the same key as this one */
+  async matches(publicKey: SubjectPublicKeyInfo): Promise<boolean> {
     if (!this.publicKeyArmored) {
       return false;
     }
     let cert = Certificate.decodePEM(this.publicKeyArmored, { label: "Certificate" });
-    let rawKey = RSAPublicKey.decode(cert.tbsCertificate.publicKey.subjectPublicKey.data);
-    return key.n == rawKey.n && key.e == rawKey.e;
+    return !indexedDB.cmp(SubjectPublicKeyInfo.encode(publicKey), SubjectPublicKeyInfo.encode(cert.tbsCertificate.publicKey));
   }
 
   /**
    * Parses the given certificate and sets it as the public key.
    */
   async setCertificate(cert: Certificate) {
-    let rsa = RSAPublicKey.decode(cert.tbsCertificate.publicKey.subjectPublicKey.data);
+    let publicKey = cert.tbsCertificate.publicKey;
     if (!this.id) {
-      let id = sanitize.bigint(rsa.n).toString(16);
-      this.id = id.slice(-16);
-      this.keyLengthInBits = id.length * 4;
+      if (publicKey.algorithmIdentifier.algorithm == "ecPublicKey") {
+        let curve = sanitize.translate(Oid.decode(publicKey.algorithmIdentifier.parameters), NamedCurve, null);
+        this.cipher = curve ? "ECDSA/P-" + curve : "ECDSA";
+        this.keyLengthInBits = curve;
+        // The curve point identifies the key, like the modulus does for RSA
+        this.id = Uint8ArrayToHex(publicKey.subjectPublicKey.data).slice(-16);
+      } else {
+        let id = sanitize.bigint(RSAPublicKey.decode(publicKey.subjectPublicKey.data).n).toString(16);
+        this.id = id.slice(-16);
+        this.keyLengthInBits = id.length * 4;
+      }
     }
     this.publicKeyArmored = Certificate.encodePEM(cert, { label: "CERTIFICATE" });
     this.userIDs.replaceAll(certificateEMailAddresses(cert));
@@ -63,17 +71,17 @@ export class SMIMEPublicKey extends PublicKey {
   }
 
   async addCertificate(cert: Certificate): Promise<boolean> {
-    let rsa = RSAPublicKey.decode(cert.tbsCertificate.publicKey.subjectPublicKey.data);
+    let publicKey = cert.tbsCertificate.publicKey;
     if (!this.publicKeyArmored) {
       await this.setCertificate(cert);
       return true;
     }
-    if (await this.matches(rsa)) {
+    if (await this.matches(publicKey)) {
       await this.setCertificate(cert);
       return false;
     }
     for (let key of this.chain) {
-      if (await key.matches(rsa)) {
+      if (await key.matches(publicKey)) {
         await key.setCertificate(cert);
         return false;
       }
@@ -227,6 +235,27 @@ async function verifySignature(cert: Certificate, signer: Certificate): Promise<
     console.error(ex);
     return false;
   }
+}
+
+/** Verifies an ECDSA signature, e.g. of a certificate or of a signed message.
+ * WebCrypto can do this for us, unlike the RSA verification, which needs a
+ * primitive that WebCrypto does not expose.
+ * @param publicKey the `subjectPublicKeyInfo` of the signer certificate
+ * @param signature the DER `ECDSASigValue` that X.509 and CMS store
+ * @param digestAlgorithm the hash that the signature was made over
+ * @param content the signed bytes */
+export async function verifyECDSA(publicKey: SubjectPublicKeyInfo, signature: Uint8Array, digestAlgorithm: WebCryptoAlgorithm, content: Uint8Array): Promise<boolean> {
+  let curve = sanitize.translate(Oid.decode(publicKey.algorithmIdentifier.parameters), NamedCurve, null);
+  if (!curve) {
+    console.log("unsupported elliptic curve");
+    return false;
+  }
+  let key = await crypto.subtle.importKey("spki", SubjectPublicKeyInfo.encode(publicKey) as BufferSource, { name: "ECDSA", namedCurve: "P-" + curve }, false, ["verify"]);
+  // WebCrypto wants r and s one after the other, each in the size of the curve
+  let size = curve + 7 >> 3;
+  let { r, s } = ECDSASigValue.decode(signature);
+  let rs = Uint8ArrayFromHex(r.toString(16).padStart(size * 2, "0") + s.toString(16).padStart(size * 2, "0"));
+  return await crypto.subtle.verify({ name: "ECDSA", hash: digestAlgorithm }, key, rs as BufferSource, content as BufferSource);
 }
 
 let promiseGetCACertificates: Record<string, Promise<Certificate[]> | undefined> = {};

--- a/app/logic/Mail/Encryption/SMIME/SMIMEPublicKey.ts
+++ b/app/logic/Mail/Encryption/SMIME/SMIMEPublicKey.ts
@@ -210,8 +210,12 @@ async function verifySignature(cert: Certificate, signer: Certificate): Promise<
     }
     let algorithm = sanitize.translate(cert.signatureAlgorithm.algorithm, SignatureAlgorithm);
     let signedCert = TBSCertificate.encode(cert.tbsCertificate);
+    let publicKey = signer.tbsCertificate.publicKey;
+    if (publicKey.algorithmIdentifier.algorithm == "ecPublicKey") {
+      return await verifyECDSA(publicKey, cert.signatureValue.data, algorithm, signedCert);
+    }
     let signedDigest = new Uint8Array(await crypto.subtle.digest(algorithm, signedCert));
-    let rsa = RSAPublicKey.decode(signer.tbsCertificate.publicKey.subjectPublicKey.data);
+    let rsa = RSAPublicKey.decode(publicKey.subjectPublicKey.data);
     let block = encrypt(cert.signatureValue.data, rsa);
     let digestInfo = DigestInfo.decode(unpadPKCS(block, BlockType.Signed));
     if (sanitize.translate(digestInfo.digestAlgorithm.algorithm, DigestAlgorithm) != algorithm) {

--- a/app/logic/Mail/Encryption/SMIME/SMIMEPublicKey.ts
+++ b/app/logic/Mail/Encryption/SMIME/SMIMEPublicKey.ts
@@ -1,6 +1,6 @@
 import { PublicKey } from "../PublicKey";
 import { EncryptionSystem, TrustLevel, trustOrder } from "../enums";
-import { DigestAlgorithm, SignatureAlgorithm, Certificate, RSAPublicKey, SubjectAlternativeName, SubjectPublicKeyInfo, NamedCurve, ECDSASigValue, Oid, RDNSequence, TBSCertificate, DigestInfo, type WebCryptoAlgorithm } from "./SMIMEASN1";
+import { DigestAlgorithm, SignatureAlgorithm, AlgorithmIdentifier, Certificate, RSAPublicKey, SubjectAlternativeName, SubjectPublicKeyInfo, NamedCurve, ECDSASigValue, RSASSAPSSParams, Oid, RDNSequence, TBSCertificate, DigestInfo, type WebCryptoAlgorithm } from "./SMIMEASN1";
 import { BlockType, unpadPKCS, decrypt, encrypt, padFF, Uint8ArrayFromHex, Uint8ArrayToHex } from "./SMIMERSAES";
 import { appGlobal } from "../../../app";
 import { sanitize } from "../../../../../lib/util/sanitizeDatatypes";
@@ -208,9 +208,12 @@ async function verifySignature(cert: Certificate, signer: Certificate): Promise<
       console.log("subject did not match issuer");
       return false;
     }
-    let algorithm = sanitize.translate(cert.signatureAlgorithm.algorithm, SignatureAlgorithm);
     let signedCert = TBSCertificate.encode(cert.tbsCertificate);
     let publicKey = signer.tbsCertificate.publicKey;
+    if (cert.signatureAlgorithm.algorithm == "rsassaPss") {
+      return await verifyRSAPSS(publicKey, cert.signatureValue.data, cert.signatureAlgorithm.parameters, signedCert);
+    }
+    let algorithm = sanitize.translate(cert.signatureAlgorithm.algorithm, SignatureAlgorithm);
     if (publicKey.algorithmIdentifier.algorithm == "ecPublicKey") {
       return await verifyECDSA(publicKey, cert.signatureValue.data, algorithm, signedCert);
     }
@@ -260,6 +263,24 @@ export async function verifyECDSA(publicKey: SubjectPublicKeyInfo, signature: Ui
   let { r, s } = ECDSASigValue.decode(signature);
   let rs = Uint8ArrayFromHex(r.toString(16).padStart(size * 2, "0") + s.toString(16).padStart(size * 2, "0"));
   return await crypto.subtle.verify({ name: "ECDSA", hash: digestAlgorithm }, key, rs as BufferSource, content as BufferSource);
+}
+
+/** Verifies an RSASSA-PSS signature, which some CAs use instead of the older
+ * PKCS#1 v1.5 padding. WebCrypto implements PSS, so this needs no maths of
+ * our own either. RFC 4055.
+ * @param parameters the `RSASSAPSSParams` of the signature algorithm */
+export async function verifyRSAPSS(publicKey: SubjectPublicKeyInfo, signature: Uint8Array, parameters: Uint8Array, content: Uint8Array): Promise<boolean> {
+  let params = RSASSAPSSParams.decode(parameters);
+  let digestAlgorithm = sanitize.translate(params.hashAlgorithm.algorithm, DigestAlgorithm);
+  // RFC 4055 section 3.1: the mask is generated with the same hash,
+  // and 1 is the only trailer field that the RFC defines.
+  if (params.maskGenAlgorithm.algorithm != "mgf1" || params.trailerField != 1n ||
+      sanitize.translate(AlgorithmIdentifier.decode(params.maskGenAlgorithm.parameters).algorithm, DigestAlgorithm, null) != digestAlgorithm) {
+    console.log("unsupported PSS parameters");
+    return false;
+  }
+  let key = await crypto.subtle.importKey("spki", SubjectPublicKeyInfo.encode(publicKey) as BufferSource, { name: "RSA-PSS", hash: digestAlgorithm }, false, ["verify"]);
+  return await crypto.subtle.verify({ name: "RSA-PSS", saltLength: Number(params.saltLength) }, key, signature as BufferSource, content as BufferSource);
 }
 
 let promiseGetCACertificates: Record<string, Promise<Certificate[]> | undefined> = {};

--- a/app/logic/Mail/Encryption/SMIME/SMIMEPublicKey.ts
+++ b/app/logic/Mail/Encryption/SMIME/SMIMEPublicKey.ts
@@ -160,6 +160,16 @@ export class SMIMEPublicKey extends PublicKey {
     return KeyStatus.ChainIncomplete;
   }
 
+  /** A certificate can be issued for signing only, or for a TLS server.
+   * Without a certificate, nothing limits the key. */
+  usableForEncryption(): boolean {
+    if (!this.certificate) {
+      return true;
+    }
+    let cert = Certificate.decodePEM(this.certificate, { label: "CERTIFICATE" });
+    return allowsKeyUsage(cert, KeyUsageBit.KeyEncipherment) && allowsPurpose(cert, "emailProtection");
+  }
+
   /** Reads an S/MIME certificate from a file.
    * @param publicKey The certificate in PEM format
    * Factory function. */

--- a/app/logic/Mail/Encryption/SMIME/SMIMEPublicKey.ts
+++ b/app/logic/Mail/Encryption/SMIME/SMIMEPublicKey.ts
@@ -129,7 +129,9 @@ export class SMIMEPublicKey extends PublicKey {
       for (let ca of await lazyGetCACertificates(type)) {
         if (await verifySignature(cert, ca)) {
           let caTrust = type == "bundled" ? TrustLevel.ThirdParty : type == "system" ? TrustLevel.OS : TrustLevel.Personal;
-          if (trustOrder(this.trustLevel) < trustOrder(caTrust)) {
+          // Never overrule the user, who distrusted this certificate
+          if (this.trustLevel != TrustLevel.Distrusted &&
+              trustOrder(this.trustLevel) < trustOrder(caTrust)) {
             this.trustLevel = caTrust;
             this.caName = certificateCommonName(ca);
           }

--- a/app/logic/Mail/Encryption/SMIME/SMIMERSAES.ts
+++ b/app/logic/Mail/Encryption/SMIME/SMIMERSAES.ts
@@ -187,7 +187,7 @@ function UbigintToHex(data: bigint, k: number): string {
   return data.toString(16).padStart(k * 2, "0");
 }
 
-function Uint8ArrayFromHex(hex: string): Uint8Array {
+export function Uint8ArrayFromHex(hex: string): Uint8Array {
   return Uint8Array.fromHex?.(hex) ?? Uint8Array.from(hex.match(/../g), s => parseInt(s, 16));
 }
 

--- a/app/logic/Mail/Encryption/SMIME/SMIMEReadProcessor.ts
+++ b/app/logic/Mail/Encryption/SMIME/SMIMEReadProcessor.ts
@@ -180,7 +180,7 @@ export class SMIMEReadProcessor extends EMailProcessor {
     let content = OctetString.decode(contentInfo.content);
     // show the msg, even if the signature is invalid
     await this.unwrapMIME(email, content);
-    email.rememberSigner(await verifySignedData(signedData, content));
+    email.rememberSigner(await verifySignedData(signedData, content, email.sent));
   }
 
   /** Verifies a cleartext message with a detached signature
@@ -204,7 +204,7 @@ export class SMIMEReadProcessor extends EMailProcessor {
       return;
     }
     let signedData = SignedData.decodeFromBase64(signatureBase64, { berToDER: true });
-    email.rememberSigner(await verifySignedData(signedData, clearText));
+    email.rememberSigner(await verifySignedData(signedData, clearText, email.sent));
   }
 
   /** Replaces the message with the MIME entity extracted from the CMS

--- a/app/logic/Mail/Encryption/SMIME/SMIMEReadProcessor.ts
+++ b/app/logic/Mail/Encryption/SMIME/SMIMEReadProcessor.ts
@@ -111,16 +111,21 @@ export class SMIMEReadProcessor extends EMailProcessor {
             continue;
           }
           let cert = Certificate.decodePEM(privateKey.certificate, { label: "CERTIFICATE" });
-          let issuer = cert.tbsCertificate.issuer;
+          let extensionValue = cert.tbsCertificate.extensions?.find(extension => extension.extnID == "subjectKeyIdentifier")?.extnValue;
+          // The extension wraps the identifier in another OCTET STRING
+          let ourKeyIdentifier = extensionValue && OctetString.decode(extensionValue);
           for (let recipientInfo of recipientInfos) {
-            if (recipientInfo.type != "ktri" ||
-                recipientInfo.value.rid.type != "issuerAndSerialNumber") {
-              // TODO Support subjectKeyIdentifier
+            if (recipientInfo.type != "ktri") {
               continue;
             }
-            let rid = recipientInfo.value.rid.value;
-            if (rid.serialNumber != cert.tbsCertificate.serialNumber ||
-                !sameName(rid.issuer, issuer)) {
+            // Senders name our certificate either by its issuer and serial
+            // number, or by its subjectKeyIdentifier. RFC 5652 section 6.2.1
+            let rid = recipientInfo.value.rid;
+            let isForOurCertificate = rid.type == "issuerAndSerialNumber"
+              ? rid.value.serialNumber == cert.tbsCertificate.serialNumber &&
+                sameName(rid.value.issuer, cert.tbsCertificate.issuer)
+              : !!ourKeyIdentifier && !indexedDB.cmp(rid.value, ourKeyIdentifier);
+            if (!isForOurCertificate) {
               continue;
             }
             let keyEncryptionAlgorithm = recipientInfo.value.keyEncryptionAlgorithm.algorithm;

--- a/app/logic/Mail/Encryption/SMIME/SMIMEReadProcessor.ts
+++ b/app/logic/Mail/Encryption/SMIME/SMIMEReadProcessor.ts
@@ -55,7 +55,7 @@ export class SMIMEReadProcessor extends EMailProcessor {
     let { contentEncryptionAlgorithm, encryptedContent } = envelopedData.content.encryptedContentInfo;
     let cipher = contentEncryptionAlgorithm.algorithm;
     if (!sanitize.enum(cipher, ["aes128cbc", "aes192cbc", "aes256cbc", "desEDE3CBC", "rc2CBC"], null)) {
-      return;
+      throw new UserError(gt`This message is encrypted with ${algorithmName(cipher)}, which is not supported`);
     }
     let symmetricKey = await this.decryptSymmetricKey(email, envelopedData.content.recipientInfos);
     let decryptedContent: Uint8Array;
@@ -87,9 +87,9 @@ export class SMIMEReadProcessor extends EMailProcessor {
   protected async readAuthEncrypted(email: EMail, blob: Uint8Array) {
     email.system = EncryptionSystem.SMIME;
     let authEnvelopedData = AuthEnvelopedData.decode(blob, { berToDER: true }).content;
-    if (!sanitize.enum(authEnvelopedData.authEncryptedContentInfo.contentEncryptionAlgorithm.algorithm,
-        ["aes128gcm", "aes192gcm", "aes256gcm"], null)) {
-      return;
+    let cipher = authEnvelopedData.authEncryptedContentInfo.contentEncryptionAlgorithm.algorithm;
+    if (!sanitize.enum(cipher, ["aes128gcm", "aes192gcm", "aes256gcm"], null)) {
+      throw new UserError(gt`This message is encrypted with ${algorithmName(cipher)}, which is not supported`);
     }
     let symmetricKey = await this.decryptSymmetricKey(email, authEnvelopedData.recipientInfos);
     email.wasEncrypted = true;
@@ -101,31 +101,41 @@ export class SMIMEReadProcessor extends EMailProcessor {
    * @throws if the message was not encrypted to any of our keys */
   protected async decryptSymmetricKey(email: EMail, recipientInfos: any[]): Promise<Uint8Array> {
     // XXX what if you were BCC'd?
+    let unsupportedKeyTransport: string | null = null;
     for (let recipient of email.allRecipients()) {
       let identity = MailIdentity.findIdentity(new ArrayColl([recipient]), email.folder?.account)?.identity;
       if (identity) {
         for (let privateKey of identity.encryptionPrivateKeys) {
-          if (privateKey instanceof SMIMEPrivateKey) {
-            let cert = Certificate.decodePEM(privateKey.certificate, { label: "CERTIFICATE" });
-            let issuer = cert.tbsCertificate.issuer;
-            for (let recipientInfo of recipientInfos) {
-              if (recipientInfo.type != "ktri" ||
-                  recipientInfo.value.keyEncryptionAlgorithm.algorithm != "rsaEncryption" ||
-                  recipientInfo.value.rid.type != "issuerAndSerialNumber") {
-                // TODO Support subjectKeyIdentifier
-                continue;
-              }
-              let rid = recipientInfo.value.rid.value;
-              if (rid.serialNumber != cert.tbsCertificate.serialNumber ||
-                  !sameName(rid.issuer, issuer)) {
-                continue;
-              }
-              let rawKey = await privateKey.decryptKey();
-              return unpadPKCS(decrypt(recipientInfo.value.encryptedKey, rawKey), BlockType.Encrypted);
+          // A key that the user just created has no certificate yet
+          if (!(privateKey instanceof SMIMEPrivateKey) || !privateKey.certificate) {
+            continue;
+          }
+          let cert = Certificate.decodePEM(privateKey.certificate, { label: "CERTIFICATE" });
+          let issuer = cert.tbsCertificate.issuer;
+          for (let recipientInfo of recipientInfos) {
+            if (recipientInfo.type != "ktri" ||
+                recipientInfo.value.rid.type != "issuerAndSerialNumber") {
+              // TODO Support subjectKeyIdentifier
+              continue;
             }
+            let rid = recipientInfo.value.rid.value;
+            if (rid.serialNumber != cert.tbsCertificate.serialNumber ||
+                !sameName(rid.issuer, issuer)) {
+              continue;
+            }
+            let keyEncryptionAlgorithm = recipientInfo.value.keyEncryptionAlgorithm.algorithm;
+            if (keyEncryptionAlgorithm != "rsaEncryption") {
+              unsupportedKeyTransport = algorithmName(keyEncryptionAlgorithm);
+              continue;
+            }
+            let rawKey = await privateKey.decryptKey();
+            return unpadPKCS(decrypt(recipientInfo.value.encryptedKey, rawKey), BlockType.Encrypted);
           }
         }
       }
+    }
+    if (unsupportedKeyTransport) {
+      throw new UserError(gt`The key of this message is encrypted with ${unsupportedKeyTransport}, which is not supported`);
     }
     throw new UserError(gt`This message is encrypted, and the key is not available`);
   }
@@ -186,4 +196,10 @@ export class SMIMEReadProcessor extends EMailProcessor {
     await email.parseMIME(); // checks signature recursively
     await email.saveCompleteMessage();
   }
+}
+
+/** Names an algorithm for the user: our name for its OID, or the OID
+ * itself, for the algorithms that we do not know. */
+function algorithmName(algorithm: string | number[]): string {
+  return Array.isArray(algorithm) ? algorithm.join(".") : algorithm;
 }

--- a/app/logic/Mail/Encryption/SMIME/SMIMEReadProcessor.ts
+++ b/app/logic/Mail/Encryption/SMIME/SMIMEReadProcessor.ts
@@ -176,7 +176,7 @@ export class SMIMEReadProcessor extends EMailProcessor {
     let parts = parseMIMEDirectSubpartsBytes(email.mime, contentTypeHeader);
     assert(parts.length == 2, "multipart/signed must have exactly 2 subparts: cleartext and signature, but got " + parts.length);
     let [clearText, signature] = parts;
-    let signatureBase64 = new TextDecoder().decode(signature).split("\r\n\r\n")[1];
+    let signatureBase64 = new TextDecoder().decode(signature).split(/\r?\n\r?\n/)[1];
     if (!signatureBase64) {
       console.warn("signature part has no content");
       return;

--- a/app/logic/Mail/Encryption/SMIME/SMIMEReadProcessor.ts
+++ b/app/logic/Mail/Encryption/SMIME/SMIMEReadProcessor.ts
@@ -3,8 +3,9 @@ import type { EMail } from "../../EMail";
 import { MailIdentity } from "../../MailIdentity";
 import { EncryptionSystem } from "../enums";
 import { SMIMEPrivateKey } from "./SMIMEPrivateKey";
-import { ContentInfo, EnvelopedData, AuthEnvelopedData, Certificate, OctetString, SignedData } from "./SMIMEASN1";
+import { ContentInfo, EnvelopedData, AuthEnvelopedData, Certificate, OctetString, RC2CBCParameters, SignedData } from "./SMIMEASN1";
 import { decryptAuthEnveloped } from "./SMIMEDecrypt";
+import { rc2Decrypt, tripleDESDecrypt } from "./legacyCiphers";
 import { BlockType, unpadPKCS, decrypt } from "./SMIMERSAES";
 import { verifySignedData, sameName } from "./SMIMEVerify";
 import { parseMIMEDirectSubpartsBytes, parseHeaderParameters } from "../MIME";
@@ -51,16 +52,32 @@ export class SMIMEReadProcessor extends EMailProcessor {
   protected async readEncrypted(email: EMail, blob: Uint8Array) {
     email.system = EncryptionSystem.SMIME;
     let envelopedData = EnvelopedData.decode(blob, { berToDER: true });
-    if (!sanitize.enum(envelopedData.content.encryptedContentInfo.contentEncryptionAlgorithm.algorithm, ["aes128cbc", "aes192cbc", "aes256cbc"], null)) {
+    let { contentEncryptionAlgorithm, encryptedContent } = envelopedData.content.encryptedContentInfo;
+    let cipher = contentEncryptionAlgorithm.algorithm;
+    if (!sanitize.enum(cipher, ["aes128cbc", "aes192cbc", "aes256cbc", "desEDE3CBC", "rc2CBC"], null)) {
       return;
     }
-    let vector = OctetString.decode(envelopedData.content.encryptedContentInfo.contentEncryptionAlgorithm.parameters);
-    let encryptedContent = envelopedData.content.encryptedContentInfo.encryptedContent;
     let symmetricKey = await this.decryptSymmetricKey(email, envelopedData.content.recipientInfos);
-    let key = await crypto.subtle.importKey("raw", symmetricKey, "AES-CBC", false, ["decrypt"]);
-    let decryptedContent = await crypto.subtle.decrypt({ name: "AES-CBC", iv: vector }, key, encryptedContent);
+    let decryptedContent: Uint8Array;
+    if (cipher == "desEDE3CBC") {
+      // Apple Mail always encrypts with Triple DES, and Thunderbird does
+      // for recipients with a short key. WebCrypto implements neither
+      // Triple DES nor RC2, so we decrypt them ourselves.
+      decryptedContent = tripleDESDecrypt(encryptedContent, symmetricKey, OctetString.decode(contentEncryptionAlgorithm.parameters));
+    } else if (cipher == "rc2CBC") {
+      let { rc2ParameterVersion, iv } = RC2CBCParameters.decode(contentEncryptionAlgorithm.parameters);
+      // RFC 3370 section 5.2: below 256, the version is a code for the
+      // effective key length, from 256 up it is that length in bits itself.
+      let version = Number(rc2ParameterVersion);
+      let effectiveKeyBits = { 58: 128, 120: 64, 160: 40 }[version] ?? version;
+      decryptedContent = rc2Decrypt(encryptedContent, symmetricKey, iv, sanitize.integerRange(effectiveKeyBits, 8, 1024));
+    } else {
+      let vector = OctetString.decode(contentEncryptionAlgorithm.parameters);
+      let key = await crypto.subtle.importKey("raw", symmetricKey, "AES-CBC", false, ["decrypt"]);
+      decryptedContent = new Uint8Array(await crypto.subtle.decrypt({ name: "AES-CBC", iv: vector }, key, encryptedContent));
+    }
     email.wasEncrypted = true;
-    await this.unwrapMIME(email, new Uint8Array(decryptedContent));
+    await this.unwrapMIME(email, decryptedContent);
   }
 
   /** Decrypts a message that was encrypted with an authenticating cipher,

--- a/app/logic/Mail/Encryption/SMIME/SMIMEReadProcessor.ts
+++ b/app/logic/Mail/Encryption/SMIME/SMIMEReadProcessor.ts
@@ -1,5 +1,6 @@
 import { EMailProcessor, ProcessingStartOn } from "../../EMailProcessor";
 import type { EMail } from "../../EMail";
+import type { Attachment } from "../../../Abstract/Attachment";
 import { MailIdentity } from "../../MailIdentity";
 import { EncryptionSystem } from "../enums";
 import { SMIMEPrivateKey } from "./SMIMEPrivateKey";
@@ -25,7 +26,8 @@ export class SMIMEReadProcessor extends EMailProcessor {
     let contentTypeHeader = sanitize.string(postal.headers.find(header => header.key == "content-type")?.value, "");
     let contentType = parseHeaderParameters(contentTypeHeader).$main;
     if (contentType == "application/pkcs7-mime" ||
-        contentType == "application/x-pkcs7-mime") { // legacy type name, used by Outlook
+        contentType == "application/x-pkcs7-mime" || // legacy type name, used by Outlook
+        isSMIMEFile(email.attachments.first, ".p7m")) {
       // The whole message is a CMS blob. It's the only body part, but fsr
       // this is an attachment.
       let cms = email.attachments.first?.content;
@@ -167,12 +169,15 @@ export class SMIMEReadProcessor extends EMailProcessor {
   /** Verifies a cleartext message with a detached signature
    * (`multipart/signed`). */
   protected async readClearSigned(email: EMail, contentTypeHeader: string) {
-    let signatureMimeType = email.attachments.last?.mimeType.toLowerCase();
+    let signaturePart = email.attachments.last;
+    let signatureMimeType = signaturePart?.mimeType.toLowerCase();
     if (signatureMimeType != "application/pkcs7-signature" &&
-        signatureMimeType != "application/x-pkcs7-signature") { // legacy type name
+        signatureMimeType != "application/x-pkcs7-signature" && // legacy type name
+        !isSMIMEFile(signaturePart, ".p7s")) {
       return;
     }
     email.system = EncryptionSystem.SMIME;
+    signaturePart.hidden = true; // we show the signature, not the file
     let parts = parseMIMEDirectSubpartsBytes(email.mime, contentTypeHeader);
     assert(parts.length == 2, "multipart/signed must have exactly 2 subparts: cleartext and signature, but got " + parts.length);
     let [clearText, signature] = parts;
@@ -201,6 +206,15 @@ export class SMIMEReadProcessor extends EMailProcessor {
     await email.parseMIME(); // checks signature recursively
     await email.saveCompleteMessage();
   }
+}
+
+/** Whether the part is an S/MIME blob that was sent with a generic file
+ * type, and can be recognised only by its file name. Microsoft sends and
+ * accepts them like this, and gateways rewrite the type that way.
+ * MS-OXOSMIME section 2.2.1 */
+function isSMIMEFile(attachment: Attachment | undefined, extension: string): boolean {
+  return attachment?.mimeType.toLowerCase() == "application/octet-stream" &&
+    !!attachment.filename?.toLowerCase().endsWith(extension);
 }
 
 /** Names an algorithm for the user: our name for its OID, or the OID

--- a/app/logic/Mail/Encryption/SMIME/SMIMEReadProcessor.ts
+++ b/app/logic/Mail/Encryption/SMIME/SMIMEReadProcessor.ts
@@ -36,7 +36,19 @@ export class SMIMEReadProcessor extends EMailProcessor {
         return;
       }
       let blob = new Uint8Array(await cms.arrayBuffer());
-      let type = ContentInfo.decode(blob, { berToDER: true }).contentType;
+      // Some archivers keep the S/MIME headers, but store the message that
+      // they decrypted. What we have is then MIME, not an ASN.1 SEQUENCE.
+      if (blob[0] != 0x30) {
+        await this.unwrapMIME(email, blob);
+        return;
+      }
+      let type: string | number[];
+      try {
+        type = ContentInfo.decode(blob, { berToDER: true }).contentType;
+      } catch (ex) {
+        console.error(ex);
+        throw new UserError(gt`This message is not a valid S/MIME message`);
+      }
       if (type == "signedData") {
         await this.readOpaqueSigned(email, blob);
       } else if (type == "envelopedData") {

--- a/app/logic/Mail/Encryption/SMIME/SMIMEReadProcessor.ts
+++ b/app/logic/Mail/Encryption/SMIME/SMIMEReadProcessor.ts
@@ -4,7 +4,7 @@ import type { Attachment } from "../../../Abstract/Attachment";
 import { MailIdentity } from "../../MailIdentity";
 import { EncryptionSystem } from "../enums";
 import { SMIMEPrivateKey } from "./SMIMEPrivateKey";
-import { ContentInfo, EnvelopedData, AuthEnvelopedData, Certificate, OctetString, RC2CBCParameters, SignedData } from "./SMIMEASN1";
+import { AlgorithmIdentifier, ContentInfo, DigestAlgorithm, EnvelopedData, AuthEnvelopedData, Certificate, OctetString, RC2CBCParameters, RSAESOAEPParams, SignedData } from "./SMIMEASN1";
 import { decryptAuthEnveloped } from "./SMIMEDecrypt";
 import { rc2Decrypt, tripleDESDecrypt } from "./legacyCiphers";
 import { BlockType, unpadPKCS, decrypt } from "./SMIMERSAES";
@@ -142,13 +142,18 @@ export class SMIMEReadProcessor extends EMailProcessor {
             if (!isForOurCertificate) {
               continue;
             }
-            let keyEncryptionAlgorithm = recipientInfo.value.keyEncryptionAlgorithm.algorithm;
-            if (keyEncryptionAlgorithm != "rsaEncryption") {
-              unsupportedKeyTransport = algorithmName(keyEncryptionAlgorithm);
-              continue;
+            let keyEncryptionAlgorithm = recipientInfo.value.keyEncryptionAlgorithm;
+            if (keyEncryptionAlgorithm.algorithm == "rsaEncryption") {
+              let rawKey = await privateKey.decryptKey();
+              return unpadPKCS(decrypt(recipientInfo.value.encryptedKey, rawKey), BlockType.Encrypted);
             }
-            let rawKey = await privateKey.decryptKey();
-            return unpadPKCS(decrypt(recipientInfo.value.encryptedKey, rawKey), BlockType.Encrypted);
+            if (keyEncryptionAlgorithm.algorithm == "rsaESOAEP") {
+              let contentKey = await decryptOAEP(recipientInfo.value.encryptedKey, privateKey, keyEncryptionAlgorithm);
+              if (contentKey) {
+                return contentKey;
+              }
+            }
+            unsupportedKeyTransport = algorithmName(keyEncryptionAlgorithm.algorithm);
           }
         }
       }
@@ -218,6 +223,33 @@ export class SMIMEReadProcessor extends EMailProcessor {
     await email.parseMIME(); // checks signature recursively
     await email.saveCompleteMessage();
   }
+}
+
+/**
+ * Decrypts the content key that was encrypted with RSA-OAEP, RFC 8551
+ * section 2.4.3. WebCrypto implements it, unlike the PKCS#1 v1.5 padding
+ * that we do ourselves.
+ * @param algorithm the `keyEncryptionAlgorithm` of the recipient
+ * @returns null, if the message uses OAEP in a way that WebCrypto cannot
+ */
+async function decryptOAEP(encryptedKey: Uint8Array, privateKey: SMIMEPrivateKey, algorithm: AlgorithmIdentifier): Promise<Uint8Array | null> {
+  let { hashFunc, maskGenFunc, pSourceFunc } = RSAESOAEPParams.decode(algorithm.parameters);
+  // RFC 3560 section 3: in CMS, the label is always empty
+  if (maskGenFunc.algorithm != "mgf1" || pSourceFunc.algorithm != "pSpecified" ||
+      pSourceFunc.parameters && OctetString.decode(pSourceFunc.parameters).length) {
+    return null;
+  }
+  let hash = sanitize.translate(hashFunc.algorithm, DigestAlgorithm, null);
+  // Without parameters, the mask generation uses SHA-1
+  let maskHash = maskGenFunc.parameters
+    ? sanitize.translate(AlgorithmIdentifier.decode(maskGenFunc.parameters).algorithm, DigestAlgorithm, null)
+    : "SHA-1";
+  if (!hash || hash != maskHash) { // WebCrypto uses the same hash for both
+    return null;
+  }
+  let pkcs8 = await privateKey.decryptKeyPKCS8();
+  let key = await crypto.subtle.importKey("pkcs8", pkcs8 as BufferSource, { name: "RSA-OAEP", hash }, false, ["decrypt"]);
+  return new Uint8Array(await crypto.subtle.decrypt({ name: "RSA-OAEP" }, key, encryptedKey as BufferSource));
 }
 
 /** Whether the part is an S/MIME blob that was sent with a generic file

--- a/app/logic/Mail/Encryption/SMIME/SMIMESend.ts
+++ b/app/logic/Mail/Encryption/SMIME/SMIMESend.ts
@@ -142,8 +142,9 @@ export class SMIMESend {
       }
       mimeAsText = contentHeaders.join("\r\n") + mimeAsText.slice(pos);
       mime = new TextEncoder().encode(mimeAsText);
-      let recipientKeys = mail.allRecipients().contents.flatMap(puid =>
+      let recipientKeys = mail.allRecipients().contents.map(puid =>
         getPublicKeyForPersonUID(puid, SMIMEPublicKey));
+      assert(recipientKeys.every(key => key), gt`Cannot encrypt to all recipients using S/MIME`);
       if (!(await Promise.all(recipientKeys.map(key => key.matches(rawKey)))).some(Boolean)) {
         recipientKeys.push(privateKey);
       }

--- a/app/logic/Mail/Encryption/SMIME/SMIMESend.ts
+++ b/app/logic/Mail/Encryption/SMIME/SMIMESend.ts
@@ -145,7 +145,8 @@ export class SMIMESend {
       let recipientKeys = mail.allRecipients().contents.map(puid =>
         getPublicKeyForPersonUID(puid, SMIMEPublicKey));
       assert(recipientKeys.every(key => key), gt`Cannot encrypt to all recipients using S/MIME`);
-      if (!(await Promise.all(recipientKeys.map(key => key.matches(rawKey)))).some(Boolean)) {
+      let myCertificate = Certificate.decodePEM(privateKey.certificate, { label: "CERTIFICATE" });
+      if (!(await Promise.all(recipientKeys.map(key => key.matches(myCertificate.tbsCertificate.publicKey)))).some(Boolean)) {
         recipientKeys.push(privateKey);
       }
       let symmetricKey = new Uint8Array(32);

--- a/app/logic/Mail/Encryption/SMIME/SMIMESend.ts
+++ b/app/logic/Mail/Encryption/SMIME/SMIMESend.ts
@@ -29,14 +29,19 @@ export class SMIMESend {
     let mime = await CreateMIME.getMIME(mail);
     let mimeAsText = new TextDecoder().decode(mime);
     if (mail.signedByKeyID) {
-      // Only the body and content type are signed, not the headers.
+      // Only the body and its own Content-* headers are signed, not the
+      // message headers. Without the transfer encoding, every reader shows
+      // the raw quoted-printable text.
       let pos = mimeAsText.indexOf("\r\n\r\n");
       // Split on CRLF, but keep folded continuation lines (those starting with
       // whitespace) attached to their header.
       let headers = mimeAsText.slice(0, pos).split(/\r\n(?![ \t])/);
-      let contentTypeHeader = headers.find(header => /^Content-Type: /i.test(header)) ?? "Content-Type: text/plain";
+      let contentHeaders = headers.filter(header => /^Content-/i.test(header));
       let otherHeaders = headers.filter(header => !/^Content-/i.test(header));
-      mimeAsText = contentTypeHeader + mimeAsText.slice(pos);
+      if (!contentHeaders.some(header => /^Content-Type: /i.test(header))) {
+        contentHeaders.push("Content-Type: text/plain");
+      }
+      mimeAsText = contentHeaders.join("\r\n") + mimeAsText.slice(pos);
       let messageDigest = new Uint8Array(await crypto.subtle.digest("SHA-256", new TextEncoder().encode(mimeAsText)));
       // DER SET OF requires the elements sorted by their encoding (X.690
       // section 11.6). With these fixed value sizes, that is the order below:
@@ -124,14 +129,18 @@ export class SMIMESend {
       pos = mimeAsText.indexOf("\r\n\r\n");
     }
     if (mail.shouldEncrypt) {
-      // Only the body and content type are encrypted, not the headers.
+      // Only the body and its own Content-* headers are encrypted, not the
+      // message headers.
       let pos = mimeAsText.indexOf("\r\n\r\n");
       // Split on CRLF, but keep folded continuation lines (those starting with
       // whitespace) attached to their header.
       let headers = mimeAsText.slice(0, pos).split(/\r\n(?![ \t])/);
-      let contentTypeHeader = headers.find(header => /^Content-Type: /i.test(header)) ?? "Content-Type: text/plain";
+      let contentHeaders = headers.filter(header => /^Content-/i.test(header));
       let otherHeaders = headers.filter(header => !/^Content-/i.test(header));
-      mimeAsText = contentTypeHeader + mimeAsText.slice(pos);
+      if (!contentHeaders.some(header => /^Content-Type: /i.test(header))) {
+        contentHeaders.push("Content-Type: text/plain");
+      }
+      mimeAsText = contentHeaders.join("\r\n") + mimeAsText.slice(pos);
       mime = new TextEncoder().encode(mimeAsText);
       let recipientKeys = mail.allRecipients().contents.flatMap(puid =>
         getPublicKeyForPersonUID(puid, SMIMEPublicKey));

--- a/app/logic/Mail/Encryption/SMIME/SMIMESend.ts
+++ b/app/logic/Mail/Encryption/SMIME/SMIMESend.ts
@@ -6,7 +6,7 @@ import { SMIMEPublicKey } from "./SMIMEPublicKey";
 import { SMIMEPrivateKey } from "./SMIMEPrivateKey";
 import { Oid, UTCTime, Attributes, DigestInfo, SignedData, Certificate, RSAPublicKey, Null, OctetString, EnvelopedData, SMIMECapabilities } from "./SMIMEASN1";
 import { decrypt, padFF, padRandom, encrypt } from "./SMIMERSAES";
-import { assert } from "../../../util/util";
+import { UserError, assert } from "../../../util/util";
 import { gt } from "../../../../l10n/l10n";
 
 export class SMIMESend {
@@ -171,7 +171,11 @@ export class SMIMESend {
       };
       for (let recipientKey of recipientKeys) {
         let cert = Certificate.decodePEM(recipientKey.certificate, { label: "CERTIFICATE" });
-        let rsa = RSAPublicKey.decode(cert.tbsCertificate.publicKey.subjectPublicKey.data);
+        let publicKey = cert.tbsCertificate.publicKey;
+        if (publicKey.algorithmIdentifier.algorithm != "rsaEncryption") {
+          throw new UserError(gt`Cannot encrypt to ${recipientKey.userIDs.first}, because we can encrypt only to RSA certificates`);
+        }
+        let rsa = RSAPublicKey.decode(publicKey.subjectPublicKey.data);
         pkcs7.content.recipientInfos.push({
           type: "ktri",
           value: {

--- a/app/logic/Mail/Encryption/SMIME/SMIMEVerify.ts
+++ b/app/logic/Mail/Encryption/SMIME/SMIMEVerify.ts
@@ -1,4 +1,4 @@
-import { DigestAlgorithm, SignatureAlgorithm, Attributes, SubjectPublicKeyInfo, RSAPublicKey, DigestInfo, OctetString, Oid, Time, type TBSCertificate } from "./SMIMEASN1";
+import { DigestAlgorithm, SignatureAlgorithm, Attributes, SubjectPublicKeyInfo, RSAPublicKey, DigestInfo, OctetString, Oid, Time, Certificate, SigningCertificate, SigningCertificateV2, type TBSCertificate } from "./SMIMEASN1";
 import { BlockType, unpadPKCS, encrypt } from "./SMIMERSAES";
 import { SMIMEPublicKey, verifyECDSA } from "./SMIMEPublicKey";
 import { sanitize } from "../../../../../lib/util/sanitizeDatatypes";
@@ -81,6 +81,22 @@ export async function verifySignedData(signedData: any, content: Uint8Array, sen
       signedAt = Time.decode(signingTimeAttribute.attrValue[0]).value;
       if (sent && Math.abs(signedAt - sent.getTime()) > k1HourMS) {
         console.log("message was signed at a different time than it was sent");
+        return null;
+      }
+    }
+    let essAttribute = signerInfo.signedAttrs.find(attr =>
+      attr.attrType == "signingCertificate" || attr.attrType == "signingCertificateV2");
+    if (essAttribute) {
+      // RFC 5035: the signer named the certificate that he used, by its hash,
+      // so that nobody can swap it for another certificate of the same owner
+      let certIDs = essAttribute.attrType == "signingCertificateV2"
+        ? SigningCertificateV2.decode(essAttribute.attrValue[0]).certs
+        : SigningCertificate.decode(essAttribute.attrValue[0]).certs;
+      let certDER = Certificate.encode(cert);
+      let hashes = await Promise.all(certIDs.map(certID =>
+        crypto.subtle.digest(sanitize.translate(certID.hashAlgorithm?.algorithm, DigestAlgorithm, "SHA-1"), certDER as BufferSource)));
+      if (!certIDs.some((certID, i) => !indexedDB.cmp(new Uint8Array(hashes[i]), certID.certHash))) {
+        console.log("the signature names another certificate than the one that it came with");
         return null;
       }
     }

--- a/app/logic/Mail/Encryption/SMIME/SMIMEVerify.ts
+++ b/app/logic/Mail/Encryption/SMIME/SMIMEVerify.ts
@@ -1,4 +1,4 @@
-import { DigestAlgorithm, SignatureAlgorithm, Attributes, SubjectPublicKeyInfo, RSAPublicKey, DigestInfo, OctetString, type TBSCertificate } from "./SMIMEASN1";
+import { DigestAlgorithm, SignatureAlgorithm, Attributes, SubjectPublicKeyInfo, RSAPublicKey, DigestInfo, OctetString, Oid, type TBSCertificate } from "./SMIMEASN1";
 import { BlockType, unpadPKCS, encrypt } from "./SMIMERSAES";
 import { SMIMEPublicKey, verifyECDSA } from "./SMIMEPublicKey";
 import { sanitize } from "../../../../../lib/util/sanitizeDatatypes";
@@ -54,6 +54,14 @@ export async function verifySignedData(signedData: any, content: Uint8Array): Pr
   // Without signed attributes, the signature covers the content directly.
   let signedContent = content;
   if (signerInfo.signedAttrs) {
+    // RFC 5652 section 5.3: the attributes must say which content they cover,
+    // so that a signature cannot be moved to another kind of content
+    let contentTypeAttribute = signerInfo.signedAttrs.find(attr => attr.attrType == "contentType");
+    if (!contentTypeAttribute ||
+        String(Oid.decode(contentTypeAttribute.attrValue[0])) != String(signedData.content.contentInfo.contentType)) {
+      console.log("signature was made for another content type");
+      return null;
+    }
     let digestAttribute = signerInfo.signedAttrs.find(attr => attr.attrType == "messageDigest");
     if (!digestAttribute) {
       console.log("signature did not contain a message digest");

--- a/app/logic/Mail/Encryption/SMIME/SMIMEVerify.ts
+++ b/app/logic/Mail/Encryption/SMIME/SMIMEVerify.ts
@@ -1,6 +1,6 @@
 import { DigestAlgorithm, SignatureAlgorithm, Attributes, SubjectPublicKeyInfo, RSAPublicKey, DigestInfo, OctetString, Oid, Time, Certificate, SigningCertificate, SigningCertificateV2, type TBSCertificate } from "./SMIMEASN1";
 import { BlockType, unpadPKCS, encrypt } from "./SMIMERSAES";
-import { SMIMEPublicKey, verifyECDSA } from "./SMIMEPublicKey";
+import { SMIMEPublicKey, verifyECDSA, allowsKeyUsage, allowsPurpose, KeyUsageBit } from "./SMIMEPublicKey";
 import { sanitize } from "../../../../../lib/util/sanitizeDatatypes";
 
 /**
@@ -30,6 +30,17 @@ export async function verifySignedData(signedData: any, content: Uint8Array, sen
     sameName(sid.issuer, cert.tbsCertificate.issuer));
   if (!cert) {
     console.log("the certificate that signed the message was not sent with it");
+    return null;
+  }
+  // RFC 5280 sections 4.2.1.3 and 4.2.1.12: the certificate must be meant for
+  // signing, and for email
+  if (!allowsKeyUsage(cert, KeyUsageBit.DigitalSignature) &&
+      !allowsKeyUsage(cert, KeyUsageBit.NonRepudiation)) {
+    console.log("the certificate is not for signing");
+    return null;
+  }
+  if (!allowsPurpose(cert, "emailProtection")) {
+    console.log("the certificate is not for email");
     return null;
   }
   let publicKey = cert.tbsCertificate.publicKey;

--- a/app/logic/Mail/Encryption/SMIME/SMIMEVerify.ts
+++ b/app/logic/Mail/Encryption/SMIME/SMIMEVerify.ts
@@ -107,5 +107,7 @@ export async function verifySignedData(signedData: any, content: Uint8Array): Pr
 /** Compares two X.501 names, e.g. certificate issuer and subject */
 export function sameName(a: TBSCertificate["issuer"], b: TBSCertificate["issuer"]): boolean {
   return a.length == b.length &&
-    a.every((attr, i) => attr.type == b[i].type && attr.value.value == b[i].value.value);
+    // Attribute types that our OID map does not know, e.g. the eIDAS
+    // organizationIdentifier, decode to arrays, which `==` compares by identity
+    a.every((attr, i) => String(attr.type) == String(b[i].type) && attr.value.value == b[i].value.value);
 }

--- a/app/logic/Mail/Encryption/SMIME/SMIMEVerify.ts
+++ b/app/logic/Mail/Encryption/SMIME/SMIMEVerify.ts
@@ -1,4 +1,4 @@
-import { DigestAlgorithm, SignatureAlgorithm, Attributes, SubjectPublicKeyInfo, RSAPublicKey, DigestInfo, OctetString, Oid, type TBSCertificate } from "./SMIMEASN1";
+import { DigestAlgorithm, SignatureAlgorithm, Attributes, SubjectPublicKeyInfo, RSAPublicKey, DigestInfo, OctetString, Oid, Time, type TBSCertificate } from "./SMIMEASN1";
 import { BlockType, unpadPKCS, encrypt } from "./SMIMERSAES";
 import { SMIMEPublicKey, verifyECDSA } from "./SMIMEPublicKey";
 import { sanitize } from "../../../../../lib/util/sanitizeDatatypes";
@@ -9,10 +9,13 @@ import { sanitize } from "../../../../../lib/util/sanitizeDatatypes";
  * @param signedData decoded `SignedData`
  * @param content the signed bytes: the cleartext MIME part for
  *   `multipart/signed`, or the unwrapped eContent for opaque-signed messages
+ * @param sent when the message says that it was sent, i.e. the `Date:`
+ *   header. Compared with the signing time, and used in its stead, if the
+ *   signature does not give one.
  * @returns the signer's public key,
  *   or null, if the signature does not verify
  */
-export async function verifySignedData(signedData: any, content: Uint8Array): Promise<SMIMEPublicKey | null> {
+export async function verifySignedData(signedData: any, content: Uint8Array, sent?: Date): Promise<SMIMEPublicKey | null> {
   let certificates = sanitize.array(signedData.content.certificates, []);
   let signerInfos = sanitize.array(signedData.content.signerInfos, []);
   if (!certificates.length || !signerInfos.length) {
@@ -53,6 +56,7 @@ export async function verifySignedData(signedData: any, content: Uint8Array): Pr
   let messageDigest = new Uint8Array(await crypto.subtle.digest(digestAlgorithm, content as BufferSource));
   // Without signed attributes, the signature covers the content directly.
   let signedContent = content;
+  let signedAt = sent?.getTime();
   if (signerInfo.signedAttrs) {
     // RFC 5652 section 5.3: the attributes must say which content they cover,
     // so that a signature cannot be moved to another kind of content
@@ -71,7 +75,23 @@ export async function verifySignedData(signedData: any, content: Uint8Array): Pr
       console.log("signed digest did not match message");
       return null;
     }
+    let signingTimeAttribute = signerInfo.signedAttrs.find(attr => attr.attrType == "signingTime");
+    if (signingTimeAttribute) {
+      const k1HourMS = 60 * 60 * 1000;
+      signedAt = Time.decode(signingTimeAttribute.attrValue[0]).value;
+      if (sent && Math.abs(signedAt - sent.getTime()) > k1HourMS) {
+        console.log("message was signed at a different time than it was sent");
+        return null;
+      }
+    }
     signedContent = Attributes.encode(signerInfo.signedAttrs);
+  }
+  // The certificate must have been valid when the message was signed. Mail
+  // that was signed before the certificate expired stays signed afterwards.
+  let { notBefore, notAfter } = cert.tbsCertificate.validity;
+  if (signedAt && (signedAt < notBefore.value || signedAt > notAfter.value)) {
+    console.log("the certificate was not valid when the message was signed");
+    return null;
   }
   /* `await crypto.subtle.verify()` returns `false` on
    * correctly signed messages...

--- a/app/logic/Mail/Encryption/SMIME/SMIMEVerify.ts
+++ b/app/logic/Mail/Encryption/SMIME/SMIMEVerify.ts
@@ -1,6 +1,6 @@
 import { DigestAlgorithm, SignatureAlgorithm, Attributes, SubjectPublicKeyInfo, RSAPublicKey, DigestInfo, OctetString, type TBSCertificate } from "./SMIMEASN1";
 import { BlockType, unpadPKCS, encrypt } from "./SMIMERSAES";
-import { SMIMEPublicKey } from "./SMIMEPublicKey";
+import { SMIMEPublicKey, verifyECDSA } from "./SMIMEPublicKey";
 import { sanitize } from "../../../../../lib/util/sanitizeDatatypes";
 
 /**
@@ -9,7 +9,7 @@ import { sanitize } from "../../../../../lib/util/sanitizeDatatypes";
  * @param signedData decoded `SignedData`
  * @param content the signed bytes: the cleartext MIME part for
  *   `multipart/signed`, or the unwrapped eContent for opaque-signed messages
- * @returns the last hex digits of the signer's RSA modulus,
+ * @returns the signer's public key,
  *   or null, if the signature does not verify
  */
 export async function verifySignedData(signedData: any, content: Uint8Array): Promise<SMIMEPublicKey | null> {
@@ -30,22 +30,25 @@ export async function verifySignedData(signedData: any, content: Uint8Array): Pr
       sameName(sid.issuer, cert.tbsCertificate.issuer)) ?? cert;
   }
   let publicKey = cert.tbsCertificate.publicKey;
-  if (publicKey.algorithmIdentifier.algorithm != "rsaEncryption") {
-    console.log("certificate does not contain an RSA public key");
+  let isECDSA = publicKey.algorithmIdentifier.algorithm == "ecPublicKey";
+  if (!isECDSA && publicKey.algorithmIdentifier.algorithm != "rsaEncryption") {
+    console.log("certificate does not contain an RSA or ECDSA public key");
     return null;
   }
   let digestAlgorithm = sanitize.translate(signerInfo.digestAlgorithm.algorithm, DigestAlgorithm);
   // RFC 5652 section 10.1.2: signers write rsaEncryption, but verifiers
   // should also accept e.g. sha256WithRSAEncryption, which some clients
-  // write instead. Its hash must match the digest algorithm.
-  if (signerInfo.signatureAlgorithm.algorithm != "rsaEncryption" &&
+  // write instead. Its hash must match the digest algorithm. RFC 5753
+  // section 2 says the same for ECDSA, where Thunderbird and Apple Mail
+  // write ecdsaWithSHA256 rather than the bare ecPublicKey.
+  if (signerInfo.signatureAlgorithm.algorithm != (isECDSA ? "ecPublicKey" : "rsaEncryption") &&
       sanitize.translate(signerInfo.signatureAlgorithm.algorithm, SignatureAlgorithm, null) != digestAlgorithm) {
-    console.log("signature was not signed with RSA");
+    console.log("signature algorithm does not match the certificate");
     return null;
   }
   let messageDigest = new Uint8Array(await crypto.subtle.digest(digestAlgorithm, content as BufferSource));
-  // Without signed attributes, the signature covers the content digest directly.
-  let signedDigest = messageDigest;
+  // Without signed attributes, the signature covers the content directly.
+  let signedContent = content;
   if (signerInfo.signedAttrs) {
     let digestAttribute = signerInfo.signedAttrs.find(attr => attr.attrType == "messageDigest");
     if (!digestAttribute) {
@@ -56,8 +59,7 @@ export async function verifySignedData(signedData: any, content: Uint8Array): Pr
       console.log("signed digest did not match message");
       return null;
     }
-    let signedAttrs = Attributes.encode(signerInfo.signedAttrs);
-    signedDigest = new Uint8Array(await crypto.subtle.digest(digestAlgorithm, signedAttrs));
+    signedContent = Attributes.encode(signerInfo.signedAttrs);
   }
   /* `await crypto.subtle.verify()` returns `false` on
    * correctly signed messages...
@@ -67,15 +69,23 @@ export async function verifySignedData(signedData: any, content: Uint8Array): Pr
     return rsa.n.toString(16);
   }
   */
-  let rsa = RSAPublicKey.decode(publicKey.subjectPublicKey.data);
-  let digestInfo = DigestInfo.decode(unpadPKCS(encrypt(signerInfo.signature, rsa), BlockType.Signed));
-  if (digestInfo.digestAlgorithm.algorithm != signerInfo.digestAlgorithm.algorithm) {
-    console.log("signature algorithm mismatch");
-    return null;
-  }
-  if (indexedDB.cmp(digestInfo.digest, signedDigest)) {
-    console.log("signature did not match the signed digest");
-    return null;
+  if (isECDSA) {
+    if (!await verifyECDSA(publicKey, signerInfo.signature, digestAlgorithm, signedContent)) {
+      console.log("signature did not match the signed content");
+      return null;
+    }
+  } else {
+    let signedDigest = new Uint8Array(await crypto.subtle.digest(digestAlgorithm, signedContent));
+    let rsa = RSAPublicKey.decode(publicKey.subjectPublicKey.data);
+    let digestInfo = DigestInfo.decode(unpadPKCS(encrypt(signerInfo.signature, rsa), BlockType.Signed));
+    if (digestInfo.digestAlgorithm.algorithm != signerInfo.digestAlgorithm.algorithm) {
+      console.log("signature algorithm mismatch");
+      return null;
+    }
+    if (indexedDB.cmp(digestInfo.digest, signedDigest)) {
+      console.log("signature did not match the signed digest");
+      return null;
+    }
   }
   let signer = new SMIMEPublicKey();
   while (cert && await signer.addCertificate(cert)) {

--- a/app/logic/Mail/Encryption/SMIME/SMIMEVerify.ts
+++ b/app/logic/Mail/Encryption/SMIME/SMIMEVerify.ts
@@ -20,14 +20,14 @@ export async function verifySignedData(signedData: any, content: Uint8Array): Pr
     return null;
   }
   let signerInfo = signerInfos[0];
-  let cert = certificates[0];
-  if (signerInfo.sid?.type == "issuerAndSerialNumber") {
-    let sid = signerInfo.sid.value;
-    // Fall back to the first certificate, for messages that we signed
-    // before, when the sid held the subject instead of the issuer.
-    cert = certificates.find(cert =>
-      cert.tbsCertificate.serialNumber == sid.serialNumber &&
-      sameName(sid.issuer, cert.tbsCertificate.issuer)) ?? cert;
+  let sid = signerInfo.sid?.value;
+  // TODO Support `subjectKeyIdentifier`
+  let cert = signerInfo.sid?.type == "issuerAndSerialNumber" && certificates.find(cert =>
+    cert.tbsCertificate.serialNumber == sid.serialNumber &&
+    sameName(sid.issuer, cert.tbsCertificate.issuer));
+  if (!cert) {
+    console.log("the certificate that signed the message was not sent with it");
+    return null;
   }
   let publicKey = cert.tbsCertificate.publicKey;
   let isECDSA = publicKey.algorithmIdentifier.algorithm == "ecPublicKey";
@@ -35,7 +35,11 @@ export async function verifySignedData(signedData: any, content: Uint8Array): Pr
     console.log("certificate does not contain an RSA or ECDSA public key");
     return null;
   }
-  let digestAlgorithm = sanitize.translate(signerInfo.digestAlgorithm.algorithm, DigestAlgorithm);
+  let digestAlgorithm = sanitize.translate(signerInfo.digestAlgorithm.algorithm, DigestAlgorithm, null);
+  if (!digestAlgorithm) {
+    console.log("message was digested with an algorithm that we do not know");
+    return null;
+  }
   // RFC 5652 section 10.1.2: signers write rsaEncryption, but verifiers
   // should also accept e.g. sha256WithRSAEncryption, which some clients
   // write instead. Its hash must match the digest algorithm. RFC 5753

--- a/app/test/logic/Contacts/EWS/galSearch.test.ts
+++ b/app/test/logic/Contacts/EWS/galSearch.test.ts
@@ -7,6 +7,19 @@ import { kCertificate, kCertificateEmailAddress, kSMIMECertificate, kSMIMECertif
 import { ArrayColl } from "svelte-collections";
 import { expect, test } from "vitest";
 
+// The browser has this, but Node does not.
+globalThis.indexedDB ??= {
+  cmp(a: Uint8Array, b: Uint8Array): number {
+    let length = Math.min(a.length, b.length);
+    for (let i = 0; i < length; i++) {
+      if (a[i] != b[i]) {
+        return a[i] < b[i] ? -1 : 1;
+      }
+    }
+    return Math.sign(a.length - b.length);
+  },
+} as any;
+
 const kPersons = [{
   name: "Ben Bucksch",
   firstName: "Ben",

--- a/app/test/logic/Contacts/OWA/galSearch.test.ts
+++ b/app/test/logic/Contacts/OWA/galSearch.test.ts
@@ -7,6 +7,19 @@ import { kCertificate, kCertificateEmailAddress, kSMIMECertificate, kSMIMECertif
 import { ArrayColl } from "svelte-collections";
 import { expect, test } from "vitest";
 
+// The browser has this, but Node does not.
+globalThis.indexedDB ??= {
+  cmp(a: Uint8Array, b: Uint8Array): number {
+    let length = Math.min(a.length, b.length);
+    for (let i = 0; i < length; i++) {
+      if (a[i] != b[i]) {
+        return a[i] < b[i] ? -1 : 1;
+      }
+    }
+    return Math.sign(a.length - b.length);
+  },
+} as any;
+
 const kPersons = [{
   DisplayName: "Ben Bucksch",
   GivenName: "Ben",

--- a/app/test/logic/Mail/Encryption/SMIME/certificateChain.test.ts
+++ b/app/test/logic/Mail/Encryption/SMIME/certificateChain.test.ts
@@ -1,0 +1,80 @@
+// The key classes use the app singleton. Importing it first breaks the
+// import cycle, which would otherwise leave the base classes undefined.
+import "../../../../../logic/app";
+import { appGlobal } from "../../../../../logic/app";
+import { SMIMEPublicKey, KeyStatus } from "../../../../../logic/Mail/Encryption/SMIME/SMIMEPublicKey";
+import { TrustLevel } from "../../../../../logic/Mail/Encryption/enums";
+import { expect, test, describe } from "vitest";
+
+// The browser has this, but Node does not.
+globalThis.indexedDB ??= {
+  cmp(a: Uint8Array, b: Uint8Array): number {
+    let length = Math.min(a.length, b.length);
+    for (let i = 0; i < length; i++) {
+      if (a[i] != b[i]) {
+        return a[i] < b[i] ? -1 : 1;
+      }
+    }
+    return Math.sign(a.length - b.length);
+  },
+} as any;
+
+/* A root CA with an EC key, as European CAs increasingly have,
+ * and an RSA certificate that it issued:
+ * openssl ecparam -name secp384r1 -genkey -noout -out ecca.key
+ * openssl req -x509 -key ecca.key -sha384 -days 3650 -out ecca.crt \
+ *   -subj "/O=Parula Test/CN=EC Test Root CA" \
+ *   -addext "basicConstraints=critical,CA:TRUE" \
+ *   -addext "keyUsage=critical,keyCertSign,cRLSign"
+ * openssl genpkey -algorithm RSA -pkeyopt rsa_keygen_bits:2048 -out rsaleaf.key
+ * openssl req -new -key rsaleaf.key -out rsaleaf.csr \
+ *   -subj "/CN=RSA Bob/emailAddress=bob@example.com"
+ * openssl x509 -req -in rsaleaf.csr -out rsaleaf.crt -set_serial 0x2a \
+ *   -CA ecca.crt -CAkey ecca.key -days 3650 -sha384 -extfile <(printf \
+ *   "basicConstraints=CA:FALSE\nextendedKeyUsage=emailProtection\n") */
+const kECRootCA = `-----BEGIN CERTIFICATE-----
+MIICAjCCAYigAwIBAgIUUMPZMm11112UBnQLvwtuV4g1yQ4wCgYIKoZIzj0EAwMw
+MDEUMBIGA1UECgwLUGFydWxhIFRlc3QxGDAWBgNVBAMMD0VDIFRlc3QgUm9vdCBD
+QTAeFw0yNjA5MDMwNjI3MDZaFw0zNjA4MzEwNjI3MDZaMDAxFDASBgNVBAoMC1Bh
+cnVsYSBUZXN0MRgwFgYDVQQDDA9FQyBUZXN0IFJvb3QgQ0EwdjAQBgcqhkjOPQIB
+BgUrgQQAIgNiAAS5MDOaudETdeCRdblOuRx2eGZ8Pxi0TllbrHAMXMonSh6uWh3H
+FAizCTAbUr3aOdkdtkYVWesIji6Ax2LDYP64XTDR7TT6m8xIxDmtd8KkJb3OS0j3
+igdo06WFVyceeFOjYzBhMB0GA1UdDgQWBBSm76u6qSaWEIpXiGfJGsMD3DxttDAf
+BgNVHSMEGDAWgBSm76u6qSaWEIpXiGfJGsMD3DxttDAPBgNVHRMBAf8EBTADAQH/
+MA4GA1UdDwEB/wQEAwIBBjAKBggqhkjOPQQDAwNoADBlAjEAh3fSimEO05YZlgro
+TRVq1/LgOLT6iVWdka2Pjm5Bn76k4fVdYMu1kxkcq2gEAeHwAjAMtGJ8d7G7YG+n
+a0VhAVu6hC9g0azgLvxoKwZNGnNq09dtHpJuYDyJKcBB3eCDAnw=
+-----END CERTIFICATE-----`;
+
+const kRSALeaf = `-----BEGIN CERTIFICATE-----
+MIICyzCCAlKgAwIBAgIBKjAKBggqhkjOPQQDAzAwMRQwEgYDVQQKDAtQYXJ1bGEg
+VGVzdDEYMBYGA1UEAwwPRUMgVGVzdCBSb290IENBMB4XDTI2MDkwMzA2MjcwNloX
+DTM2MDgzMTA2MjcwNlowMjEQMA4GA1UEAwwHUlNBIEJvYjEeMBwGCSqGSIb3DQEJ
+ARYPYm9iQGV4YW1wbGUuY29tMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKC
+AQEApNf9JaDKNTGvSoPXCM37LxuUe01ElJAI9uUdKKly9crDruXvDgOc5ag/WvFR
+FLniv29BLoj6YhavzQVU/LroFrUzh0Hs8L+W7b78qyM1lwyJFcuvzr/xXEfGzs5D
+Fye/BcjNFfX616g4HcszXW3Fknso6X5Z0oP+p/cBgCn1BSnrCGmAtWlRj8EPEivU
+3muGNUGGCs5yCSeC7P4Ub38qKiPWjesHZjYaAfEoTmcMZoY55l9+9BM+StdHnqVa
+ZLBRqv29sz4dsmP0/4uDVvFH8GoQUadbTveGUcrBxENVgqViB1dPRzWdGS98T7U2
+ROhLpv4rqwKPtm8QFIureHWB9QIDAQABo4GPMIGMMAkGA1UdEwQCMAAwDgYDVR0P
+AQH/BAQDAgWgMBMGA1UdJQQMMAoGCCsGAQUFBwMEMBoGA1UdEQQTMBGBD2JvYkBl
+eGFtcGxlLmNvbTAdBgNVHQ4EFgQUcUlujAGT9BsTQvCvOrbwz4etOVEwHwYDVR0j
+BBgwFoAUpu+ruqkmlhCKV4hnyRrDA9w8bbQwCgYIKoZIzj0EAwMDZwAwZAIwIxdR
+MsJt4do7Rv0376bfm9Dl+mwGQ1JxTHgWS7kyZd+9GBY50zDzB78wngvmHW/MAjB4
+cD0wdFSSGXx0GEFDJDKhPZOkkHk9FfMNh4jYJD/KvwDL+MxnfiChzTi8ztx08/s=
+-----END CERTIFICATE-----`;
+
+appGlobal.remoteApp ??= {
+  async getCACertificates(type: string): Promise<string[]> {
+    return type == "extra" ? [kECRootCA] : [];
+  },
+};
+
+describe("Certificate issued by an EC certificate authority", () => {
+  test("is valid, and as trusted as the CA that we found it in", async () => {
+    let key = await SMIMEPublicKey.importPublicKey(kRSALeaf);
+    expect(await key.keyStatus()).toBe(KeyStatus.Valid);
+    expect(key.trustLevel).toBe(TrustLevel.Personal);
+    expect(key.caName).toBe("EC Test Root CA");
+  });
+});

--- a/app/test/logic/Mail/Encryption/SMIME/certificateChain.test.ts
+++ b/app/test/logic/Mail/Encryption/SMIME/certificateChain.test.ts
@@ -64,9 +64,67 @@ MsJt4do7Rv0376bfm9Dl+mwGQ1JxTHgWS7kyZd+9GBY50zDzB78wngvmHW/MAjB4
 cD0wdFSSGXx0GEFDJDKhPZOkkHk9FfMNh4jYJD/KvwDL+MxnfiChzTi8ztx08/s=
 -----END CERTIFICATE-----`;
 
+/* A root CA that signs with RSASSA-PSS instead of the older PKCS#1 v1.5
+ * padding, and a certificate that it issued:
+ * openssl req -x509 -newkey rsa:2048 -keyout pssca.key -out pssca.crt \
+ *   -days 3650 -nodes -sha256 -sigopt rsa_padding_mode:pss \
+ *   -sigopt rsa_pss_saltlen:-1 -subj "/O=Parula Test/CN=PSS Test Root CA" \
+ *   -addext "basicConstraints=critical,CA:TRUE" \
+ *   -addext "keyUsage=critical,keyCertSign,cRLSign"
+ * openssl x509 -req -in pssleaf.csr -out pssleaf.crt -set_serial 0x2b \
+ *   -CA pssca.crt -CAkey pssca.key -days 3650 -sha256 \
+ *   -sigopt rsa_padding_mode:pss -sigopt rsa_pss_saltlen:-1 -extfile <(printf \
+ *   "basicConstraints=CA:FALSE\nextendedKeyUsage=emailProtection\n") */
+const kPSSRootCA = `-----BEGIN CERTIFICATE-----
+MIIDuzCCAm+gAwIBAgIUQDvP5TTqbKnzk1WRSE+QPPR1jOgwQQYJKoZIhvcNAQEK
+MDSgDzANBglghkgBZQMEAgEFAKEcMBoGCSqGSIb3DQEBCDANBglghkgBZQMEAgEF
+AKIDAgEgMDExFDASBgNVBAoMC1BhcnVsYSBUZXN0MRkwFwYDVQQDDBBQU1MgVGVz
+dCBSb290IENBMB4XDTI2MDkwMzA2NDUwMloXDTM2MDgzMTA2NDUwMlowMTEUMBIG
+A1UECgwLUGFydWxhIFRlc3QxGTAXBgNVBAMMEFBTUyBUZXN0IFJvb3QgQ0EwggEi
+MA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDtii3VDit7KCCYTKJZDrjLZUU/
+bfXwtNyI+zCXOKhKnsAFJtFiWBq7yLXW7bAbr0h1tTFrIVyxxehWJcZBAV/d4RLM
+rpHh3kw71VaQ2AqrQJvrhaPlt6OqhlLBZr1F/Vw5EdWwcJn8RCHLl/VkcjQtswbG
+Am3ZZbF4ZL6pMi3xfjuRe4FB2qd8K7fqgzK8q6WHZyhK7UXBdFBwA1bsIGV2FOZy
+VBysZr50BBxQSAtucGI8oSKXbAuPKKnP1hD5oOslzhCXYyWOeej0W9o/Y1Jp2Yvk
+jRjGh4BcdUW7T1cNXd/pyfxPhMH8zD+rTb9ZC5uWzCiAb6gwHqEQHH9WLqH3AgMB
+AAGjYzBhMB0GA1UdDgQWBBSBU7CiO+fudQcADudjBj3/rRzMfTAfBgNVHSMEGDAW
+gBSBU7CiO+fudQcADudjBj3/rRzMfTAPBgNVHRMBAf8EBTADAQH/MA4GA1UdDwEB
+/wQEAwIBBjBBBgkqhkiG9w0BAQowNKAPMA0GCWCGSAFlAwQCAQUAoRwwGgYJKoZI
+hvcNAQEIMA0GCWCGSAFlAwQCAQUAogMCASADggEBADkF3vo6fGvy1A7gHhgOJSo+
+dNYT2TaHqW1zwn+kTCD+U1JnM9LTfJQk43g5WvexIjRDyfVw54AUTAYzCny8tRoS
+SgPImMVqFZJsVvT8ShAiH1VFHftMAN6CDQqGGmbxNmkpMeWCXz4acs2pRfYLsSjd
+2AzdQbqNfyloRhgCo4zPKLikUXhbkAyfR0gROgOeVU9dFfLDxN/rUhm0h1LafSwz
+U+I+pp4Fgd/aQSyuW/q7nBxAK4KISsBRb/gMiA3jqaoNhfEHpnXpKurGzy4mA0Vx
+wU0JSLA7zZP1yuME0PZQSFOKIlN+uDWU6mSMXqsTM896f7jway61fH4etF4MoM4=
+-----END CERTIFICATE-----`;
+
+const kPSSLeaf = `-----BEGIN CERTIFICATE-----
+MIIDyzCCAn+gAwIBAgIBKzBBBgkqhkiG9w0BAQowNKAPMA0GCWCGSAFlAwQCAQUA
+oRwwGgYJKoZIhvcNAQEIMA0GCWCGSAFlAwQCAQUAogMCASAwMTEUMBIGA1UECgwL
+UGFydWxhIFRlc3QxGTAXBgNVBAMMEFBTUyBUZXN0IFJvb3QgQ0EwHhcNMjYwOTAz
+MDY0NTAyWhcNMzYwODMxMDY0NTAyWjA1MRAwDgYDVQQDDAdQU1MgQm9iMSEwHwYJ
+KoZIhvcNAQkBFhJwc3Nib2JAZXhhbXBsZS5jb20wggEiMA0GCSqGSIb3DQEBAQUA
+A4IBDwAwggEKAoIBAQCRQRTe7tAgMUnaW10RWJlM/TYpJEg3hu2tJFTDEvJaZraJ
+omdF78RSgt0Qheu8dm98CvRYYZvxp1hrLdj0Ks95hO4L1V2XLNXFv4Mn9kVC5F+M
+Q+HvjphFQZ2BcFix9gGxa6I9DsTXihs3WyszxOXIMIxw7PRyusX709OvTTZnj0Ss
+/PLQAbhMJQxLfcYs3bDRqHNdR9KtPq8mf4kc+SEz4WEKv6nJ+AVSwXz5P1FQ+OQR
+nv9yfJij5TbLF8HInVnzyiyZyMHKHWufs9cOYHmKMiOOAPfD5091gj8dXvSCH8Bq
+nWcjAz9joTJM2BkN0a2WsSffLXMe9O1IMBvD063JAgMBAAGjgYEwfzAJBgNVHRME
+AjAAMBMGA1UdJQQMMAoGCCsGAQUFBwMEMB0GA1UdEQQWMBSBEnBzc2JvYkBleGFt
+cGxlLmNvbTAdBgNVHQ4EFgQUgSert8xjX7wyoLqsxcue1mQfQ4owHwYDVR0jBBgw
+FoAUgVOwojvn7nUHAA7nYwY9/60czH0wQQYJKoZIhvcNAQEKMDSgDzANBglghkgB
+ZQMEAgEFAKEcMBoGCSqGSIb3DQEBCDANBglghkgBZQMEAgEFAKIDAgEgA4IBAQDD
+w75zlbIOwr/NNWHnJ8MyTDIave0XG9iYoKoOMAuRUylaXccSQHNHBWobVJcU0gHV
+WqzYUHwEkLucONhZzPOUqG9na6slNcDq9sGGQIlG83ENpNH6KjoAAv9RfwxmC12m
+smc+ZxLvaO9MS5eA6J78tWg3QOzXBo/ATbRRvPfRlI5eLYPRsTb30x4tcuUYdYqm
+UQ/i8YVxk3MJwhovF+x0KBLFSCj6RH0oPLvoqRJYty6SWKaZSs1jvOd8VAjko6YE
+QpQYGLQWDbm8H4tjgltSrneaiKh+jMQJqk/CCcKSzcpyV3rnRHuq6toN301MwYhH
+GaL7trvUPa5x6YdUJd7b
+-----END CERTIFICATE-----`;
+
 appGlobal.remoteApp ??= {
   async getCACertificates(type: string): Promise<string[]> {
-    return type == "extra" ? [kECRootCA] : [];
+    return type == "extra" ? [kECRootCA, kPSSRootCA] : [];
   },
 };
 
@@ -76,5 +134,13 @@ describe("Certificate issued by an EC certificate authority", () => {
     expect(await key.keyStatus()).toBe(KeyStatus.Valid);
     expect(key.trustLevel).toBe(TrustLevel.Personal);
     expect(key.caName).toBe("EC Test Root CA");
+  });
+});
+
+describe("Certificate signed with RSA-PSS", () => {
+  test("is valid, and names the CA that signed it", async () => {
+    let key = await SMIMEPublicKey.importPublicKey(kPSSLeaf);
+    expect(await key.keyStatus()).toBe(KeyStatus.Valid);
+    expect(key.caName).toBe("PSS Test Root CA");
   });
 });

--- a/app/test/logic/Mail/Encryption/SMIME/keyStatus.test.ts
+++ b/app/test/logic/Mail/Encryption/SMIME/keyStatus.test.ts
@@ -1,0 +1,102 @@
+// The key classes use the app singleton. Importing it first breaks the
+// import cycle, which would otherwise leave the base classes undefined.
+import "../../../../../logic/app";
+import { SMIMEPublicKey, KeyStatus } from "../../../../../logic/Mail/Encryption/SMIME/SMIMEPublicKey";
+import { TrustLevel } from "../../../../../logic/Mail/Encryption/enums";
+import { appGlobal } from "../../../../../logic/app";
+import { expect, test, describe } from "vitest";
+
+// `verifySignature()` compares using `indexedDB.cmp()`,
+// which the browser has, but Node does not.
+globalThis.indexedDB ??= {
+  cmp(a: Uint8Array, b: Uint8Array): number {
+    let length = Math.min(a.length, b.length);
+    for (let i = 0; i < length; i++) {
+      if (a[i] != b[i]) {
+        return a[i] < b[i] ? -1 : 1;
+      }
+    }
+    return Math.sign(a.length - b.length);
+  },
+} as any;
+
+// Our test CA is the only trusted root. `SMIMEPublicKey` caches this per
+// process, so it has to be the same for all tests in this file.
+appGlobal.remoteApp ??= {
+  async getCACertificates(type: string): Promise<string[]> {
+    return type == "bundled" ? [kTestCA] : [];
+  },
+};
+
+describe("Trust level of a certificate that a CA vouches for", () => {
+  test("is raised to the CA level", async () => {
+    let key = await SMIMEPublicKey.importPublicKey(kEvaCert);
+    expect(await key.keyStatus()).toBe(KeyStatus.Valid);
+    expect(key.trustLevel).toBe(TrustLevel.ThirdParty);
+    expect(key.caName).toBe("Test CA");
+  });
+
+  test("stays distrusted, when the user distrusted it", async () => {
+    let key = await SMIMEPublicKey.importPublicKey(kEvaCert);
+    key.trustLevel = TrustLevel.Distrusted;
+    expect(await key.keyStatus()).toBe(KeyStatus.Valid);
+    expect(key.trustLevel).toBe(TrustLevel.Distrusted);
+  });
+});
+
+/* Our test CA, and a certificate that it issued.
+ * openssl genpkey -quiet -algorithm RSA -pkeyopt rsa_keygen_bits:2048 -out ca.key
+ * openssl req -x509 -key ca.key -out ca.crt -days 3650 -sha256 \
+ *   -subj "/CN=Test CA/2.5.4.97=VATDE-999" \
+ *   -addext "basicConstraints=critical,CA:TRUE" -addext "keyUsage=critical,keyCertSign,cRLSign"
+ * openssl req -new -key eva.key -out eva.csr \
+ *   -subj "/CN=Eva/2.5.4.97=VATDE-123/emailAddress=eva@example.com"
+ * openssl x509 -req -in eva.csr -out eva.crt -CA ca.crt -CAkey ca.key -days 3000 -sha256 \
+ *   -set_serial 0x2a -extfile <(printf "basicConstraints=CA:FALSE\nkeyUsage=critical,digitalSignature,keyEncipherment\nextendedKeyUsage=emailProtection\nsubjectAltName=email:eva@example.com\nsubjectKeyIdentifier=hash\nauthorityKeyIdentifier=keyid,issuer\n")
+ */
+const kTestCA = `
+-----BEGIN CERTIFICATE-----
+MIIDPTCCAiWgAwIBAgIUcJkmmMw4TSqmRlLPccH3/BHmkmIwDQYJKoZIhvcNAQEL
+BQAwJjEQMA4GA1UEAwwHVGVzdCBDQTESMBAGA1UEYQwJVkFUREUtOTk5MB4XDTI2
+MDkwMzA2Mjg1MFoXDTM2MDgzMTA2Mjg1MFowJjEQMA4GA1UEAwwHVGVzdCBDQTES
+MBAGA1UEYQwJVkFUREUtOTk5MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKC
+AQEAuVMbuQyUAAVUfLIhYQap5HXOlFzAzNa/JU7zk04qTwL2FwvwQeMQnx2Jk9LL
+QEPvHCxtZg3gDDJlyMnmOfSSUibtCDbWjUOSoDsoe//ap0xswt+yt8M4GHu6699Y
+kWwhznIcCBAnTgxhzpqpTQltKF5CmSIih4C9fEiajNPNGajlYuJFcqfN6czxOuiH
+jX9rf9AlSedAvvzKXmrF08fTad3E2HFQ3gjzOOW5sHoOFy4l4ewDDRUr63LOtIqu
+izVxFUMQnFu5FdUB5u8KTk5FzcEVh/Y0RbnoMAzMsuoTXnWUxY5h0D5HCjy4wLyL
+dQUzC94Ahp2SZj/Zrdt6PkwXjwIDAQABo2MwYTAdBgNVHQ4EFgQUhvNcd2obmnDc
+913nfrD3oVQH0b0wHwYDVR0jBBgwFoAUhvNcd2obmnDc913nfrD3oVQH0b0wDwYD
+VR0TAQH/BAUwAwEB/zAOBgNVHQ8BAf8EBAMCAQYwDQYJKoZIhvcNAQELBQADggEB
+AK0jtEkEccykLpeITue8KeemRdfC7N3mQfH88FImDgJesbmFmneS7zGf78mEOZla
+zy370OoDjC63w7Kp/gYu/Kr6y8Ml3jk20R+qIOGPJP7NgStlgiH818c9tsSyMEWU
+xqTx6bzTRtL20wpeoykCRFDpefhcVHpK9W2oth5DHOFTx/VZ4Z9L9caALh0cOWjS
+vBnk6cZzsJa8J+S+kXAMECC5qUTPOBAdPGWdSPjaGrDS8t7nkAJGXWA162IGIvq1
+mZcEdMA85ClEdR+IPYVEAdYTQBKMSIeoSFi+2jJ+0gh1SgqAePOra6oBtTkHxiLh
+pDts0aruPhe9R3k/Xn7AwsU=
+-----END CERTIFICATE-----
+`;
+
+const kEvaCert = `
+-----BEGIN CERTIFICATE-----
+MIIDczCCAlugAwIBAgIBKjANBgkqhkiG9w0BAQsFADAmMRAwDgYDVQQDDAdUZXN0
+IENBMRIwEAYDVQRhDAlWQVRERS05OTkwHhcNMjYwOTAzMDYyODUwWhcNMzQxMTIw
+MDYyODUwWjBCMQwwCgYDVQQDDANFdmExEjAQBgNVBGEMCVZBVERFLTEyMzEeMBwG
+CSqGSIb3DQEJARYPZXZhQGV4YW1wbGUuY29tMIIBIjANBgkqhkiG9w0BAQEFAAOC
+AQ8AMIIBCgKCAQEAtHnpvtitvfqLmNxgJ2IX4ZH7rcdW5CbEHwzJJbGFCZ8MzwUU
+T7v0QM4Pu3soCmFvDmoqqH/JbP31wz0gkaSj+dUDhSiqCvObn5SQ7QuHvza3j6Vt
+qZIx6PSJ+/lKT6iICvIWrEQkL0+/77HA/af/7Yro9hTC50O8ATctgqvC4ngS/a18
+OyJSZLJy3yDFbXe6xG/uxAi3MtoWD5srQwmkYonyeEbpkwaSDGPYvhswp9/LZSTz
+E490IuUtsoLg7aayDECNjHgOr/NCj97mLPWobgKBM3mXNPvt+3rDJNfRUNOx+cwI
+mAPGQkcpgvm9qRl5Xyo5XRt5t5o+eR9nchj4tQIDAQABo4GPMIGMMAkGA1UdEwQC
+MAAwDgYDVR0PAQH/BAQDAgWgMBMGA1UdJQQMMAoGCCsGAQUFBwMEMBoGA1UdEQQT
+MBGBD2V2YUBleGFtcGxlLmNvbTAdBgNVHQ4EFgQU3Zv6m443avRUCiOHUPPtrKxf
+NAEwHwYDVR0jBBgwFoAUhvNcd2obmnDc913nfrD3oVQH0b0wDQYJKoZIhvcNAQEL
+BQADggEBAJJbSNEs/Coqm0xiOndUWpSpZE2eXtS7dxcE36bxGS376CPDQhtA1iLF
+uFNa68xeX3fFPTDTsYj24Bfs+rI9B5/YKwL/arm46uWQ4/Z4trUtGg1Snd0FbseH
+u4Wxmi74h7ASVbGLeARdm5fm8l2hSJJN86dwEj86FRfAU7+AE1U2mjumH86ooJoB
+fzqD+ABnuskB7d2RD+5ZhJLFgeKsAbtjPv3MftiGXbzetRbtD5RN7T+U3/rGDTA+
+TeuIDYruN/Zz0GN5+/iV/F83nsc8GAu5KfXFTWRCRlNFphkQ/sj38/3/o76ZMliM
+vgZwOWdT5Li5Iz5UVO4HZdZVWTp5EDQ=
+-----END CERTIFICATE-----
+`;

--- a/app/test/logic/Mail/Encryption/SMIME/keyStatus.test.ts
+++ b/app/test/logic/Mail/Encryption/SMIME/keyStatus.test.ts
@@ -44,6 +44,33 @@ describe("Trust level of a certificate that a CA vouches for", () => {
   });
 });
 
+describe("Certificate chain", () => {
+  test("through a CA that may issue this certificate is valid", async () => {
+    let key = await SMIMEPublicKey.importPublicKey(kErinCert + kIntermediate);
+    expect(await key.keyStatus()).toBe(KeyStatus.Valid);
+  });
+
+  test("through an issuer that is not a CA is invalid", async () => {
+    let key = await SMIMEPublicKey.importPublicKey(kBobCert + kNotACA);
+    expect(await key.keyStatus()).toBe(KeyStatus.ChainInvalid);
+  });
+
+  test("through an issuer that may not sign certificates is invalid", async () => {
+    let key = await SMIMEPublicKey.importPublicKey(kCarolCert + kCANotSigningCertificates);
+    expect(await key.keyStatus()).toBe(KeyStatus.ChainInvalid);
+  });
+
+  test("deeper than the CA allows is invalid", async () => {
+    let key = await SMIMEPublicKey.importPublicKey(kDaveCert + kSubCA + kIntermediate);
+    expect(await key.keyStatus()).toBe(KeyStatus.ChainInvalid);
+  });
+
+  test("for an address that the CA may not issue is invalid", async () => {
+    let key = await SMIMEPublicKey.importPublicKey(kFrankCert + kIntermediate);
+    expect(await key.keyStatus()).toBe(KeyStatus.ChainInvalid);
+  });
+});
+
 /* Our test CA, and a certificate that it issued.
  * openssl genpkey -quiet -algorithm RSA -pkeyopt rsa_keygen_bits:2048 -out ca.key
  * openssl req -x509 -key ca.key -out ca.crt -days 3650 -sha256 \
@@ -98,5 +125,189 @@ u4Wxmi74h7ASVbGLeARdm5fm8l2hSJJN86dwEj86FRfAU7+AE1U2mjumH86ooJoB
 fzqD+ABnuskB7d2RD+5ZhJLFgeKsAbtjPv3MftiGXbzetRbtD5RN7T+U3/rGDTA+
 TeuIDYruN/Zz0GN5+/iV/F83nsc8GAu5KfXFTWRCRlNFphkQ/sj38/3/o76ZMliM
 vgZwOWdT5Li5Iz5UVO4HZdZVWTp5EDQ=
+-----END CERTIFICATE-----
+`;
+
+/* The chains below, all from the same test CA. Their keys are only 1024 bits,
+ * to keep them short: these tests are about the extensions, not the strength.
+ * `issue` is the command above, with `-CA` and these extensions:
+ * intermediate: basicConstraints=critical,CA:TRUE,pathlen:0
+ *   keyUsage=critical,keyCertSign,cRLSign
+ *   nameConstraints=critical,permitted;email:example.com
+ * sub CA, under the intermediate: basicConstraints=critical,CA:TRUE
+ *   keyUsage=critical,keyCertSign,cRLSign
+ * not a CA: basicConstraints=critical,CA:FALSE
+ *   keyUsage=critical,keyCertSign,digitalSignature
+ * CA that may not sign certificates: basicConstraints=critical,CA:TRUE
+ *   keyUsage=critical,digitalSignature,cRLSign
+ * The leaves are as `kEvaCert`, under: Erin the intermediate, Frank the
+ * intermediate, Dave the sub CA, Bob "not a CA", Carol the CA that may not
+ * sign certificates.
+ * openssl verify -CAfile ca.crt -untrusted <chain> -purpose smimesign <leaf>
+ * agrees with each of the tests above.
+ */
+const kIntermediate = `
+-----BEGIN CERTIFICATE-----
+MIICyDCCAbCgAwIBAgIJAOl6ahjU9kcsMA0GCSqGSIb3DQEBCwUAMCYxEDAOBgNV
+BAMMB1Rlc3QgQ0ExEjAQBgNVBGEMCVZBVERFLTk5OTAeFw0yNjA5MDMwNjQ0MDJa
+Fw0zNDExMjAwNjQ0MDJaMBwxGjAYBgNVBAMMEVRlc3QgSW50ZXJtZWRpYXRlMIGf
+MA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQCXJ9yiAd2SXrBzmVEEV0vvb6XndE5L
+CyXyzVLq5Z+hLD3DgcNNIdz6HfRVZY55NjrGowj+ZoGAwAnzdgiBSpkp/XJR9qd9
+BjcK6ci2Uc/QrpsbmpoCg8jvd7cL0aIiEiWOakbbXcU/5ZtaM26GZzJ0OuUrwlwp
+iX/zejX7jhbiyQIDAQABo4GGMIGDMBIGA1UdEwEB/wQIMAYBAf8CAQAwDgYDVR0P
+AQH/BAQDAgEGMB0GA1UdHgEB/wQTMBGgDzANgQtleGFtcGxlLmNvbTAdBgNVHQ4E
+FgQUhIAYyfXriosKkG99cRO/o/uDztkwHwYDVR0jBBgwFoAUhvNcd2obmnDc913n
+frD3oVQH0b0wDQYJKoZIhvcNAQELBQADggEBAAmwSxJs7evkZ/AUDRMh0QXeFdaV
+0xJYepOkUUBmXIds5s9PRc2V7qlC5pseC3Uumvbpdk6H5iujrDNefcXwMEpxhw+z
+5BLlled3D9RaWOxFQ3PPqyzg+dzJKzrP9G9xDdcBNcluEKvZltCwLTHgfkoOHsmk
+555zPZosW6P3PoiOsy1HQmkPAxN859dCgDQIoZwG6h4FtBBhHm60MbkYgHFcaZ4m
+6BLSCrgnTzr4dBcATXzHaIbNT8864oQlP10y/DCQX3ffEeCIzTTo+mR0YMxpBbgo
+tckohUmHeJXvLLfP8lg9K5cDTp1zWkX1wNNcdcULscFDWwBcd0bGXbkEcYg=
+-----END CERTIFICATE-----
+`;
+
+const kSubCA = `
+-----BEGIN CERTIFICATE-----
+MIICEjCCAXugAwIBAgIIL71ClPV7HY4wDQYJKoZIhvcNAQELBQAwHDEaMBgGA1UE
+AwwRVGVzdCBJbnRlcm1lZGlhdGUwHhcNMjYwOTAzMDY0NDAyWhcNMzQxMTIwMDY0
+NDAyWjAWMRQwEgYDVQQDDAtUZXN0IFN1YiBDQTCBnzANBgkqhkiG9w0BAQEFAAOB
+jQAwgYkCgYEArmieXW2eplFD1X38EmULwSdpdp0CrXF7Qk6relgKKcZJI6ts+RO/
+6DlYPAneJmgCtQ5VyYwS0P5eF1ZPQkQepi6g/DGbpjjNPbHbGD10kqFkQbId1eHn
+DC8Yrb9Ig4Xq8UMk4TYg5UYZO8dKr7DP7EZH1KvcKiCW/T4ayJpCE0sCAwEAAaNj
+MGEwDwYDVR0TAQH/BAUwAwEB/zAOBgNVHQ8BAf8EBAMCAQYwHQYDVR0OBBYEFBYx
+OfWPzOXuBNY5avVMBv8PVvivMB8GA1UdIwQYMBaAFISAGMn164qLCpBvfXETv6P7
+g87ZMA0GCSqGSIb3DQEBCwUAA4GBAFGQ57NLUEPq99IFtl4eGlWo9Q73GzaYxsz8
+xEg5mIYZP2h0Nd7yJjzqLerM9BT72qkF4n/ub9eBzlfEF7XgNde23tFz/PwuYM/B
+v0ifDvjfM8G0kcqM50/wx3QBtxaxwNq+FDMypw4Yir8txeYKxs88zQX66M/bLt/e
+kOSnPHR2
+-----END CERTIFICATE-----
+`;
+
+const kNotACA = `
+-----BEGIN CERTIFICATE-----
+MIICmDCCAYCgAwIBAgIJAJpI7O1rZ2xNMA0GCSqGSIb3DQEBCwUAMCYxEDAOBgNV
+BAMMB1Rlc3QgQ0ExEjAQBgNVBGEMCVZBVERFLTk5OTAeFw0yNjA5MDMwNjQ0MDJa
+Fw0zNDExMjAwNjQ0MDJaMBMxETAPBgNVBAMMCE5vdCBBIENBMIGfMA0GCSqGSIb3
+DQEBAQUAA4GNADCBiQKBgQDeaU0MHcMagSzuwP7Y0uEpJ5JYmE4VmAvDLnRxUQvZ
+v4TXkorXnphJkjlXDJZBJpNeWj54p9EXHBVxTbgSdIwb1+PP0VvX/0S9fUHWRzaC
+xYh3ddNoMseH827YV1KaUsCSO2AYFN8Rt64ZDAEVlgnvv28eZuhbhP9sEJNQPncK
+dQIDAQABo2AwXjAMBgNVHRMBAf8EAjAAMA4GA1UdDwEB/wQEAwIChDAdBgNVHQ4E
+FgQUAjCdSDk5NGFvLF6yCKQ3pR5RYiQwHwYDVR0jBBgwFoAUhvNcd2obmnDc913n
+frD3oVQH0b0wDQYJKoZIhvcNAQELBQADggEBABZuGCnlcGR/HPM1SDj/pf1AHQMb
+7LRcymKK5BihLS0fVhz6fPnACzh5eRWo2vkyASFVkFkwb8+KFPZIDT3HUqLmIgjs
+frFfSSDJgLKvBtJenKHCNKptEDmLzxe7b4R96DnK4gUq7NCmERF1Qjyhqkwlzoqt
+U0jkjHAcDxTzjqdkn417yiVohgGDbNH13XjIqF4ekn+T/IcEhmVFvMaJMI/Hk9v1
+NFWZ98zv7VF4kPJYYbJvq9Sxftwt4xSvYxIiSDysrqjeI1aaSgyenog1qadj1FWy
+Fa3us/OzKTD9Lbj8VjL5Kt4ATfENEcYRTk3DEeqrHfGvj1eD1f5F4P05VdY=
+-----END CERTIFICATE-----
+`;
+
+const kCANotSigningCertificates = `
+-----BEGIN CERTIFICATE-----
+MIICsDCCAZigAwIBAgIJAMOJ8MNoAuF1MA0GCSqGSIb3DQEBCwUAMCYxEDAOBgNV
+BAMMB1Rlc3QgQ0ExEjAQBgNVBGEMCVZBVERFLTk5OTAeFw0yNjA5MDMwNjQ0MDJa
+Fw0zNDExMjAwNjQ0MDJaMCgxJjAkBgNVBAMMHVRlc3QgQ0EgV2l0aG91dCBLZXkg
+Q2VydCBTaWduMIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQC+F4Yf66BoEnRy
+cUyuamWimVb1OftHEEIRX5pQIoc+a5yKo6qtoBDLBRC23C0mkuZenJpaQj9f3DQd
+xy6D0cgfkyRywbPvtH+CfDygu2KJHCLc6nTv2hB97qa4yggSPXnVtfi1oB3U7N+Z
+aWFWpC0QxdedKudbd/TkcamVuB/olQIDAQABo2MwYTAPBgNVHRMBAf8EBTADAQH/
+MA4GA1UdDwEB/wQEAwIBgjAdBgNVHQ4EFgQUg5KrgV635eprcjrteFtPlLhy4MIw
+HwYDVR0jBBgwFoAUhvNcd2obmnDc913nfrD3oVQH0b0wDQYJKoZIhvcNAQELBQAD
+ggEBADcVE+/FCBFxgXrQin1qN0XgoBdlEWci1r47LvZnUMpturOapaWK/LV2uizM
+a5iSGyYuAlX/Of1p1Nca6jYHC0u1JGGWasp/MfMi3w3xC4nfdOW674JS82VWC9oL
+0Yiex6JtMxtmfW/CTDPyteRlGAkF1vL1lbvINACS3ch/90xjSfHRkqk1UPBRTdQa
+ZzFludGc5nEvjN+THEjUyNcVQGTTFHYvimU4O1CYwf2P2ZfRcgJr7R6SNFIhDibg
+TjTtwGPIMgsT7Ji7Nle6v6q2l/OhGQ/orfO654/jSALqRbvQR8OtVniDindGZDnn
+Df+OEGWM5pubJY0ffRlHgC6rzbw=
+-----END CERTIFICATE-----
+`;
+
+const kErinCert = `
+-----BEGIN CERTIFICATE-----
+MIICWzCCAcSgAwIBAgIJAPY1j8+VoFexMA0GCSqGSIb3DQEBCwUAMBwxGjAYBgNV
+BAMMEVRlc3QgSW50ZXJtZWRpYXRlMB4XDTI2MDkwMzA2NDQwMloXDTM0MTEyMDA2
+NDQwMlowMDENMAsGA1UEAwwERXJpbjEfMB0GCSqGSIb3DQEJARYQZXJpbkBleGFt
+cGxlLmNvbTCBnzANBgkqhkiG9w0BAQEFAAOBjQAwgYkCgYEA3CMOIHOYJ4o09XvR
+dJfZQ53m5I3dEYVx/tb5zcEZ4TORaTDHQZ28RpaKGLWkyBTZwuUOCK3oCal4XRe6
+1UES8gAFVOKVtfcw/UqOaz4iGnKAskFnwfiJ0UirHKY1AWlyKy3Tu48IxTHJ3QTs
+uI0RTQ5S6pszGIAuefrT/R4BDNcCAwEAAaOBkDCBjTAJBgNVHRMEAjAAMA4GA1Ud
+DwEB/wQEAwIFoDATBgNVHSUEDDAKBggrBgEFBQcDBDAbBgNVHREEFDASgRBlcmlu
+QGV4YW1wbGUuY29tMB0GA1UdDgQWBBQ7u+auDbDy2LzJCuag5mv3zjDhQDAfBgNV
+HSMEGDAWgBSEgBjJ9euKiwqQb31xE7+j+4PO2TANBgkqhkiG9w0BAQsFAAOBgQAW
+Tl3f0O2PqTgFZoOHHJ6qu0B8NRjktusvd96nHD42F8f9T+Y94Sum7muKQNuzKQBt
+mjTmAyYs4NsIWAoRSA8rCDN7BZMEvzz0ZRq90XuJmzu4ubvIJyD/8hAivs0TPdSr
+AzLaAHl5d1TtCPYlAeJ+OjSAuorNfQXadXB8kBFCiw==
+-----END CERTIFICATE-----
+`;
+
+const kFrankCert = `
+-----BEGIN CERTIFICATE-----
+MIICWjCCAcOgAwIBAgIJAPIma4JYvIHkMA0GCSqGSIb3DQEBCwUAMBwxGjAYBgNV
+BAMMEVRlc3QgSW50ZXJtZWRpYXRlMB4XDTI2MDkwMzA2NDQwMloXDTM0MTEyMDA2
+NDQwMlowMDEOMAwGA1UEAwwFRnJhbmsxHjAcBgkqhkiG9w0BCQEWD2ZyYW5rQG90
+aGVyLm9yZzCBnzANBgkqhkiG9w0BAQEFAAOBjQAwgYkCgYEA2ogd69pS9PhLu0ce
+atDurc2quI0r5y3oTevloBsPPrbLc4wNj84dH9GhC7xE1XeNbv61el96WjL8hMXo
+r2GOzkjpWTug59KqCd9kqqyZ25dSaHz53ZFOR9crTV2pjEAM4X+r93S+D3hA9vNG
+pmEfVPTyo+21nScqTOrOGVAtWQECAwEAAaOBjzCBjDAJBgNVHRMEAjAAMA4GA1Ud
+DwEB/wQEAwIFoDATBgNVHSUEDDAKBggrBgEFBQcDBDAaBgNVHREEEzARgQ9mcmFu
+a0BvdGhlci5vcmcwHQYDVR0OBBYEFBuCVOq3c0Gw4AMb1pN06Px+TqdBMB8GA1Ud
+IwQYMBaAFISAGMn164qLCpBvfXETv6P7g87ZMA0GCSqGSIb3DQEBCwUAA4GBAJVB
+ISHtSAzsPGpGvZZJNM3XDbKU7PSgoQl97xkOavpIs4GdmIHjxnje2Pp/narFX9xt
+VaZQbDP+xQC7lsg+Mdx/ZDy0P2NhIMNks8GurX7pIPP9cppTCDX+z2ipWoypr38B
+JUjEUorQ+1VbqrfWGCMH49h10REN2ZW+1iRfhVbI
+-----END CERTIFICATE-----
+`;
+
+const kDaveCert = `
+-----BEGIN CERTIFICATE-----
+MIICVDCCAb2gAwIBAgIIfscxvX4sMiwwDQYJKoZIhvcNAQELBQAwFjEUMBIGA1UE
+AwwLVGVzdCBTdWIgQ0EwHhcNMjYwOTAzMDY0NDAyWhcNMzQxMTIwMDY0NDAyWjAw
+MQ0wCwYDVQQDDAREYXZlMR8wHQYJKoZIhvcNAQkBFhBkYXZlQGV4YW1wbGUuY29t
+MIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQC5oSCu+yYx9jRsRVVjkEgmSECN
+50zAnN0ZSWkQMPCNabZOztmWgZif0t9Suj8+YBe2431SskzEQAFl+NNSg2Cw0rT+
+RDpp3wLfCoLbsDChs0/ydM75dVrky+gBQgRwsPdVnfxXDj8JWotD4me8BzlRlduI
+8W6BXJWPkrQghu1YxQIDAQABo4GQMIGNMAkGA1UdEwQCMAAwDgYDVR0PAQH/BAQD
+AgWgMBMGA1UdJQQMMAoGCCsGAQUFBwMEMBsGA1UdEQQUMBKBEGRhdmVAZXhhbXBs
+ZS5jb20wHQYDVR0OBBYEFECb6C1y93DDWEiCiaErBLCQVNu9MB8GA1UdIwQYMBaA
+FBYxOfWPzOXuBNY5avVMBv8PVvivMA0GCSqGSIb3DQEBCwUAA4GBAJ/D4ikA0S1U
+5u3B6Hm0+IEmSRy+C0/9aB2YkKV3JoJWFFjdK833pg7q1Npn2liPHmqub3Sp+gPs
+ITTRg4i9YrFrCjA6L7f8BV0qWXABgqMs4Sujl4LDGPl9kUF+CpvWa21HS7mp7NVk
+tYuXmkxoIZboTllWEUhS4vw4pmFJvNns
+-----END CERTIFICATE-----
+`;
+
+const kBobCert = `
+-----BEGIN CERTIFICATE-----
+MIICTjCCAbegAwIBAgIIWthQVDHCmecwDQYJKoZIhvcNAQELBQAwEzERMA8GA1UE
+AwwITm90IEEgQ0EwHhcNMjYwOTAzMDY0NDAyWhcNMzQxMTIwMDY0NDAyWjAuMQww
+CgYDVQQDDANCb2IxHjAcBgkqhkiG9w0BCQEWD2JvYkBleGFtcGxlLmNvbTCBnzAN
+BgkqhkiG9w0BAQEFAAOBjQAwgYkCgYEArjVq6gWhbSPqPaj03Ynl0KU/Q42G5kRS
+lArvsVwO3MSQYV02GchKNZP4Ohd0FkhNyIBmkpZHLH12fhxNnWqxLj4itLBehu2v
+sj19YvNSgn2L4+kEEq8XLJtre76jZAlGtJhuCkfVd+40Rccq9JCgyOrQwmfUiTct
+WP+sCsa1Jf0CAwEAAaOBjzCBjDAJBgNVHRMEAjAAMA4GA1UdDwEB/wQEAwIFoDAT
+BgNVHSUEDDAKBggrBgEFBQcDBDAaBgNVHREEEzARgQ9ib2JAZXhhbXBsZS5jb20w
+HQYDVR0OBBYEFJhAeAYgvdfY1TRFHuwEKzVd75yDMB8GA1UdIwQYMBaAFAIwnUg5
+OTRhbyxesgikN6UeUWIkMA0GCSqGSIb3DQEBCwUAA4GBAAmouqyCS+tkUf/L4JTW
+5KvxdFS8XMRxNG28MB2N4UC89nFmzMzENZUkYdHhTkDkWjFKzM7g5Gew6WcSGD8b
+LcYkdzTZqtP1dxrAFzUnPJrZsIvHWjYIukypyUn7dnteRlaMkSyK02FBFI9EbJUc
+RmWdRC5NqLQZxL46TU5V0Uxj
+-----END CERTIFICATE-----
+`;
+
+const kCarolCert = `
+-----BEGIN CERTIFICATE-----
+MIICajCCAdOgAwIBAgIJAPvN2jndfGzTMA0GCSqGSIb3DQEBCwUAMCgxJjAkBgNV
+BAMMHVRlc3QgQ0EgV2l0aG91dCBLZXkgQ2VydCBTaWduMB4XDTI2MDkwMzA2NDQw
+MloXDTM0MTEyMDA2NDQwMlowMjEOMAwGA1UEAwwFQ2Fyb2wxIDAeBgkqhkiG9w0B
+CQEWEWNhcm9sQGV4YW1wbGUuY29tMIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKB
+gQC+rrw/aliKb0ng3Fwb5+uSO3jt2OznOcEwSf166P3iNGSa4hqslXh5BORSohF1
+bMh9e3IeR1JwPhr7xmkdLhETU5bSkmC4GDH8lix2iwKVlOHCYQtQa8VVzOXURt0l
+Ds7+LS6+iQe42spcbZ6uYVFStd06KjMkHU32xNMSdErOgwIDAQABo4GRMIGOMAkG
+A1UdEwQCMAAwDgYDVR0PAQH/BAQDAgWgMBMGA1UdJQQMMAoGCCsGAQUFBwMEMBwG
+A1UdEQQVMBOBEWNhcm9sQGV4YW1wbGUuY29tMB0GA1UdDgQWBBQASgsqY442vUEE
+tF3Gcs0pxTB85DAfBgNVHSMEGDAWgBSDkquBXrfl6mtyOu14W0+UuHLgwjANBgkq
+hkiG9w0BAQsFAAOBgQCHWMIq0gt0DILj7yJT423e8wgyzIvFg8iNP6NMXTo2g5L8
+4IRxTD2N3Ar760hoySFrwAgpLI8Wi+148q6cLdauxpGucPHhrwPiZ5IiqPj9vgkq
+Mu1oTHf3vGKuKuAtg2omOSQAda+8Mnr7vvVP5Kmux0qfFmkSLL/c4JrVp+qvYA==
 -----END CERTIFICATE-----
 `;

--- a/app/test/logic/Mail/Encryption/SMIME/keyStatus.test.ts
+++ b/app/test/logic/Mail/Encryption/SMIME/keyStatus.test.ts
@@ -71,6 +71,16 @@ describe("Certificate chain", () => {
   });
 });
 
+describe("Encrypting to a certificate", () => {
+  test("needs a certificate that allows it", async () => {
+    let key = await SMIMEPublicKey.importPublicKey(kEvaCert);
+    expect(key.usableForEncryption()).toBe(true);
+    // A CA certificate is for signing certificates, not for mail
+    let ca = await SMIMEPublicKey.importPublicKey(kIntermediate);
+    expect(ca.usableForEncryption()).toBe(false);
+  });
+});
+
 /* Our test CA, and a certificate that it issued.
  * openssl genpkey -quiet -algorithm RSA -pkeyopt rsa_keygen_bits:2048 -out ca.key
  * openssl req -x509 -key ca.key -out ca.crt -days 3650 -sha256 \

--- a/app/test/logic/Mail/Encryption/SMIME/readEncrypted.test.ts
+++ b/app/test/logic/Mail/Encryption/SMIME/readEncrypted.test.ts
@@ -487,7 +487,7 @@ REUwfAYJKoZIhvcNAQcBMB0GCWCGSAFlAwQBKgQQLhZ9MZr1QUFEQ7ufBZWtN4BQ
 const kMislabelled = `From: Alice <alice@example.com>
 To: User <user@example.com>
 Subject: Mangled by an archiver
-Date: Tue, 14 Jul 2026 10:00:00 +0000
+Date: Thu, 03 Sep 2026 06:45:06 +0000
 Message-ID: <enc-mislabelled@example.com>
 MIME-Version: 1.0
 Content-Disposition: attachment; filename="smime.p7m"

--- a/app/test/logic/Mail/Encryption/SMIME/readEncrypted.test.ts
+++ b/app/test/logic/Mail/Encryption/SMIME/readEncrypted.test.ts
@@ -92,6 +92,22 @@ test("A CMS blob that was delivered as a plain file, as Microsoft sends it", asy
   expect(email.text.trim()).toBe("Hello, this is encrypted.");
 });
 
+describe("Messages that only claim to be S/MIME", () => {
+  test("An archiver kept the S/MIME headers around the plain message", async () => {
+    let { email, errors } = await read(kMislabelled);
+
+    expect(errors).toEqual([]);
+    expect(email.text.trim()).toBe("Hello, this is signed.");
+    expect(email.signedByKeyID).toBe("b687f50d63928c37"); // the inner signature was checked
+  });
+
+  test("A blob that is neither MIME nor valid CMS says so", async () => {
+    let { errors } = await read(kNotCMS);
+
+    expect(errors).toEqual(["This message is not a valid S/MIME message"]);
+  });
+});
+
 describe("Algorithms that we do not implement", () => {
   test("An unsupported cipher is named, instead of leaving the message empty", async () => {
     let { errors } = await read(kCamellia, await SMIMEPrivateKey.importPrivateKey(kOurKey));
@@ -445,3 +461,87 @@ DNdHAPJQuCZuybECCZUKMaABQzGiwKhPvQTvpe2CfpiQPXi0wBf9IeaMXMxnN0bO
 REUwfAYJKoZIhvcNAQcBMB0GCWCGSAFlAwQBKgQQLhZ9MZr1QUFEQ7ufBZWtN4BQ
 85DMorulmVpREDsUAoQyZqPsjQMs0aaAincZRr3Dwu4L0E3PX20k5wLaNmOG4XK3
 5Gllpx+qCxwIIr7h99iaHTy8LfqFSpdYbWcLbYYkUz4=`;
+
+/** As archivers mangle them: the headers say enveloped-data, but the
+ * content is the plain MIME message, here a `multipart/signed` from
+ * `openssl cms -sign -in part.txt -signer alice.crt -inkey alice.key
+ *   -outform SMIME -md sha256`, base64-encoded with CRLF */
+const kMislabelled = `From: Alice <alice@example.com>
+To: User <user@example.com>
+Subject: Mangled by an archiver
+Date: Tue, 14 Jul 2026 10:00:00 +0000
+Message-ID: <enc-mislabelled@example.com>
+MIME-Version: 1.0
+Content-Disposition: attachment; filename="smime.p7m"
+Content-Type: application/pkcs7-mime; smime-type=enveloped-data; name="smime.p7m"
+Content-Transfer-Encoding: base64
+
+TUlNRS1WZXJzaW9uOiAxLjANCkNvbnRlbnQtVHlwZTogbXVsdGlwYXJ0L3NpZ25l
+ZDsgcHJvdG9jb2w9ImFwcGxpY2F0aW9uL3BrY3M3LXNpZ25hdHVyZSI7IG1pY2Fs
+Zz0ic2hhLTI1NiI7IGJvdW5kYXJ5PSItLS0tNkM5NDg0MDkxN0M3NEE1MjEyRTI2
+OEZGODc5ODNDODMiDQoNClRoaXMgaXMgYW4gUy9NSU1FIHNpZ25lZCBtZXNzYWdl
+DQoNCi0tLS0tLTZDOTQ4NDA5MTdDNzRBNTIxMkUyNjhGRjg3OTgzQzgzDQpDb250
+ZW50LVR5cGU6IHRleHQvcGxhaW47IGNoYXJzZXQ9dXRmLTgNCg0KSGVsbG8sIHRo
+aXMgaXMgc2lnbmVkLg0KDQotLS0tLS02Qzk0ODQwOTE3Qzc0QTUyMTJFMjY4RkY4
+Nzk4M0M4Mw0KQ29udGVudC1UeXBlOiBhcHBsaWNhdGlvbi9wa2NzNy1zaWduYXR1
+cmU7IG5hbWU9InNtaW1lLnA3cyINCkNvbnRlbnQtVHJhbnNmZXItRW5jb2Rpbmc6
+IGJhc2U2NA0KQ29udGVudC1EaXNwb3NpdGlvbjogYXR0YWNobWVudDsgZmlsZW5h
+bWU9InNtaW1lLnA3cyINCg0KTUlJRit3WUpLb1pJaHZjTkFRY0NvSUlGN0RDQ0Jl
+Z0NBUUV4RFRBTEJnbGdoa2dCWlFNRUFnRXdDd1lKS29aSQ0KaHZjTkFRY0JvSUlE
+WnpDQ0EyTXdnZ0pMb0FNQ0FRSUNGQ1U5M2FBQVBMeFM2cDhYWGJaTjFEVWlETWpD
+TUEwRw0KQ1NxR1NJYjNEUUVCQ3dVQU1ESXhEakFNQmdOVkJBTU1CVUZzYVdObE1T
+QXdIZ1lKS29aSWh2Y05BUWtCRmhGaA0KYkdsalpVQmxlR0Z0Y0d4bExtTnZiVEFl
+RncweU5qQTVNRE13TmpNd01UUmFGdzB6TmpBNE16RXdOak13TVRSYQ0KTURJeERq
+QU1CZ05WQkFNTUJVRnNhV05sTVNBd0hnWUpLb1pJaHZjTkFRa0JGaEZoYkdsalpV
+QmxlR0Z0Y0d4bA0KTG1OdmJUQ0NBU0l3RFFZSktvWklodmNOQVFFQkJRQURnZ0VQ
+QURDQ0FRb0NnZ0VCQU15NFFMOC9RVmxvUlRjcg0KRERhOTQxOWdZMnMyRFN6cW1q
+S0pvdllxdDRodDJ6Y0E1TzgxSkRucDVYeU9ra01tOUFNVHZ0d05lenNUMWI5Sw0K
+K29OZ1ZSc1RTdTZGWWdZdFkwbHdQK3EvcDZXSTY1MzIvTUUzcHN2UXoyeDJxRk9l
+MCtyMkdOK3UxY0hVN0lQNQ0KeXhoaHhYUGpwcFJnTHo0YUNIMTEzc282OWtFM3VP
+cXdCQlZQYXIwMFp1N1l1aytIak13d1BUR2dLUlZaek9RdQ0KVS9FOCtTL2JFZExE
+NTFocjRRVTBJN0VxNnpUeG5ybUszWms2bjlMb2pQaXlqUCtYVTdTSkgyOVlUTjBH
+QlZUTw0KQURIV2grelEyWFlTMjRBS0ppdmEzME1ObkRkZW0zTGVmZzVXRy9DS2Fn
+S1FNK1k0bXdUTHdzbE5ZbVJGdG9mMQ0KRFdPU2pEY0NBd0VBQWFOeE1HOHdIUVlE
+VlIwT0JCWUVGQW54Rnh5MGJ3Z21wZ2JrdFl1OC9iNnoxcVJxTUI4Rw0KQTFVZEl3
+UVlNQmFBRkFueEZ4eTBid2dtcGdia3RZdTgvYjZ6MXFScU1BOEdBMVVkRXdFQi93
+UUZNQU1CQWY4dw0KSEFZRFZSMFJCQlV3RTRFUllXeHBZMlZBWlhoaGJYQnNaUzVq
+YjIwd0RRWUpLb1pJaHZjTkFRRUxCUUFEZ2dFQg0KQUtUaVVwTnpSUlNVSjBSR0d3
+a2Z3RHlQdSs4V1NMR2ZkdEZZRS92bk9BYlRWaTAzUDRrYnNTSlFCZHBjcGNJKw0K
+cXpQa3JBeU1UaGFxeTNEajJyT2F6T2szWjkwZEZlVjNJZUxsZ0tkQlNtMHkydHU2
+aFVTS2gwYklSNnZMcC94RQ0KMkxvcmhnZUdEL1BNUVZIZkRtYmJ1UXlGUDZDSHoz
+UmhyQUR4bm1EeFRGM0FMdlhTMjRpWmY4UUY2T3ZCSWxUbw0KbmpOcnNjcTlzWUhD
+QmpuNWQvOVBDYm1lMlFRRFliMzVpeS9HV2JzeG5HZXk5UzVmVVUrY3FUU3hKL25J
+OVNzNA0KQURjTnNLNityV2ZmeDFjQllPNVN3SGEyOUIvdHFvS2VMT0JxbDNaM2tV
+Z2R4RUxGRGhwdmV4R1RHNXVaTFFkQQ0KWklzMDVDR0I1eGJjWVlQaS95VDZjeVl4
+Z2dKYU1JSUNWZ0lCQVRCS01ESXhEakFNQmdOVkJBTU1CVUZzYVdObA0KTVNBd0hn
+WUpLb1pJaHZjTkFRa0JGaEZoYkdsalpVQmxlR0Z0Y0d4bExtTnZiUUlVSlQzZG9B
+QTh2RkxxbnhkZA0KdGszVU5TSU15TUl3Q3dZSllJWklBV1VEQkFJQm9JSGtNQmdH
+Q1NxR1NJYjNEUUVKQXpFTEJna3Foa2lHOXcwQg0KQndFd0hBWUpLb1pJaHZjTkFR
+a0ZNUThYRFRJMk1Ea3dNekEyTkRVd05sb3dMd1lKS29aSWh2Y05BUWtFTVNJRQ0K
+SUZETnBKcTZmVmFWNS8wY3NxNkZMbkh4YjlwRHYzL2pDVlk2WkIzZG1SSzRNSGtH
+Q1NxR1NJYjNEUUVKRHpGcw0KTUdvd0N3WUpZSVpJQVdVREJBRXFNQXNHQ1dDR1NB
+RmxBd1FCRmpBTEJnbGdoa2dCWlFNRUFRSXdDZ1lJS29aSQ0KaHZjTkF3Y3dEZ1lJ
+S29aSWh2Y05Bd0lDQWdDQU1BMEdDQ3FHU0liM0RRTUNBZ0ZBTUFjR0JTc09Bd0lI
+TUEwRw0KQ0NxR1NJYjNEUU1DQWdFb01BMEdDU3FHU0liM0RRRUJBUVVBQklJQkFG
+c2VNRnBIQUNGaXNDR0hKRHE0UkJvag0KUE1oOG1hNVhybEV2OSt5ZzJpNGhMdVJk
+cityUHB5S0h3NzVnN0xzN29oekVqQ1NYTmFOUGhVNko0ZnJLZE04UA0KMkp1RVpk
+SXhvR2sxTFFWZEhGNjhHMCtYVE1WRWhPcmxFQnN6WjRQeXk3UEFTTkZ3VnFQL3Y5
+ZFd6dTA0blZoUQ0KUGRqK3Mya21FR1dwdHArVDFoU0FyWlo1aUJDVUlWYTRpcWll
+U1UxQXRpN3JTSkkvT0hvRXNqVStQdTV6bTVRRw0KQUJPTnBEOGUvNnVQQXFUVXhx
+bmptcGt6RHJNMjBIdEw0L21Sb04zTGtWVWZ6N2EwdkV2aVdVVkUwWllzWS9EZg0K
+bkVwaVYrWE5iSXlqVnhjcUNMQklOa1o0ZFNwdmE1T1F2NjdWb0JHclZ3UEZESHkv
+a0RPVVk4K3Q2cnRxOURzPQ0KDQotLS0tLS02Qzk0ODQwOTE3Qzc0QTUyMTJFMjY4
+RkY4Nzk4M0M4My0tDQoNCg==`;
+
+/** The content is an ASN.1 SEQUENCE, but not a CMS ContentInfo */
+const kNotCMS = `From: Alice <alice@example.com>
+To: User <user@example.com>
+Subject: Not a CMS blob
+Date: Tue, 14 Jul 2026 10:00:00 +0000
+Message-ID: <enc-notcms@example.com>
+MIME-Version: 1.0
+Content-Disposition: attachment; filename="smime.p7m"
+Content-Type: application/pkcs7-mime; smime-type=enveloped-data; name="smime.p7m"
+Content-Transfer-Encoding: base64
+
+MAMCAQU=`;

--- a/app/test/logic/Mail/Encryption/SMIME/readEncrypted.test.ts
+++ b/app/test/logic/Mail/Encryption/SMIME/readEncrypted.test.ts
@@ -84,6 +84,14 @@ test("A message that names our certificate by its subjectKeyIdentifier", async (
   expect(email.text.trim()).toBe("Hello, this is encrypted.");
 });
 
+test("A CMS blob that was delivered as a plain file, as Microsoft sends it", async () => {
+  let { email, errors } = await read(kOctetStream, await SMIMEPrivateKey.importPrivateKey(kOurKey));
+
+  expect(errors).toEqual([]);
+  expect(email.wasEncrypted).toBe(true);
+  expect(email.text.trim()).toBe("Hello, this is encrypted.");
+});
+
 describe("Algorithms that we do not implement", () => {
   test("An unsupported cipher is named, instead of leaving the message empty", async () => {
     let { errors } = await read(kCamellia, await SMIMEPrivateKey.importPrivateKey(kOurKey));
@@ -412,3 +420,28 @@ xEUsq+M6twfxGBGHhmCR+rz2pqd8CrL1JLJEvd5Mkk+ngFL6PbuXpVsUhhmCjDB8
 BgkqhkiG9w0BBwEwHQYJYIZIAWUDBAEqBBAxdIlTvEfnQrSKea7ihQxzgFDk3W25
 fGVVagXm1xTBCsl4oCNjrKPK93GMEiBDztEktg3oIAuRn8WMJQ+tKOPTwAPoveL9
 HLxHAcbqU8yiKZB81KFOji2jLU6WIqdorSqPmQ==`;
+
+/** `openssl cms -encrypt -aes256 -in body.txt -outform SMIME -recip user.crt`,
+ * with the Content-Type replaced by the generic file type that Microsoft
+ * uses and that gateways rewrite to. MS-OXOSMIME section 2.2.1 */
+const kOctetStream = `From: Alice <alice@example.com>
+To: User <user@example.com>
+Subject: Encrypted, delivered as a file
+Date: Tue, 14 Jul 2026 10:00:00 +0000
+Message-ID: <enc-octet@example.com>
+MIME-Version: 1.0
+Content-Disposition: attachment; filename="smime.p7m"
+Content-Type: application/octet-stream; name="smime.p7m"
+Content-Transfer-Encoding: base64
+
+MIIB/AYJKoZIhvcNAQcDoIIB7TCCAekCAQAxggFkMIIBYAIBADBIMDAxDTALBgNV
+BAMMBFVzZXIxHzAdBgkqhkiG9w0BCQEWEHVzZXJAZXhhbXBsZS5jb20CFDZ9lJ8R
+9Y552WBSOMXxoflDDLt3MA0GCSqGSIb3DQEBAQUABIIBABA2+2E7Tdf+TWzwzy6i
+K3DOG35PkFxaLLOLWiXX0P/CcQis+pDNg5Ga2hb5O4orCGzg0D/XFsIYfDOGzUyg
+KMJPNLnQ2tnO3ObkWJ2DMHCuJkfLwA9i9pNTi6DSWsq0RhqqlTs01GlIq8gBfoj3
+d8wHwdvVURDpP2f9e5X3Ht8FOzA5N1LTNpjqq3TX9nQjU5VIFcSlEACtBz80FFnW
+50nTI8YgFqcmZ2Gl9tDDhcSJZVQt0TewqtpRsDNGc0IBPFnFvpdF3rHyrZelvaSW
+DNdHAPJQuCZuybECCZUKMaABQzGiwKhPvQTvpe2CfpiQPXi0wBf9IeaMXMxnN0bO
+REUwfAYJKoZIhvcNAQcBMB0GCWCGSAFlAwQBKgQQLhZ9MZr1QUFEQ7ufBZWtN4BQ
+85DMorulmVpREDsUAoQyZqPsjQMs0aaAincZRr3Dwu4L0E3PX20k5wLaNmOG4XK3
+5Gllpx+qCxwIIr7h99iaHTy8LfqFSpdYbWcLbYYkUz4=`;

--- a/app/test/logic/Mail/Encryption/SMIME/readEncrypted.test.ts
+++ b/app/test/logic/Mail/Encryption/SMIME/readEncrypted.test.ts
@@ -76,6 +76,14 @@ describe("Ciphers that other mail apps encrypt with", () => {
   });
 });
 
+test("A message that names our certificate by its subjectKeyIdentifier", async () => {
+  let { email, errors } = await read(kKeyIdentifier, await SMIMEPrivateKey.importPrivateKey(kOurKey));
+
+  expect(errors).toEqual([]);
+  expect(email.wasEncrypted).toBe(true);
+  expect(email.text.trim()).toBe("Hello, this is encrypted.");
+});
+
 describe("Algorithms that we do not implement", () => {
   test("An unsupported cipher is named, instead of leaving the message empty", async () => {
     let { errors } = await read(kCamellia, await SMIMEPrivateKey.importPrivateKey(kOurKey));
@@ -381,3 +389,26 @@ RzdNM/j29ibMdc79c1Iwtm5UbTXt6uo1MHwGCSqGSIb3DQEHATAdBglghkgBZQME
 ASoEELZRNmez5JQ3FWy++6q9JTKAUJuCIk93Mea2ePGVnVePWa744VxpkfzX9Oja
 wSRTDC7T1ij8Z94jF0Lueip0XOYXKwxD0IY0fnYcPNZgnNiAF9bhj17QmADGf49g
 f5OAMaBd`;
+
+/** `openssl cms -encrypt -keyid -aes256 ...`: the recipient is named by the
+ * subjectKeyIdentifier of the certificate, not by issuer and serial number */
+const kKeyIdentifier = `From: Alice <alice@example.com>
+To: User <user@example.com>
+Subject: Encrypted by key identifier
+Date: Tue, 14 Jul 2026 10:00:00 +0000
+Message-ID: <enc-keyid@example.com>
+MIME-Version: 1.0
+Content-Disposition: attachment; filename="smime.p7m"
+Content-Type: application/pkcs7-mime; smime-type=enveloped-data; name="smime.p7m"
+Content-Transfer-Encoding: base64
+
+MIIByAYJKoZIhvcNAQcDoIIBuTCCAbUCAQIxggEwMIIBLAIBAoAUQyVTD7PKf3aR
+90Fj3Bpp2oQYh5cwDQYJKoZIhvcNAQEBBQAEggEAm3dcHXGfuSs7AJY6V3DllJmG
+c2bNY75AahsSXsmIG3G7b6Ll0SrJL+/0mKv7YxMA02F/H0e/pjiz2e+smxbyyzhl
+XxQUsAIjz8ZmxyjjwmA3udRZmkRwV8JNNADCxJlVSQUI2+OWIX7JlM19sTrzG6Iu
+Jr6UFoSmrcmQ9UYyb9Lu7891jkBvbyTdcvLkVoOR3whRJ1sC3L+yTwXIrum3Dh3a
+ZP8k4I/hYiSsHmcNpwduN+KVNlR7lFex69xhTeF2eAVBTTWJ3I9ceXkwLJ/urHhY
+xEUsq+M6twfxGBGHhmCR+rz2pqd8CrL1JLJEvd5Mkk+ngFL6PbuXpVsUhhmCjDB8
+BgkqhkiG9w0BBwEwHQYJYIZIAWUDBAEqBBAxdIlTvEfnQrSKea7ihQxzgFDk3W25
+fGVVagXm1xTBCsl4oCNjrKPK93GMEiBDztEktg3oIAuRn8WMJQ+tKOPTwAPoveL9
+HLxHAcbqU8yiKZB81KFOji2jLU6WIqdorSqPmQ==`;

--- a/app/test/logic/Mail/Encryption/SMIME/readEncrypted.test.ts
+++ b/app/test/logic/Mail/Encryption/SMIME/readEncrypted.test.ts
@@ -92,6 +92,24 @@ test("A CMS blob that was delivered as a plain file, as Microsoft sends it", asy
   expect(email.text.trim()).toBe("Hello, this is encrypted.");
 });
 
+describe("RSA-OAEP key transport, which RFC 8551 asks for", () => {
+  test("with SHA-1, which the sender leaves out as the default", async () => {
+    let { email, errors } = await read(kOAEP, await SMIMEPrivateKey.importPrivateKey(kOurKey));
+
+    expect(errors).toEqual([]);
+    expect(email.wasEncrypted).toBe(true);
+    expect(email.text.trim()).toBe("Hello, this is encrypted.");
+  });
+
+  test("with SHA-256", async () => {
+    let { email, errors } = await read(kOAEPSHA256, await SMIMEPrivateKey.importPrivateKey(kOurKey));
+
+    expect(errors).toEqual([]);
+    expect(email.wasEncrypted).toBe(true);
+    expect(email.text.trim()).toBe("Hello, this is encrypted.");
+  });
+});
+
 describe("Messages that only claim to be S/MIME", () => {
   test("An archiver kept the S/MIME headers around the plain message", async () => {
     let { email, errors } = await read(kMislabelled);
@@ -115,8 +133,8 @@ describe("Algorithms that we do not implement", () => {
     expect(errors).toEqual(["This message is encrypted with 1.2.392.200011.61.1.1.1.2, which is not supported"]);
   });
 
-  test("An unsupported key transport is named, not reported as a missing key", async () => {
-    let { errors } = await read(kOAEP, await SMIMEPrivateKey.importPrivateKey(kOurKey));
+  test("OAEP with a different hash for the mask than for the digest", async () => {
+    let { errors } = await read(kOAEPMixedHashes, await SMIMEPrivateKey.importPrivateKey(kOurKey));
 
     expect(errors).toEqual(["The key of this message is encrypted with rsaESOAEP, which is not supported"]);
   });
@@ -367,7 +385,7 @@ hN0wfgYJKoZIhvcNAQcBMB8GCyqDCIyaSz0BAQECBBAIRM331zx1v66IGd/vNXTI
 gFDGGMQO5T77gbbSkB6bK7wuVfwKTGVJNsQEVAkW+fb8dxA9YfWJavtiUaWxUUB4
 fwOvE+nAm22cF7W8FTPUaqGiMyBXStfBfbudN7yYSTruhQ==`;
 
-/** `openssl cms -encrypt -aes256 -keyopt rsa_padding_mode:oaep ...`:
+/** `openssl cms -encrypt -aes256 -recip user.crt -keyopt rsa_padding_mode:oaep`:
  * the content key is encrypted with RSA-OAEP instead of PKCS#1 v1.5 */
 const kOAEP = `From: Alice <alice@example.com>
 To: User <user@example.com>
@@ -545,3 +563,51 @@ Content-Type: application/pkcs7-mime; smime-type=enveloped-data; name="smime.p7m
 Content-Transfer-Encoding: base64
 
 MAMCAQU=`;
+
+/** As `kOAEP`, but with `-keyopt rsa_oaep_md:sha256` */
+const kOAEPSHA256 = `From: Alice <alice@example.com>
+To: User <user@example.com>
+Subject: Encrypted with RSA-OAEP and SHA-256
+Date: Tue, 14 Jul 2026 10:00:00 +0000
+Message-ID: <enc-oaep256@example.com>
+MIME-Version: 1.0
+Content-Disposition: attachment; filename="smime.p7m"
+Content-Type: application/pkcs7-mime; smime-type=enveloped-data; name="smime.p7m"
+Content-Transfer-Encoding: base64
+
+MIICJwYJKoZIhvcNAQcDoIICGDCCAhQCAQAxggGPMIIBiwIBADBIMDAxDTALBgNV
+BAMMBFVzZXIxHzAdBgkqhkiG9w0BCQEWEHVzZXJAZXhhbXBsZS5jb20CFDZ9lJ8R
+9Y552WBSOMXxoflDDLt3MDgGCSqGSIb3DQEBBzAroA0wCwYJYIZIAWUDBAIBoRow
+GAYJKoZIhvcNAQEIMAsGCWCGSAFlAwQCAQSCAQB3zs6BjpmNbYsS9OTUeTvtm3pq
+WgTbIrMFzJaEJvAgBtPcwq1iKSZ0dazRPOxPvyGt31l5Xax79yPsn9QfGGWyQdgw
+HKgRHFcNyWE/bALly3tfIp50ZUEuoOeG2QaCWOR8CJUZ76WGQFKgZKTRCSb0p9TI
+6Ljwy3jcEOOjBTALL+iQIDMPgfUP8JeghNVUpFaZZV6wq4xB5UyXNz7HABz0twfZ
+zsD2hAuwPqLlTjoI0WL1amwvBokWPL/rck554g7WjwkMKNG79IRFDuynQQAqOPp8
+Z7xRZlYPVIaogqeq40wnqAfs92UBcmd5MsdaNOytzqMnoPn9ZD16RfoMIXJXMHwG
+CSqGSIb3DQEHATAdBglghkgBZQMEASoEELuPk9hIoNve/YWGQD6S+OCAUMaHwD4v
+gDlQdrYeLWUy/YZXYnXMiEPxqWSTgfaCVJ9dAgqjformP4grMxonMG1QQpfFYccF
+VFMbbjUkFXWCGUh4e6ceKHQzVn8/n04gRd8l`;
+
+/** As `kOAEP`, but with `-keyopt rsa_oaep_md:sha256 -keyopt rsa_mgf1_md:sha1`,
+ * which WebCrypto cannot do: it uses one hash for the digest and the mask */
+const kOAEPMixedHashes = `From: Alice <alice@example.com>
+To: User <user@example.com>
+Subject: Encrypted with RSA-OAEP and 2 hashes
+Date: Tue, 14 Jul 2026 10:00:00 +0000
+Message-ID: <enc-oaepmix@example.com>
+MIME-Version: 1.0
+Content-Disposition: attachment; filename="smime.p7m"
+Content-Type: application/pkcs7-mime; smime-type=enveloped-data; name="smime.p7m"
+Content-Transfer-Encoding: base64
+
+MIICCwYJKoZIhvcNAQcDoIIB/DCCAfgCAQAxggFzMIIBbwIBADBIMDAxDTALBgNV
+BAMMBFVzZXIxHzAdBgkqhkiG9w0BCQEWEHVzZXJAZXhhbXBsZS5jb20CFDZ9lJ8R
+9Y552WBSOMXxoflDDLt3MBwGCSqGSIb3DQEBBzAPoA0wCwYJYIZIAWUDBAIBBIIB
+AKu2MkkXt3aad4BOfHEYA8FF9wS6mOV2bV95wJzNCHjc2v3kpvNUCaxnnD0Z00Gp
+kOvc1e0gABAy723+D3Yup5PjbVFaALjNnWaAb92Nf0dLad0egZznULeUgd5dIGdU
+sT0gxsdKBHPMdT349gK1DlqQU0oXBUcuRNhjX0i+sWBpEZ8ic+0MMNSkAWWyCjVP
+I+Ga7Hahv1TQYyx6ovwfeVoF/BpZ23zg/F7xhJtakccoQBsSrvSI/9/khg0gF19t
+7aShS+Hc/L+1NGsV/A3Cn81ropICoxIpTCvchHmJPzM/DbxBiBZYDG9Kan7Jp/Fb
+wM1P7/iE9uAS7ZuhVYXaA88wfAYJKoZIhvcNAQcBMB0GCWCGSAFlAwQBKgQQRxQ7
+TNLlehPPNu8+eZGzY4BQoFaD6JFl51+vbUjWxNzZM9UoarLm8IuY1d7/ZcZtSoDv
+oHIbzPGWb+TXMqpLR0nP2VEAr/dG9X/+CMmJSVonKKUrd3m/a16kI7xyezqjuWg=`;

--- a/app/test/logic/Mail/Encryption/SMIME/readEncrypted.test.ts
+++ b/app/test/logic/Mail/Encryption/SMIME/readEncrypted.test.ts
@@ -76,6 +76,35 @@ describe("Ciphers that other mail apps encrypt with", () => {
   });
 });
 
+describe("Algorithms that we do not implement", () => {
+  test("An unsupported cipher is named, instead of leaving the message empty", async () => {
+    let { errors } = await read(kCamellia, await SMIMEPrivateKey.importPrivateKey(kOurKey));
+
+    expect(errors).toEqual(["This message is encrypted with 1.2.392.200011.61.1.1.1.2, which is not supported"]);
+  });
+
+  test("An unsupported key transport is named, not reported as a missing key", async () => {
+    let { errors } = await read(kOAEP, await SMIMEPrivateKey.importPrivateKey(kOurKey));
+
+    expect(errors).toEqual(["The key of this message is encrypted with rsaESOAEP, which is not supported"]);
+  });
+
+  test("A message to an EC certificate is not for us, whatever the sender used", async () => {
+    let { errors } = await read(kECDH, await SMIMEPrivateKey.importPrivateKey(kOurKey));
+
+    expect(errors).toEqual(["This message is encrypted, and the key is not available"]);
+  });
+
+  test("A key without a certificate does not stop the other keys", async () => {
+    let { email, errors } = await read(k3DES,
+      await SMIMEPrivateKey.createNewPrivateKey("user@example.com"), // as [Create new key] leaves it
+      await SMIMEPrivateKey.importPrivateKey(kOurKey));
+
+    expect(errors).toEqual([]);
+    expect(email.text.trim()).toBe("Hello, this is encrypted.");
+  }, 30000); // generating the 4096 bit key takes a while
+});
+
 /** `openssl smime -sign | openssl smime -encrypt`, to a certificate that is not ours */
 const kEncrypted = `From: Alice <alice@example.com>
 To: User <user@example.com>
@@ -282,3 +311,73 @@ U2g8BfQFpt80fgIWrFVw8Kh8zwhcl0tifFzGgVhy94wJhg0AW4U8Fy6NIPfTdUTd
 0uswcQYJKoZIhvcNAQcBMBoGCCqGSIb3DQMCMA4CAgCgBAgSZnhpIyC3u4BIYyJy
 FX/G+LwiLT2k641mQH1sAaQXDv9LK/ULoZZHyQAFzMFpiEBE7WD4CdOG59a8+PMZ
 UMYGFLFYP9MPSj13EdiN7JbrOZVJ`;
+
+/** `openssl cms -encrypt -camellia128 ...`: a cipher that we do not implement */
+const kCamellia = `From: Alice <alice@example.com>
+To: User <user@example.com>
+Subject: Encrypted with Camellia
+Date: Tue, 14 Jul 2026 10:00:00 +0000
+Message-ID: <enc-camellia@example.com>
+MIME-Version: 1.0
+Content-Disposition: attachment; filename="smime.p7m"
+Content-Type: application/pkcs7-mime; smime-type=enveloped-data; name="smime.p7m"
+Content-Transfer-Encoding: base64
+
+MIIB/gYJKoZIhvcNAQcDoIIB7zCCAesCAQAxggFkMIIBYAIBADBIMDAxDTALBgNV
+BAMMBFVzZXIxHzAdBgkqhkiG9w0BCQEWEHVzZXJAZXhhbXBsZS5jb20CFDZ9lJ8R
+9Y552WBSOMXxoflDDLt3MA0GCSqGSIb3DQEBAQUABIIBAC9DhweaUbqf4w89Bj2P
+EyJAFVPUXTnlwEkY5zlYTi6iXwMunRobvoI8DoXf/lN5vBxuUBA3cQwg1+c2L/Xr
+BTsrbFGSZT8iKxb1TiVpsA0Gphtr3Tn+vslvaI8b0dRPvf6kBsTvNVTXCFQ0wjGh
+AZkdz7WiemeILXbW17nVq4l1aRBVYDlcLRqzxJ0LSdGF9M2fazdXmYakilMwofWs
+E9+e7seMMM+xuLNr1wGogviVJEzMFLOsqLiBxNkDwDNqCGVMDfaK5MM6vjg/IY2z
+xyRd7PvaXgStA6rRpBEkJpI5fX1aQM4bqPNXjrZzufytLLR5/4Qyj8BbgELRcfE+
+hN0wfgYJKoZIhvcNAQcBMB8GCyqDCIyaSz0BAQECBBAIRM331zx1v66IGd/vNXTI
+gFDGGMQO5T77gbbSkB6bK7wuVfwKTGVJNsQEVAkW+fb8dxA9YfWJavtiUaWxUUB4
+fwOvE+nAm22cF7W8FTPUaqGiMyBXStfBfbudN7yYSTruhQ==`;
+
+/** `openssl cms -encrypt -aes256 -keyopt rsa_padding_mode:oaep ...`:
+ * the content key is encrypted with RSA-OAEP instead of PKCS#1 v1.5 */
+const kOAEP = `From: Alice <alice@example.com>
+To: User <user@example.com>
+Subject: Encrypted with RSA-OAEP
+Date: Tue, 14 Jul 2026 10:00:00 +0000
+Message-ID: <enc-oaep@example.com>
+MIME-Version: 1.0
+Content-Disposition: attachment; filename="smime.p7m"
+Content-Type: application/pkcs7-mime; smime-type=enveloped-data; name="smime.p7m"
+Content-Transfer-Encoding: base64
+
+MIIB/AYJKoZIhvcNAQcDoIIB7TCCAekCAQAxggFkMIIBYAIBADBIMDAxDTALBgNV
+BAMMBFVzZXIxHzAdBgkqhkiG9w0BCQEWEHVzZXJAZXhhbXBsZS5jb20CFDZ9lJ8R
+9Y552WBSOMXxoflDDLt3MA0GCSqGSIb3DQEBBzAABIIBAEAa1wWQ61WqVJl2Z87B
+WN/IwnnV1RrO7p9odFZ4aLe+EmEPLlys9qnP/Jx7bsFN1fMOY13VFZz+xg6xw5TG
+VbvQOuf5cpFmytoNak9LXQJA5tw/jxP0SlJhb+ARX8hmZ2NxVUNPBVgxgzKzNX16
+6y5BmOMnHoTPPxlcVjRt1/6rf/9l8fNt+3vrRbzlXJO1mwTGN2DNaEFxP+c652gu
+0HUTar2vrf3dca4YRj1iz2Qua4cUKd8xMTvlNf9GWsfWpD59dQLbH2usfAulo3H0
+6IbKwlnbBx0+cMRtjI0ow/+jn8WgkAKY3ZZz63LKz7khJSLSmXSfX7jw6zejNYji
+z0owfAYJKoZIhvcNAQcBMB0GCWCGSAFlAwQBKgQQHpzfNJOdR+9vexUeW0BEboBQ
+aBrnnQ9HhHGEcMqjqjlS87kikTbSyy3HR479tEzVMHHfv8FQQp9el2DKypN8qIww
+DSoahJ89vm89/M6HMB2X2Rlx7UAXFmjvwJgIBDx/480=`;
+
+/** `openssl cms -encrypt -aes256 ... -recip ec.crt`, where `ec.crt` is an
+ * EC certificate: the sender then uses key agreement, not key transport.
+ * `openssl req -x509 -newkey ec -pkeyopt ec_paramgen_curve:P-256` */
+const kECDH = `From: Alice <alice@example.com>
+To: User <user@example.com>
+Subject: Encrypted to an EC key
+Date: Tue, 14 Jul 2026 10:00:00 +0000
+Message-ID: <enc-ecdh@example.com>
+MIME-Version: 1.0
+Content-Disposition: attachment; filename="smime.p7m"
+Content-Type: application/pkcs7-mime; smime-type=enveloped-data; name="smime.p7m"
+Content-Transfer-Encoding: base64
+
+MIIBggYJKoZIhvcNAQcDoIIBczCCAW8CAQIxgeuhgegCAQOgUaFPMAkGByqGSM49
+AgEDQgAEDvN8iS2lkk5NBffdBBA2TFOh4oOyFrmPZuBsKHHWysczNW6Vkf47GFEz
+8x8TV5EKLo2qfeJO5gqvIv/8l1HE8zAYBgkrgQUQhkg/AAIwCwYJYIZIAWUDBAEt
+MHYwdDBIMDAxDTALBgNVBAMMBFVzZXIxHzAdBgkqhkiG9w0BCQEWEHVzZXJAZXhh
+bXBsZS5jb20CFCrDSc8tdxKCmYU+ZU6DjBEiOTOzBCiKYMhaZ7u88Esj5yN7IMD2
+RzdNM/j29ibMdc79c1Iwtm5UbTXt6uo1MHwGCSqGSIb3DQEHATAdBglghkgBZQME
+ASoEELZRNmez5JQ3FWy++6q9JTKAUJuCIk93Mea2ePGVnVePWa744VxpkfzX9Oja
+wSRTDC7T1ij8Z94jF0Lueip0XOYXKwxD0IY0fnYcPNZgnNiAF9bhj17QmADGf49g
+f5OAMaBd`;

--- a/app/test/logic/Mail/Encryption/SMIME/readEncrypted.test.ts
+++ b/app/test/logic/Mail/Encryption/SMIME/readEncrypted.test.ts
@@ -2,7 +2,9 @@ import "../../../../../logic/app";
 import { setupTestFolder } from "../../SQL/setup";
 import { appGlobal } from "../../../../../logic/app";
 import { MailIdentity } from "../../../../../logic/Mail/MailIdentity";
-import { expect, test } from "vitest";
+import { SMIMEPrivateKey } from "../../../../../logic/Mail/Encryption/SMIME/SMIMEPrivateKey";
+import type { EMail } from "../../../../../logic/Mail/EMail";
+import { expect, test, describe } from "vitest";
 
 // The browser has this, but Node does not.
 globalThis.indexedDB ??= {
@@ -17,21 +19,61 @@ globalThis.indexedDB ??= {
   },
 } as any;
 
-test("An encrypted message that is not for us tells the user why it stays empty", async () => {
+/**
+ * Reads the message as the user that it is addressed to.
+ * @param privateKeys the S/MIME keys of that user, in the order that the
+ *   settings hold them
+ * @returns the message, and the errors that the user was shown
+ */
+async function read(mime: string, ...privateKeys: SMIMEPrivateKey[]): Promise<{ email: EMail, errors: string[] }> {
   let { folder } = await setupTestFolder();
+  // `findIdentity()` searches all accounts, including those of earlier tests
+  appGlobal.emailAccounts.clear();
   let identity = new MailIdentity(folder.account);
   identity.emailAddress = "user@example.com";
   identity.realname = "User";
+  identity.encryptionPrivateKeys.addAll(privateKeys);
   folder.account.identities.add(identity);
   appGlobal.emailAccounts.add(folder.account);
-  let errors: Error[] = [];
-  folder.account.errorCallback = (ex) => errors.push(ex);
+  let errors: string[] = [];
+  folder.account.errorCallback = ex => errors.push(ex.message);
 
   let email = folder.newEMail();
-  email.mime = new TextEncoder().encode(kEncrypted.replace(/\n/g, "\r\n"));
+  email.mime = new TextEncoder().encode(mime.replace(/\n/g, "\r\n"));
   await email.parseMIME();
+  return { email, errors };
+}
 
-  expect(errors.map(ex => ex.message)).toEqual(["This message is encrypted, and the key is not available"]);
+test("An encrypted message that is not for us tells the user why it stays empty", async () => {
+  let { errors } = await read(kEncrypted);
+
+  expect(errors).toEqual(["This message is encrypted, and the key is not available"]);
+});
+
+describe("Ciphers that other mail apps encrypt with", () => {
+  test("Triple DES, as Apple Mail and Thunderbird send it", async () => {
+    let { email, errors } = await read(k3DES, await SMIMEPrivateKey.importPrivateKey(kOurKey));
+
+    expect(errors).toEqual([]);
+    expect(email.wasEncrypted).toBe(true);
+    expect(email.text.trim()).toBe("Hello, this is encrypted.");
+  });
+
+  test("RC2 with 128 bits", async () => {
+    let { email, errors } = await read(kRC2, await SMIMEPrivateKey.importPrivateKey(kOurKey));
+
+    expect(errors).toEqual([]);
+    expect(email.wasEncrypted).toBe(true);
+    expect(email.text.trim()).toBe("Hello, this is encrypted.");
+  });
+
+  test("RC2 with the 40 bit export key length", async () => {
+    let { email, errors } = await read(kRC2Export, await SMIMEPrivateKey.importPrivateKey(kOurKey));
+
+    expect(errors).toEqual([]);
+    expect(email.wasEncrypted).toBe(true);
+    expect(email.text.trim()).toBe("Hello, this is encrypted.");
+  });
 });
 
 /** `openssl smime -sign | openssl smime -encrypt`, to a certificate that is not ours */
@@ -112,3 +154,131 @@ sF4lpN22hBEJeL/Ophn6Bgp84v4WwbCJAZawO9JNhL+d/WBn0yf05KU4yfqKcOH4
 OTI4DTbekCe8ODSpWFo/1MynsRWTDM2B+enLAnX2XLMdVwQ=
 
 `;
+
+/** The S/MIME identity that the messages below are encrypted to.
+ * `openssl req -x509 -newkey rsa:2048 -keyout user.key -out user.crt -nodes
+ *   -subj "/CN=User/emailAddress=user@example.com"
+ *   -addext "subjectAltName=email:user@example.com"
+ *   -addext "subjectKeyIdentifier=hash"
+ *   -addext "keyUsage=digitalSignature,keyEncipherment"` */
+const kOurKey = `-----BEGIN PRIVATE KEY-----
+MIIEvQIBADANBgkqhkiG9w0BAQEFAASCBKcwggSjAgEAAoIBAQDHFL19V/qBg0z4
+KcGCo9GIcy/9SyL8g6rTgn0QXdhjoUXdIjMG/uJ/XnSiFWJjps6WSOSY93XcSXrp
+30ngrUBa0qRnC/cUe4Jlj1HU1izE1fAi+onlvY1ny3OEiFNpbsVMv3QUsiz8Xh5v
+QmNkR97q5GkOipEryuOdoZjuHCmERFjBiG0+JIuCbG0JzgWiREJ9PGI3TjbDx9Pj
+YAnwBTIBMeUGbpXCT+o1AKmMJ/Pr/F1WBqe77hVGbfmqNtvkcrYzweUt8bo7VJck
+Jix+AUHNcPMEftnuU8xq/fDt+buAQOcHzQOunuJcxVSF8AoF77UMYBY1zWLPIyG8
+PBU+4jEPAgMBAAECggEAXcTWldXdH6iNFexxAYwQsvDyXx9HXOHVkedJ6e4R8Kdz
+JTupBjgCzhRa4kcpPx+/+Yhe5+/S203e745lGUbxY3YIyqKXn9Wm7xgo5pN0pcfQ
+4mDYl9YG5ycsg3XEuAndM4+P6Pmdd8cLFcOS1haGGGQ6WYeJ5jMbr9EAG9M2+N11
+Z8Po5pumGEC7tXYeso707r+tqQLYVCl7WuA2H0HqvTsyptmHxz0asZxAwVeMalJT
+OcJnfjevISlhRJa9ZfksDBu/L4nfS/5X/6MIym/s/8TvSWrIygFh74u83znIPs6K
+kcmZnFOFoBxHowguuFNvmEJ/A2kuxnykFIDo9eS24QKBgQDuV78FLzJ0uTy7YRzN
+cgYlmBbTuOUqeRMfGRZcVcC6auhecSsunsdtBM38lD7RXiRdAWBJlahTsvS+upwL
+SzhFcCb+YOEjGuV4NY5VmY1gnY4VmD1YNQ3tnsPl34OM4WB0s0ILRVZ6mWHoB1mV
+l854CWzndIbtitmN7xZ2FGqqLwKBgQDV1GGfmiwXHDHfC9fzps9S0OoXNeLJLs4J
+rDdIowMpedVnmV7/YkoDLjEBdH1BG4LXe0l6Kb7yVEVKS5j1DtrcVVs9fOoNkVl8
+62RDq8Q7wHZ+FLDqnUC2X3jKYcY4b1d1tx58vjZ8+NwfIvx2uSQUVN+9srb94DSK
+fbGQ/o6PIQKBgQDCRM80QJYVwe6YpL0/T9NmzSK+DBTum6VUUbSCKnte90jTwdZ6
+t3zBhYsIdyUEroFhNX/wOoXrQxBubdhG9Fa3coS2Du0zGfc0FiMf7nrn50Qqod5O
+iWAC8MeoFJk7OXDPblVEro2gfGjrISKJ5iSqfrQ/rCFWeTh+kgRy1o1ijQKBgFzF
+wn1OlKaKMxEEwHMUAot53LapSHXk+ruznmDDaRHLrE1Ae7jt2hK7LcPl2Jow53m6
+Ic0A47mb2lw7pGdeRJKn7egllB7C20KZlmzNz1vlSwO00nVYOMVncq7L8QZ3OEj4
+ZB/XHyjliAtyUHrqJL81e8WADmjjp6gWlL3F0/BBAoGAWdLZeoxC+jTiT7/QKeh+
+gByK2TC7+CbSNMLkDwF/C1vM08ACn6rHaz2L53TmRRlPIhHPbE4t7ENlsM+wca5n
+UjMQcdDfg+MMl5xzhc89Wcu7NMuvxWDqD1jjhi9Poik1QyRYu1IJ+2DtsH5Viqf1
+d4Lk+gHjiODNex6QqnxkIwc=
+-----END PRIVATE KEY-----
+-----BEGIN CERTIFICATE-----
+MIIDazCCAlOgAwIBAgIUNn2UnxH1jnnZYFI4xfGh+UMMu3cwDQYJKoZIhvcNAQEL
+BQAwMDENMAsGA1UEAwwEVXNlcjEfMB0GCSqGSIb3DQEJARYQdXNlckBleGFtcGxl
+LmNvbTAeFw0yNjA5MDMwNjE4MzdaFw0zNjA4MzEwNjE4MzdaMDAxDTALBgNVBAMM
+BFVzZXIxHzAdBgkqhkiG9w0BCQEWEHVzZXJAZXhhbXBsZS5jb20wggEiMA0GCSqG
+SIb3DQEBAQUAA4IBDwAwggEKAoIBAQDHFL19V/qBg0z4KcGCo9GIcy/9SyL8g6rT
+gn0QXdhjoUXdIjMG/uJ/XnSiFWJjps6WSOSY93XcSXrp30ngrUBa0qRnC/cUe4Jl
+j1HU1izE1fAi+onlvY1ny3OEiFNpbsVMv3QUsiz8Xh5vQmNkR97q5GkOipEryuOd
+oZjuHCmERFjBiG0+JIuCbG0JzgWiREJ9PGI3TjbDx9PjYAnwBTIBMeUGbpXCT+o1
+AKmMJ/Pr/F1WBqe77hVGbfmqNtvkcrYzweUt8bo7VJckJix+AUHNcPMEftnuU8xq
+/fDt+buAQOcHzQOunuJcxVSF8AoF77UMYBY1zWLPIyG8PBU+4jEPAgMBAAGjfTB7
+MB8GA1UdIwQYMBaAFEMlUw+zyn92kfdBY9waadqEGIeXMA8GA1UdEwEB/wQFMAMB
+Af8wGwYDVR0RBBQwEoEQdXNlckBleGFtcGxlLmNvbTAdBgNVHQ4EFgQUQyVTD7PK
+f3aR90Fj3Bpp2oQYh5cwCwYDVR0PBAQDAgWgMA0GCSqGSIb3DQEBCwUAA4IBAQDF
+VeJlLzy0dK1c78kqQIqWrPTWtRFgypW0Kvz6mnG9649gqm0HmHe/PLbUm4oZrdFD
+7C3xBYwVL7JSSjsdU2tOiS5eAtv26y/kThfxjgp9I7uBpiJ28tUylicB3wD+G6bN
+WUzH0zg4B2GInfrutwziwFQ1gheKyf8Q4Q9xgW+HgP7EiX6NaMCCNdPeolIw1LkI
+WV0rzv81Q5Ad3uta5BG4cy9kptUIYvLPrUkqhbXkrOo4KyAfljVw90B6DSjZrU4n
+5n/ySiiSVlEY9VygZJdPDuDE73MiI9VrZvEN2PA5xZldHcohvQW3XaXw/17RHmKq
+1ewAnoWSUmfPbKCQgmtF
+-----END CERTIFICATE-----`;
+
+/** `openssl cms -encrypt -des3 -in body.txt -outform SMIME -recip user.crt`,
+ * where `body.txt` is the MIME entity that the message decrypts to */
+const k3DES = `From: Alice <alice@example.com>
+To: User <user@example.com>
+Subject: Encrypted with 3DES
+Date: Tue, 14 Jul 2026 10:00:00 +0000
+Message-ID: <enc-des3@example.com>
+MIME-Version: 1.0
+Content-Disposition: attachment; filename="smime.p7m"
+Content-Type: application/pkcs7-mime; smime-type=enveloped-data; name="smime.p7m"
+Content-Transfer-Encoding: base64
+
+MIIB6wYJKoZIhvcNAQcDoIIB3DCCAdgCAQAxggFkMIIBYAIBADBIMDAxDTALBgNV
+BAMMBFVzZXIxHzAdBgkqhkiG9w0BCQEWEHVzZXJAZXhhbXBsZS5jb20CFDZ9lJ8R
+9Y552WBSOMXxoflDDLt3MA0GCSqGSIb3DQEBAQUABIIBALvgpagNSko+cHvDIw9D
+S2khFMKv2hPEtlJHdBBJ6bAuqu20DJUgMq3zlXLM5IzWFKRYR/2Nwmk35lVxLCny
+9KXj4+RtJC4RQlFWToElr57/z63sUbPMLYh6EvDv2URdag3Pb5KXJ+x1BXgcm4e+
+nP1MgmlFgOxc9FXS9iCXXiUf6/NBS0BGtDWA1oY6UzFg9Z33NDjHuzJuv9U0XzKw
+9wN4yK/dy9juYWQ7QFpTHL3c/2x0y6MAnCB/a9WfA7uQNBTHa7sMkBi4+++fwohM
+QLXTuOTmGCc303IW7vwbVJfnrNXiMRONC+FxWYSSq1pSDcS6RL0iUBPccKpqIw9k
+4gEwawYJKoZIhvcNAQcBMBQGCCqGSIb3DQMHBAjQon5SqXREV4BIwkEbCZV79TBG
+SUEJfF087NTIp84e6tiNuFzXJDIFXlcQqwoY5BIvyvZ+vZ9gfCrseB/O4tX1YNvq
+/w9PYPmjQsZ08TyBa0QB`;
+
+/** `openssl cms -encrypt -rc2-128 -provider legacy -provider default
+ *   -in body.txt -outform SMIME -recip user.crt`.
+ * RC2 lives in the legacy provider of OpenSSL 3. */
+const kRC2 = `From: Alice <alice@example.com>
+To: User <user@example.com>
+Subject: Encrypted with RC2
+Date: Tue, 14 Jul 2026 10:00:00 +0000
+Message-ID: <enc-rc2@example.com>
+MIME-Version: 1.0
+Content-Disposition: attachment; filename="smime.p7m"
+Content-Type: application/pkcs7-mime; smime-type=enveloped-data; name="smime.p7m"
+Content-Transfer-Encoding: base64
+
+MIIB8AYJKoZIhvcNAQcDoIIB4TCCAd0CAQAxggFkMIIBYAIBADBIMDAxDTALBgNV
+BAMMBFVzZXIxHzAdBgkqhkiG9w0BCQEWEHVzZXJAZXhhbXBsZS5jb20CFDZ9lJ8R
+9Y552WBSOMXxoflDDLt3MA0GCSqGSIb3DQEBAQUABIIBAFwAwL+jAyj56j1HUfCv
+7GPHHtyNGmKyAd4ZVljWWkSeyY5Ggt9MqzN1mb5mLX5qZ3/f3fewHFqLQuNOOmde
+SHSsj9LkSOryoHdaz5HcfB7fcc6J7N7ZydSZ6kxOc4JyYn7vOHDfLEkuC4xSeJQV
+ICA1DtLFCIflkkie+FR+bJnwnZTY271NQaowmtTaVkT+Ewv4Oe0+uyyNzVwOyZVs
+18ty9c3XSW12yvK3Tiz8K+aiNlq04APPMFnE+sSWNagdcJjAeo7KuxRfn4HHjQPS
+DDvhe0GrrnkN0f5QepxEVDgGlvZzs1AEanixKA+m0celuK95gxm2eSeRQATX1dgI
+KvcwcAYJKoZIhvcNAQcBMBkGCCqGSIb3DQMCMA0CAToECFu0so91oorLgEg3jcBR
+2P2Gh+U0oulXNEgiKt5lUWdvIZpcDX08kHjZmObAPJBIN9LTitsJUDGqGPri4qv1
+3iM1LDR56tCa3qKnXz/PMxKisHQ=`;
+
+/** As `kRC2`, but with `-rc2-40` */
+const kRC2Export = `From: Alice <alice@example.com>
+To: User <user@example.com>
+Subject: Encrypted with RC2-40
+Date: Tue, 14 Jul 2026 10:00:00 +0000
+Message-ID: <enc-rc240@example.com>
+MIME-Version: 1.0
+Content-Disposition: attachment; filename="smime.p7m"
+Content-Type: application/pkcs7-mime; smime-type=enveloped-data; name="smime.p7m"
+Content-Transfer-Encoding: base64
+
+MIIB8QYJKoZIhvcNAQcDoIIB4jCCAd4CAQAxggFkMIIBYAIBADBIMDAxDTALBgNV
+BAMMBFVzZXIxHzAdBgkqhkiG9w0BCQEWEHVzZXJAZXhhbXBsZS5jb20CFDZ9lJ8R
+9Y552WBSOMXxoflDDLt3MA0GCSqGSIb3DQEBAQUABIIBAFj92uLMItuLnZWN6FhH
+UJ2nH73j8oz6dZmQiRgSUJDJxVY3umLVBT4l+yC3/B9Wl5S18E0yQ3lZaSLiDqsk
+QQ16OBRsQCz/gC1SYWA9RNJ40W2QEQ4L95cKQWE0wWOGgXhDcZJEvzhEiUCqntPv
+WPtOCBLj3/i3HlpZqoaXJuSt32V7uJP6d7E+yB7rHTuIRB7m4YbWsJ6mKM9RyoZt
+9CN9d7dZaRqgLa/f0tp+/PO8k7NmzYgUC5pau5ddsu3DFUZOnN0aDO85JfK4iY/f
+U2g8BfQFpt80fgIWrFVw8Kh8zwhcl0tifFzGgVhy94wJhg0AW4U8Fy6NIPfTdUTd
+0uswcQYJKoZIhvcNAQcBMBoGCCqGSIb3DQMCMA4CAgCgBAgSZnhpIyC3u4BIYyJy
+FX/G+LwiLT2k641mQH1sAaQXDv9LK/ULoZZHyQAFzMFpiEBE7WD4CdOG59a8+PMZ
+UMYGFLFYP9MPSj13EdiN7JbrOZVJ`;

--- a/app/test/logic/Mail/Encryption/SMIME/readSigned.test.ts
+++ b/app/test/logic/Mail/Encryption/SMIME/readSigned.test.ts
@@ -85,6 +85,18 @@ describe("Signature of a received message, without an own private key", () => {
     let key = await getPublicKeyByKeyID(email.signedByKeyID, email);
     expect(key.trustLevel).toBe(TrustLevel.Sender);
   });
+
+  test("a certificate for another address does not sign for the sender", async () => {
+    let email = await readMessage(toCRLF(kClearSigned.replace("Alice <alice@", "Bob <bob@")));
+    expect(email.text.trim()).toBe("Hello, this is signed.");
+    expect(email.signedByKeyID).toBe(null);
+    expect(email.from.encryptionPublicKey).toBeFalsy();
+  });
+
+  test("the sender address is compared case-insensitively", async () => {
+    let email = await readMessage(toCRLF(kClearSigned.replace("alice@example.com", "Alice@Example.COM")));
+    expect(await signedWithKeyName(email)).toBe("F9D7");
+  });
 });
 
 describe("Signature made with an elliptic curve key", () => {

--- a/app/test/logic/Mail/Encryption/SMIME/readSigned.test.ts
+++ b/app/test/logic/Mail/Encryption/SMIME/readSigned.test.ts
@@ -97,6 +97,17 @@ describe("Signature of a received message, without an own private key", () => {
     let email = await readMessage(toCRLF(kClearSigned.replace("alice@example.com", "Alice@Example.COM")));
     expect(await signedWithKeyName(email)).toBe("F9D7");
   });
+
+  test("a signature from hours before the message was sent does not count", async () => {
+    // The signature was made at 20:20:12 on the day before
+    let sentLater = "Date: Tue, 01 Sep 2026 05:20:12 +0000";
+    let clearSigned = await readMessage(toCRLF(kClearSigned.replace(/Date: .*/, sentLater)));
+    expect(clearSigned.text.trim()).toBe("Hello, this is signed.");
+    expect(clearSigned.signedByKeyID).toBe(null);
+    let opaqueSigned = await readMessage(toCRLF(kOpaqueSigned.replace(/Date: .*/, sentLater)));
+    expect(opaqueSigned.text.trim()).toBe("Hello, this is signed.");
+    expect(opaqueSigned.signedByKeyID).toBe(null);
+  });
 });
 
 describe("Signature made with an elliptic curve key", () => {

--- a/app/test/logic/Mail/Encryption/SMIME/readSigned.test.ts
+++ b/app/test/logic/Mail/Encryption/SMIME/readSigned.test.ts
@@ -3,7 +3,7 @@ import { setupTestFolder } from "../../SQL/setup";
 import { getPublicKeyByKeyID } from "../../../../../logic/Mail/Encryption/KeyUtils";
 import { TrustLevel } from "../../../../../logic/Mail/Encryption/enums";
 import type { EMail } from "../../../../../logic/Mail/EMail";
-import { kClearSigned, kClearSignedLF, kOpaqueSigned } from "./signedMessages";
+import { kClearSigned, kClearSignedLF, kClearSignedOctetStream, kOpaqueSigned } from "./signedMessages";
 import { expect, test, describe } from "vitest";
 
 // The browser has this, but Node does not.
@@ -71,6 +71,13 @@ describe("Signature of a received message, without an own private key", () => {
     let email = await readMessage(kClearSignedLF);
     expect(email.text.trim()).toBe("Hello, this is signed.");
     expect(await signedWithKeyName(email)).toBe("B687");
+  });
+
+  test("a signature that was delivered as a plain file, as Microsoft sends it", async () => {
+    let email = await readMessage(toCRLF(kClearSignedOctetStream));
+    expect(email.text.trim()).toBe("Hello, this is signed.");
+    expect(await signedWithKeyName(email)).toBe("B687");
+    expect(email.attachments.last.hidden).toBe(true);
   });
 
   test("an unknown CA leaves the trust level to the user", async () => {

--- a/app/test/logic/Mail/Encryption/SMIME/readSigned.test.ts
+++ b/app/test/logic/Mail/Encryption/SMIME/readSigned.test.ts
@@ -3,7 +3,7 @@ import { setupTestFolder } from "../../SQL/setup";
 import { getPublicKeyByKeyID } from "../../../../../logic/Mail/Encryption/KeyUtils";
 import { TrustLevel } from "../../../../../logic/Mail/Encryption/enums";
 import type { EMail } from "../../../../../logic/Mail/EMail";
-import { kClearSigned, kClearSignedLF, kClearSignedOctetStream, kOpaqueSigned } from "./signedMessages";
+import { kClearSigned, kClearSignedLF, kClearSignedOctetStream, kOpaqueSigned, kECClearSigned256, kECClearSigned384, kECClearSigned521 } from "./signedMessages";
 import { expect, test, describe } from "vitest";
 
 // The browser has this, but Node does not.
@@ -84,5 +84,25 @@ describe("Signature of a received message, without an own private key", () => {
     let email = await readMessage(toCRLF(kClearSigned));
     let key = await getPublicKeyByKeyID(email.signedByKeyID, email);
     expect(key.trustLevel).toBe(TrustLevel.Sender);
+  });
+});
+
+describe("Signature made with an elliptic curve key", () => {
+  test.each([
+    ["P-256", 256, kECClearSigned256],
+    ["P-384", 384, kECClearSigned384],
+    ["P-521", 521, kECClearSigned521],
+  ])("%s verifies", async (curve, keyLengthInBits, mime: string) => {
+    let email = await readMessage(toCRLF(mime));
+    expect(email.text.trim()).toBe("Hello, this is signed.");
+    let key = await getPublicKeyByKeyID(email.signedByKeyID, email);
+    expect(key.cipher).toBe("ECDSA/" + curve);
+    expect(key.keyLengthInBits).toBe(keyLengthInBits);
+  });
+
+  test("a changed message does not verify", async () => {
+    let email = await readMessage(toCRLF(kECClearSigned256.replace("this is signed", "this was changed")));
+    expect(email.text.trim()).toBe("Hello, this was changed.");
+    expect(email.signedByKeyID).toBe(null);
   });
 });

--- a/app/test/logic/Mail/Encryption/SMIME/readSigned.test.ts
+++ b/app/test/logic/Mail/Encryption/SMIME/readSigned.test.ts
@@ -3,7 +3,7 @@ import { setupTestFolder } from "../../SQL/setup";
 import { getPublicKeyByKeyID } from "../../../../../logic/Mail/Encryption/KeyUtils";
 import { TrustLevel } from "../../../../../logic/Mail/Encryption/enums";
 import type { EMail } from "../../../../../logic/Mail/EMail";
-import { kClearSigned, kOpaqueSigned } from "./signedMessages";
+import { kClearSigned, kClearSignedLF, kOpaqueSigned } from "./signedMessages";
 import { expect, test, describe } from "vitest";
 
 // The browser has this, but Node does not.
@@ -36,7 +36,7 @@ async function readMessage(mime: string): Promise<EMail> {
     },
   });
   let email = folder.newEMail();
-  email.mime = new TextEncoder().encode(toCRLF(mime));
+  email.mime = new TextEncoder().encode(mime);
   await email.parseMIME();
   return email;
 }
@@ -56,19 +56,25 @@ async function signedWithKeyName(email: EMail): Promise<string | null> {
 
 describe("Signature of a received message, without an own private key", () => {
   test("clear-signed message", async () => {
-    let email = await readMessage(kClearSigned);
+    let email = await readMessage(toCRLF(kClearSigned));
     expect(email.text.trim()).toBe("Hello, this is signed.");
     expect(await signedWithKeyName(email)).toBe("F9D7");
   });
 
   test("opaque-signed message, as Outlook sends it", async () => {
-    let email = await readMessage(kOpaqueSigned);
+    let email = await readMessage(toCRLF(kOpaqueSigned));
     expect(email.text.trim()).toBe("Hello, this is signed.");
     expect(await signedWithKeyName(email)).toBe("F9D7");
   });
 
+  test("a message with bare LF line endings, as NSS writes them", async () => {
+    let email = await readMessage(kClearSignedLF);
+    expect(email.text.trim()).toBe("Hello, this is signed.");
+    expect(await signedWithKeyName(email)).toBe("B687");
+  });
+
   test("an unknown CA leaves the trust level to the user", async () => {
-    let email = await readMessage(kClearSigned);
+    let email = await readMessage(toCRLF(kClearSigned));
     let key = await getPublicKeyByKeyID(email.signedByKeyID, email);
     expect(key.trustLevel).toBe(TrustLevel.Sender);
   });

--- a/app/test/logic/Mail/Encryption/SMIME/send.test.ts
+++ b/app/test/logic/Mail/Encryption/SMIME/send.test.ts
@@ -1,0 +1,237 @@
+// app first, to resolve the import cycle around Abstract/Account.ts
+import { appGlobal } from "../../../../../logic/app";
+import { MailIdentity } from "../../../../../logic/Mail/MailIdentity";
+import { SMIMEPrivateKey } from "../../../../../logic/Mail/Encryption/SMIME/SMIMEPrivateKey";
+import { SMIMEPublicKey } from "../../../../../logic/Mail/Encryption/SMIME/SMIMEPublicKey";
+import { SMIMESend } from "../../../../../logic/Mail/Encryption/SMIME/SMIMESend";
+import { findOrCreatePersonUID } from "../../../../../logic/Abstract/PersonUID";
+import type { EMail } from "../../../../../logic/Mail/EMail";
+import { setupTestFolder } from "../../SQL/setup";
+import MailComposer from "../../../../../../desktop/backend/node_modules/nodemailer/lib/mail-composer/index.js";
+import { expect, test, describe } from "vitest";
+
+// The browser has these, but Node does not.
+globalThis.indexedDB ??= {
+  cmp(a: Uint8Array, b: Uint8Array): number {
+    let length = Math.min(a.length, b.length);
+    for (let i = 0; i < length; i++) {
+      if (a[i] != b[i]) {
+        return a[i] < b[i] ? -1 : 1;
+      }
+    }
+    return Math.sign(a.length - b.length);
+  },
+} as any;
+globalThis.window ??= globalThis as any; // `setCertificate()` digests with `window.crypto`
+// `logic/app` installs a localStorage that forgets everything, but the send
+// format has to survive, so replace it.
+globalThis.localStorage = {
+  values: new Map<string, string>(),
+  getItem(key: string): string | null {
+    return this.values.get(key) ?? null;
+  },
+  setItem(key: string, value: string) {
+    this.values.set(key, value);
+  },
+} as any;
+
+/**
+ * Composes the mail with the real MIME generator, signs and encrypts it,
+ * and reads it back in, the way the recipient app does.
+ * Alice sends, and we read the message as the recipient User,
+ * so both identities live in the same test account.
+ */
+async function sendAndRead(sendFormat: "text" | "html", shouldEncrypt: boolean): Promise<{ sent: string, read: EMail }> {
+  localStorage.setItem("mail.send.format", JSON.stringify(sendFormat));
+  let { folder } = await setupTestFolder({
+    // <copied from="desktop/backend/backend.ts">
+    getMIMENodemailer: async (mail: any) => new Uint8Array(await new MailComposer(mail).compile().build()),
+    getCACertificates: async () => {
+      throw new Error("getCACertificates is not a function"); // as on mobile and webmail
+    },
+  });
+  let errors: Error[] = [];
+  folder.account.errorCallback = ex => errors.push(ex);
+  let senderKey = await SMIMEPrivateKey.importPrivateKey(kAlicePrivateKey + kAliceCertificate);
+  let sender = new MailIdentity(folder.account);
+  sender.emailAddress = "alice@example.com";
+  sender.realname = "Alice";
+  sender.encryptionPrivateKeys.add(senderKey);
+  let recipient = new MailIdentity(folder.account);
+  recipient.emailAddress = "user@example.com";
+  recipient.realname = "User";
+  recipient.encryptionPrivateKeys.add(await SMIMEPrivateKey.importPrivateKey(kUserPrivateKey + kUserCertificate));
+  folder.account.identities.addAll([sender, recipient]);
+  appGlobal.emailAccounts.add(folder.account);
+
+  let mail = folder.newEMail();
+  mail.identity = sender;
+  mail.from = findOrCreatePersonUID("alice@example.com", "Alice");
+  let to = findOrCreatePersonUID("user@example.com", "User");
+  to.encryptionPublicKey = await SMIMEPublicKey.importPublicKey(kUserCertificate);
+  mail.to.add(to);
+  mail.subject = "Test";
+  mail.text = "Hällo wörld";
+  mail.html = "<p>Hällo wörld</p>";
+  mail.signedByKeyID = senderKey.id;
+  mail.shouldEncrypt = shouldEncrypt;
+  let sent = (await SMIMESend.encryptAndSign(mail)).sendRawMIME;
+
+  let read = folder.newEMail();
+  read.mime = new TextEncoder().encode(sent);
+  await read.parseMIME();
+  expect(errors.map(ex => ex.message)).toEqual([]);
+  return { sent, read };
+}
+
+/** The message headers, i.e. everything before the body */
+function headers(mime: string): string {
+  return mime.slice(0, mime.indexOf("\r\n\r\n"));
+}
+
+/** The first part of a `multipart/signed`, i.e. the entity that is signed */
+function signedEntity(mime: string): string {
+  let boundary = headers(mime).match(/boundary="(.+?)"/)[1];
+  return mime.split(`--${boundary}\r\n`)[1];
+}
+
+describe("Signing and encrypting keep the headers of the signed entity", () => {
+  test("a text-only message keeps its transfer encoding", async () => {
+    let { sent, read } = await sendAndRead("text", false);
+    expect(signedEntity(sent)).toContain("Content-Type: text/plain; charset=utf-8");
+    expect(signedEntity(sent)).toContain("Content-Transfer-Encoding: quoted-printable");
+    expect(headers(sent)).not.toContain("Content-Transfer-Encoding"); // belongs to the signed part
+    expect(read.text.trim()).toBe("Hällo wörld");
+  });
+
+  test("an encrypted text-only message keeps its transfer encoding", async () => {
+    let { sent, read } = await sendAndRead("text", true);
+    expect(headers(sent)).toContain("Content-Transfer-Encoding: base64"); // for the CMS blob
+    expect(read.wasEncrypted).toBe(true);
+    let decrypted = new TextDecoder().decode(read.mime);
+    expect(signedEntity(decrypted)).toContain("Content-Transfer-Encoding: quoted-printable");
+    expect(read.text.trim()).toBe("Hällo wörld");
+  });
+
+  test("a multipart message keeps its folded content type", async () => {
+    let { sent, read } = await sendAndRead("html", false);
+    expect(signedEntity(sent)).toContain("Content-Type: multipart/alternative;\r\n boundary=");
+    expect(read.text.trim()).toBe("Hällo wörld");
+    expect(read.html).toContain("Hällo wörld");
+  });
+});
+
+/* Test keys, generated with:
+ * openssl req -x509 -newkey rsa:2048 -keyout alice.key -out alice.crt -days 7300 -nodes \
+ *   -subj "/CN=Alice/emailAddress=alice@example.com" \
+ *   -addext "subjectAltName=email:alice@example.com"
+ * and the same for User <user@example.com>. */
+const kAlicePrivateKey = `
+-----BEGIN PRIVATE KEY-----
+MIIEvAIBADANBgkqhkiG9w0BAQEFAASCBKYwggSiAgEAAoIBAQC8GDjZAmfuPgfI
+mLXT0U1zY55d4SNgfei2EmDy3aoWirbhdroZJRf6pUgKS4QsWaaiCmBazPL0ZIx3
+3Ovwmd8AvHlRJL5qEkZJ5YqZNoaC66DNZyKYOcsHSAMVWLlHs8hmYBwjdXO4yPP1
+HiAmCFKlb2iU/YX94OroycvotZtUmn9Is+kiqeDCz6x/HT061dgryzZaFTLkhKiU
+LxY9I3h7H6gRM1In6qbIuz29wbc7zaMnpk0PVClF/0PMyACSW+elFK92yRm1/1xt
+rbNZuEOVsooe4mS+N9OOGXEiRsFDem8N3U82GLNe2JGSrY30TNVFbU9miRDJiM45
+o+AmqjJtAgMBAAECggEAKydzg3Zl2ecpagB/VwWiO2MTpn5M24qHpZ451/67U0io
+BLp0n+g+xCa/jH0e6f33mR3AVZTH+QJIqAdrqlvjKgwT2WYQuc1Piwy668PywH7G
++dk7uqknx5fh/TfJ6oV46OQMEKaV0kNolUhAH/mw3HvfBq/T2heMTbResBladeJH
+l7Q40MZWFIjr8zKwdW4o/u8nHTQAInL6sygIbNjSUM9L5zUxyFnvJphd0MO8vQ4/
+dSP+9FZyW36/dod6fdWg/tqG4eR8FTcgCMOLzKbcXxz0Cc96Zlo1jwR+YLy69zqj
+eJJoKjaDT46ZH4wchPwKIBJ1NHYgjfspinc6XlShgQKBgQDm1kpudrxmtHHJINeT
+KBC3udaX/97+y2PnnFUINAEVHvcu/bIQY019mP5uGAXL6x/Dxy5qPECmZJGMD9fR
+Ai0QzPhJLPsJHPv8jH71PlNSEVO8+gPh4s5Mu1KArahSxRPAJnTn/+O4CaQbvzNi
+BndN/jrfej1I5C2DtoJccGUxKQKBgQDQmSp5kKH4RUZiYPOJp3Z+i49Qb63n/DL8
+Ysufwvd/Upigdx8JAwBT4NBq+Lm23Ld3ZMSjAZEdpWksLDyl+Ox1YVjYfYGNISo9
+fUhFj5npCeXuvW26iMrqb/4UQcLNxVZcTuSK9JP1to9d0TV0TdmhOTnWtY1qQI04
+B05hXIbLpQKBgGW7nXQPijqtXdRpT/i/2JZQJb45ezrJwo7pvCPwX2XCjue70UUd
+rqIi0kcM+UkEp6wt1UvmoAt1GRwkQ1YO4nOcEfSWCVDb4EZOWQmWXTw2/LO1cA6W
+WZtBlzu0zRElX+34RN+WS/Lo9NVxr6CM/vl1iNbC1c2RGmoI/mzk8AP5AoGAK/s/
+Y2ZFYE1q6685ahqu9zuBuhnx9unL7j7+Y+79tBC8MYksOAAz/3t1Nji/H3kmDbxn
+YV8hM7j+ldu15eC4Kn+d9fdwa0tE1rYlmNUQRHxbyJyUGDJjZk66qZa79hrXfJr9
+wPaUg8g8LjHALYeEjWO9eDHLYU2++MNBmXGi0ikCgYBaq27PGPRj6RYEJNLnoeSw
+CnYKDB4VzcJVj9bDxKINRiPXS+0E6S+XhgrE126Wqw4owfD+RG8DQh8NxCAy5vRb
+OkdM7w7vwV714p8VRLLnv0FQgiFZ37uT86oE5mg5Qs0SaVBpY39An5+Qt5GNsg4P
+KQK8lDMUEtGQEuon2mcYaA==
+-----END PRIVATE KEY-----
+`;
+
+const kAliceCertificate = `
+-----BEGIN CERTIFICATE-----
+MIIDYzCCAkugAwIBAgIUXyuXUq+uBb5HoD/SwKsNkTrasvAwDQYJKoZIhvcNAQEL
+BQAwMjEOMAwGA1UEAwwFQWxpY2UxIDAeBgkqhkiG9w0BCQEWEWFsaWNlQGV4YW1w
+bGUuY29tMB4XDTI2MDkwMzA2MjAxNVoXDTQ2MDgyOTA2MjAxNVowMjEOMAwGA1UE
+AwwFQWxpY2UxIDAeBgkqhkiG9w0BCQEWEWFsaWNlQGV4YW1wbGUuY29tMIIBIjAN
+BgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAvBg42QJn7j4HyJi109FNc2OeXeEj
+YH3othJg8t2qFoq24Xa6GSUX+qVICkuELFmmogpgWszy9GSMd9zr8JnfALx5USS+
+ahJGSeWKmTaGguugzWcimDnLB0gDFVi5R7PIZmAcI3VzuMjz9R4gJghSpW9olP2F
+/eDq6MnL6LWbVJp/SLPpIqngws+sfx09OtXYK8s2WhUy5ISolC8WPSN4ex+oETNS
+J+qmyLs9vcG3O82jJ6ZND1QpRf9DzMgAklvnpRSvdskZtf9cba2zWbhDlbKKHuJk
+vjfTjhlxIkbBQ3pvDd1PNhizXtiRkq2N9EzVRW1PZokQyYjOOaPgJqoybQIDAQAB
+o3EwbzAdBgNVHQ4EFgQUF0F17SK7ICCjTydpJIr7I/DvBG4wHwYDVR0jBBgwFoAU
+F0F17SK7ICCjTydpJIr7I/DvBG4wDwYDVR0TAQH/BAUwAwEB/zAcBgNVHREEFTAT
+gRFhbGljZUBleGFtcGxlLmNvbTANBgkqhkiG9w0BAQsFAAOCAQEAWnSpEFF0ULep
+QpYTbOb2HcBL22IofcWyMlrN9RP0uPww9Nt6ZARZVWk8nIQrxgmHqD7C+I1RGXix
+SR9kQ+0zsCbiO5gGBhnO2T+emaAK58uw4a9mfHBAAACv4XhPX70kBEuDJJmZiE0x
+dCXBbvH4u/dvkqQCzCO4co6YKmhyyX2KeU0fzGdiNkTmcuMk7XOTMiTefQHpLkJv
+dAXfOIEh+HG8jMkDozoFf18/cHb0YfXsFhkgx16xsFU04iWHkG0KmYgugxu4nSKe
+bPcN5G0J3+GPy+ab/uhNFsL/HU6veJhZ/lSomdl47V8VtnrUKZkWi82FDJ1VWKN+
+h/EjNKGJQg==
+-----END CERTIFICATE-----
+`;
+
+const kUserPrivateKey = `
+-----BEGIN PRIVATE KEY-----
+MIIEvQIBADANBgkqhkiG9w0BAQEFAASCBKcwggSjAgEAAoIBAQCr1abvdL6s7jfQ
+f7uVwm7n8mwHqNO7Yy+YwBbOCswAKfKIz1X6MeYgXSbu6y7RCsjYQgNp5YKH0hlP
+Ei0RfysgkcPNO50ZsiNFMn1CJcTgiVrv1Xidt186xXxvQUR3wPxwgKLALXPzfBvy
+/ZekCjcuLmaxFDltVm6WFYrMiTHeE7bOBGUfKfrZU9V+oGOytc5Hj0ehLhqKmZ9T
+7hUyG0uaKoJ7f7O01KUdqw1376jS7VSZyLCCMw4RP5Lfz9GJdFEyjkLs11o/OYzO
+gGO/RLA/WEn9meXJdbQnpvTZSsUjfVfanC0e/caKuBRrNUUt3sCk/CewytJVCj4z
+hzxEgi3jAgMBAAECggEAHGCZQ/xMrPReRVGC4hWNCUMQsicgaFbV+mzmlzpTPEex
+JQTQlxP8hCW+E0DFp4IXbxdfxvI/Hz0ELvm6daRBtAw+gLsyk5bGmlvfMbhZDhfA
+69CeLbWlxWftx9XIf9pgFhg4SHJ5LqG1X+ifTVjeigLhtKa5YSQf+Ssvk92oXZsv
+2POTyH1u5DJOXD+ir4so4L7mkEbbIwFm6LA04c7PHsXtMZNLaYRDSODjRNCQhmFA
+SNunzOq9dpl46YzUD/3dIBuG+a3DLr4d9N87K5M9o9GlMYL8Czk/Wz0e5G4ES5D7
+T3RPMte4YQKAdQy7+HX1GWcCi1bi3ETVaprXECA1yQKBgQDyfz5t6dLONjtAAgwr
+IspXKjNFg3BeHT8WQdCy+UQjfgRNVc9S3EY0Z5nUEzmDlCaxd3uNlGVrxvRhSfFc
+ePDd/TBFFD6aL1M2Ghzxd796NBtV0DPUR2C/ftrxNNDaHOPOVrrcEn3xR88McnWy
+p4QrsYLYdz7p1Rlua1csG5kntQKBgQC1ZyBN00TJZX+CkxLKngVVAkIHk24h/3KR
+ucpe4vZniM/BZkxfUBunxdcIlHi1sopmb9ysRTCE/9Wl74VvcHQAa2ZKvPnNmoBO
+KoI99nltOcf20qL8ebOh1mm1N/sGQrhQJUCNmQaUsbSOl+g1U3orYLPOMAcXC701
+IEpTgGvONwKBgCiGKyCjGp9rYKtprC7pOXcnjjnnpTeVG53UkdPW5BQqUv25gVQP
+i4vmZEaUj9/1OiIeHX+jdO916BD6EmOpslbmoNJqd6u8jONVqdCQemcpngfRK1gm
+NXzK7juw39YTTd6Fj+SHEpTnsyoZVqHsbKIAoCUciF77Ray2M3MjiYyhAoGBAJls
+qGjKSAJiQu8n/xu5fN8CMuB/dAVzLO5Nifio0yiMENMM94khktJaRN2v3UwnvmCX
+ObfGKRxD2OooY9316Va1f2W04T5g7yWtVEyd2uNjnFmIm2sYb7JwSyWHPFt2MLcw
+WqGoDGXUytZTaoU3njtz5X99JXH7bsKxFcv78LIPAoGAPwMmY1Mj6kQuKBYLVtdg
+vPX6oJegxEmqHURsyw976VdT1G02CxZRDY+IGdaO0lcdEjWwvKVkngRzGr+GljKY
+iMMR9BCp/iEkjUK/bM6F/grSH+HM2RReb90Ycd+ZBp+ZEXEUvdFNUo+MqaOB+NXr
+zl1CNTtT5ikuRkmEVJa7gTE=
+-----END PRIVATE KEY-----
+`;
+
+const kUserCertificate = `
+-----BEGIN CERTIFICATE-----
+MIIDXjCCAkagAwIBAgIUDM+iDLbIL9gdahCFEXiESRzD2GkwDQYJKoZIhvcNAQEL
+BQAwMDENMAsGA1UEAwwEVXNlcjEfMB0GCSqGSIb3DQEJARYQdXNlckBleGFtcGxl
+LmNvbTAeFw0yNjA5MDMwNjIzMThaFw00NjA4MjkwNjIzMThaMDAxDTALBgNVBAMM
+BFVzZXIxHzAdBgkqhkiG9w0BCQEWEHVzZXJAZXhhbXBsZS5jb20wggEiMA0GCSqG
+SIb3DQEBAQUAA4IBDwAwggEKAoIBAQCr1abvdL6s7jfQf7uVwm7n8mwHqNO7Yy+Y
+wBbOCswAKfKIz1X6MeYgXSbu6y7RCsjYQgNp5YKH0hlPEi0RfysgkcPNO50ZsiNF
+Mn1CJcTgiVrv1Xidt186xXxvQUR3wPxwgKLALXPzfBvy/ZekCjcuLmaxFDltVm6W
+FYrMiTHeE7bOBGUfKfrZU9V+oGOytc5Hj0ehLhqKmZ9T7hUyG0uaKoJ7f7O01KUd
+qw1376jS7VSZyLCCMw4RP5Lfz9GJdFEyjkLs11o/OYzOgGO/RLA/WEn9meXJdbQn
+pvTZSsUjfVfanC0e/caKuBRrNUUt3sCk/CewytJVCj4zhzxEgi3jAgMBAAGjcDBu
+MB0GA1UdDgQWBBSC/AGRI+gFMhKI2uvN7CxpRTpBszAfBgNVHSMEGDAWgBSC/AGR
+I+gFMhKI2uvN7CxpRTpBszAPBgNVHRMBAf8EBTADAQH/MBsGA1UdEQQUMBKBEHVz
+ZXJAZXhhbXBsZS5jb20wDQYJKoZIhvcNAQELBQADggEBAB8ClJaNQZ1ba9jjLQsW
+WmYE3UtFNzT5G+VyQW8nnh4qzbe/OZBcliyQQ7mVJ54IrDzGJ3zCywEilLVaXOEY
+IZWqgYMBLtiXkJsFRbCrv3ancWdEKL92QlvqfDEnqnird7KMS0gEVRr+uNl8uEJk
+dsgc9bhthksyQIELA3iPlv27lXL46gmw8VhItD1qUWBkm6bc8aXuSDWbntMevJ96
+NFUhHCO10AGO4NddnJvi9AHykdTWqk20lCrYe+MmJ066uvoRU/stlneaHe/2Ik6Z
+8sAGAlsfGNPvXm6p6lGkhLZ+ANk+Qpe3n1bGZH3YqOKKmeAtauqxHqz1vkx/A6Wx
+f4Y=
+-----END CERTIFICATE-----
+`;

--- a/app/test/logic/Mail/Encryption/SMIME/sendECRecipient.test.ts
+++ b/app/test/logic/Mail/Encryption/SMIME/sendECRecipient.test.ts
@@ -1,0 +1,117 @@
+// The key classes use the app singleton. Importing it first breaks the
+// import cycle, which would otherwise leave the base classes undefined.
+import "../../../../../logic/app";
+import { setupTestFolder } from "../../SQL/setup";
+import { SMIMEPrivateKey } from "../../../../../logic/Mail/Encryption/SMIME/SMIMEPrivateKey";
+import { SMIMEPublicKey } from "../../../../../logic/Mail/Encryption/SMIME/SMIMEPublicKey";
+import { SMIMESend } from "../../../../../logic/Mail/Encryption/SMIME/SMIMESend";
+import { MailIdentity } from "../../../../../logic/Mail/MailIdentity";
+import { findOrCreatePersonUID } from "../../../../../logic/Abstract/PersonUID";
+import { expect, test, describe } from "vitest";
+
+// The browser has this, but Node does not.
+globalThis.indexedDB ??= {
+  cmp(a: Uint8Array, b: Uint8Array): number {
+    let length = Math.min(a.length, b.length);
+    for (let i = 0; i < length; i++) {
+      if (a[i] != b[i]) {
+        return a[i] < b[i] ? -1 : 1;
+      }
+    }
+    return Math.sign(a.length - b.length);
+  },
+} as any;
+
+/* Our own key and certificate:
+ * openssl req -x509 -newkey rsa:2048 -keyout alice.key -out alice.crt \
+ *   -days 3650 -nodes -sha256 -subj "/CN=Alice/emailAddress=alice@example.com" \
+ *   -addext "subjectAltName=email:alice@example.com" */
+const kMyKeyAndCertificate = `-----BEGIN PRIVATE KEY-----
+MIIEvQIBADANBgkqhkiG9w0BAQEFAASCBKcwggSjAgEAAoIBAQDoW74WldRvCIU9
+rMq5izDq/PNwHrAmqHY+w2GCLyoMjcbwT+c6w+0oXF6IFwSermY0aW3SmC0TfpEJ
++lTDYY/JMKVmeYcnEZTObSHfvy9u/4nFN0PbeJL/9fCnvRG5W/gqFJDNqstI0ubK
+C1t/M58J2wPBwMF32YKZiFcJITY5oAAYwP2cvH820oKsamJGfPXNbAY0wHo6T6v1
+K+lZeDOOoOdZDhsNwonlsrAnzRNj4nWShF5G7BO/FCA9nxeKHtVtv5YhVwYojlyg
+61sv5Jr95MQSUxHZXVlN6bG13MmlFc4Fp2xlvfhEOhPaud1pN6yjJcZ+ifieox93
+R9kLyWlLAgMBAAECggEANWvOTswAzMxVMeJVs4XsZ8JjR75OenzVvsVV2EP2s28v
+M1XzkB+2mUZvV3OPVNo81kT9AmOJTYeWWghrT4ZRNAzSojZDm/hfUXxmwtXmVms6
+5hQ4Li/RADcvrqj597dM3YPf7OEdHq+abw5gaWTZZj8r5HJoKKFh9OGTPR6dJG8U
+H/KcNTUrs/X7Fz3jCDX5Z4mqpjUsqhGeX7v9yjAXg7GaKqKyLMj/Tlsu+OtQ9pye
+/3ConHfKzrTpmFThtaDPROOH+vnNvqciCvbzD5FseGytEu1zy0YOASNfYnAd/611
+vt0ZuH8yGFEmdmZJylRPoEeObfm5mvioRGGlCjPidQKBgQD1xz9X/0BOKJyrwdft
+AN8FolKwhftpxKfkVjtMFwx0tDI3gp4NT6LNiWUPb+cXjRkLWSGqwv+sfma0c68G
+w8otErTSCoYWm/8MHCtnJS9B3iaJ93AftjOdUhbip+QGRbPlTcCVU72VDmj7CaJ8
+eh4ZQHg4dp2kZD8Uwmw50feylQKBgQDyBZ2cNKhXmqPIRFcbTHJoQ3HZu5VZdl9n
+BogQiyHrbBZkIA8CQfK1zgkvhx+Bj8qv9Z4QbJSeZPb7yQMejbo8QIYTHEg8vH/x
+jNQr1DIQar5uTkGGzm1KiWnZ9P7/6YWmNpMpchl9MCNMoKgOOUCARRp3jWd0qLiD
+WnIsbyCUXwKBgDHAHVBguNGZYu1Zla3B6WMoknhtBpFIX3vXALXMTJcrCqc152xm
+XFwinbRcQHkB9LnZVvlL85klFQEeEaXa6Afrq3KA8teMyDnZUefVHRXGNCLlVWr1
+5MjJnxxOQ9gJL/sQnBUeGFgdzJ5UOvHbflA6PpufVxW5vRMkr+ecWvlpAoGBAKP/
+jCqCQCSExED7li8IYWoncamCBBUIMmOEuITFUunNZ2rXknQMLiRmBjFvlbjcsBMG
+E+K7QQYIEpjRQEze6vjTHEcs3gJSFTygGlHMy1P2kS3710k67jIY5WJtMrJFEmxs
+BNKL35vGF9Vf9CEXSI7ixKmIZzdU8RsJGd7kOqZvAoGAVMWLU1Ha79nukSJZpYQW
+qTfkhwtPf/HqF59WvxEd90cW31qd26j1lMcLtJJc2guQuClDyPGIEGDlAcePds1i
+LRBe8MPxL0BP90+3Pjgmli+B5yxdNwFlkxgPSH6x/y3CKejFKbUtbD4eCzgJGldh
+dv9kwvEGDoHjj/L7wZXzhIw=
+-----END PRIVATE KEY-----
+-----BEGIN CERTIFICATE-----
+MIIDYzCCAkugAwIBAgIUJgpLRS4T2zhqWOyAiMxINIKOqAYwDQYJKoZIhvcNAQEL
+BQAwMjEOMAwGA1UEAwwFQWxpY2UxIDAeBgkqhkiG9w0BCQEWEWFsaWNlQGV4YW1w
+bGUuY29tMB4XDTI2MDkwMzA2MzkzNFoXDTM2MDgzMTA2MzkzNFowMjEOMAwGA1UE
+AwwFQWxpY2UxIDAeBgkqhkiG9w0BCQEWEWFsaWNlQGV4YW1wbGUuY29tMIIBIjAN
+BgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA6Fu+FpXUbwiFPazKuYsw6vzzcB6w
+Jqh2PsNhgi8qDI3G8E/nOsPtKFxeiBcEnq5mNGlt0pgtE36RCfpUw2GPyTClZnmH
+JxGUzm0h378vbv+JxTdD23iS//Xwp70RuVv4KhSQzarLSNLmygtbfzOfCdsDwcDB
+d9mCmYhXCSE2OaAAGMD9nLx/NtKCrGpiRnz1zWwGNMB6Ok+r9SvpWXgzjqDnWQ4b
+DcKJ5bKwJ80TY+J1koReRuwTvxQgPZ8Xih7Vbb+WIVcGKI5coOtbL+Sa/eTEElMR
+2V1ZTemxtdzJpRXOBadsZb34RDoT2rndaTesoyXGfon4nqMfd0fZC8lpSwIDAQAB
+o3EwbzAdBgNVHQ4EFgQUFi5fHJ4Ay52QpawzpIVkuoRag5IwHwYDVR0jBBgwFoAU
+Fi5fHJ4Ay52QpawzpIVkuoRag5IwDwYDVR0TAQH/BAUwAwEB/zAcBgNVHREEFTAT
+gRFhbGljZUBleGFtcGxlLmNvbTANBgkqhkiG9w0BAQsFAAOCAQEAL0ZppnhHoBqO
+dR19wa/E4OjvfSbZGG/r1JXClwJf727qT1thkcRvM79gwVsseSciDcEZ6N4AHBxS
+XnxDEM7zS6wkAUTrGmPglg33sHr/NcfJCw4ZARJQHfdfZ1MEe2paxqNsEbsMEGDj
+vh9Ypc583+UE1Aijd3P/ZawPc3W9DxZFc4JYskrfIc6oWmwkJDDESB2LjS3Nej6r
+PBzPep1HNvVAfxsAw+7Lhq+YFWHSBL1CdaK19D7U9+C9UGKshd3Zif1h7svA8o4o
+4Ifb8xdtde2X4bgZNymZ1exSel39a6sKheZ6zNk2wS0AyHRXyfgK7NRWg1cSQi3D
+sk6K0qOkEw==
+-----END CERTIFICATE-----`;
+
+/* The certificate of a correspondent who has an EC key. See signedMessages.ts */
+const kECCertificate = `-----BEGIN CERTIFICATE-----
+MIIB3TCCAYOgAwIBAgIUSt5QlwOZ5QNWuBcfFnoUzDIVBP4wCgYIKoZIzj0EAwIw
+NTERMA8GA1UEAwwIRUMgQWxpY2UxIDAeBgkqhkiG9w0BCQEWEWVjMjU2QGV4YW1w
+bGUuY29tMB4XDTI2MDkwMzA2MjcwNloXDTM2MDgzMTA2MjcwNlowNTERMA8GA1UE
+AwwIRUMgQWxpY2UxIDAeBgkqhkiG9w0BCQEWEWVjMjU2QGV4YW1wbGUuY29tMFkw
+EwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEOnaFMyGVQuhyzmE/5VGaj4LudsPFMY/R
+y2Y0n0d/9C3PniHLV+29ZIpl8a8DODBVP61w6O0Fgkta4TaLOFWlXaNxMG8wHQYD
+VR0OBBYEFG4bUTxKhpOlazlgeZ1CVDvW0byEMB8GA1UdIwQYMBaAFG4bUTxKhpOl
+azlgeZ1CVDvW0byEMA8GA1UdEwEB/wQFMAMBAf8wHAYDVR0RBBUwE4ERZWMyNTZA
+ZXhhbXBsZS5jb20wCgYIKoZIzj0EAwIDSAAwRQIhAILDqsn0T7n39WToJAxgbFo+
+lqKWt5faiS8BUJTxvnWyAiAq/SUgd10eYrzPGOuzQQRa/V4jYGPOAGQ8NnhZbA/F
+Vg==
+-----END CERTIFICATE-----`;
+
+describe("Encrypting to a recipient", () => {
+  test("says so, when their certificate is not RSA", async () => {
+    // nodemailer lives in the backend, so the tests cannot reach it
+    let { folder } = await setupTestFolder({
+      getMIMENodemailer: async () =>
+        new TextEncoder().encode("Content-Type: text/plain\r\n\r\nHello\r\n"),
+    });
+    let identity = new MailIdentity(folder.account);
+    identity.emailAddress = "alice@example.com";
+    identity.encryptionPrivateKeys.add(await SMIMEPrivateKey.importPrivateKey(kMyKeyAndCertificate, ""));
+    folder.account.identities.add(identity);
+
+    let mail = folder.newEMail();
+    mail.identity = identity;
+    mail.from = findOrCreatePersonUID("alice@example.com", "Alice");
+    let recipient = findOrCreatePersonUID("ec256@example.com", "EC Alice");
+    recipient.encryptionPublicKey = await SMIMEPublicKey.importPublicKey(kECCertificate);
+    mail.to.add(recipient);
+    mail.text = "Hello";
+    mail.shouldEncrypt = true;
+
+    await expect(SMIMESend.encryptAndSign(mail)).rejects.toThrow("ec256@example.com");
+  });
+});

--- a/app/test/logic/Mail/Encryption/SMIME/sendRecipientKey.test.ts
+++ b/app/test/logic/Mail/Encryption/SMIME/sendRecipientKey.test.ts
@@ -1,0 +1,98 @@
+// app first, to resolve the import cycle around Abstract/Account.ts
+import { appGlobal } from "../../../../../logic/app";
+import { MailIdentity } from "../../../../../logic/Mail/MailIdentity";
+import { SMIMEPrivateKey } from "../../../../../logic/Mail/Encryption/SMIME/SMIMEPrivateKey";
+import { SMIMESend } from "../../../../../logic/Mail/Encryption/SMIME/SMIMESend";
+import { findOrCreatePersonUID } from "../../../../../logic/Abstract/PersonUID";
+import { setupTestFolder } from "../../SQL/setup";
+import { expect, test } from "vitest";
+
+globalThis.window ??= globalThis as any; // `setCertificate()` digests with `window.crypto`
+
+test("Encrypting to a recipient whose key we do not have says so", async () => {
+  let { folder } = await setupTestFolder({
+    getMIMENodemailer: async () => new TextEncoder().encode(kMIME),
+  });
+  let identity = new MailIdentity(folder.account);
+  identity.emailAddress = "alice@example.com";
+  identity.realname = "Alice";
+  identity.encryptionPrivateKeys.add(await SMIMEPrivateKey.importPrivateKey(kPrivateKey + kCertificate));
+  folder.account.identities.add(identity);
+  appGlobal.emailAccounts.add(folder.account);
+
+  let mail = folder.newEMail();
+  mail.identity = identity;
+  mail.from = findOrCreatePersonUID("alice@example.com", "Alice");
+  mail.to.add(findOrCreatePersonUID("stranger@example.com", "Stranger")); // we have no key for him
+  mail.shouldEncrypt = true;
+
+  await expect(SMIMESend.encryptAndSign(mail)).rejects.toThrow("Cannot encrypt to all recipients using S/MIME");
+});
+
+const kMIME =
+  "From: Alice <alice@example.com>\r\n" +
+  "To: Stranger <stranger@example.com>\r\n" +
+  "Subject: Test\r\n" +
+  "MIME-Version: 1.0\r\n" +
+  "Content-Type: text/plain; charset=utf-8\r\n" +
+  "\r\n" +
+  "Hello\r\n";
+
+/* Test key, generated with:
+ * openssl req -x509 -newkey rsa:2048 -keyout alice.key -out alice.crt -days 7300 -nodes \
+ *   -subj "/CN=Alice/emailAddress=alice@example.com" \
+ *   -addext "subjectAltName=email:alice@example.com" */
+const kPrivateKey = `
+-----BEGIN PRIVATE KEY-----
+MIIEvAIBADANBgkqhkiG9w0BAQEFAASCBKYwggSiAgEAAoIBAQC8GDjZAmfuPgfI
+mLXT0U1zY55d4SNgfei2EmDy3aoWirbhdroZJRf6pUgKS4QsWaaiCmBazPL0ZIx3
+3Ovwmd8AvHlRJL5qEkZJ5YqZNoaC66DNZyKYOcsHSAMVWLlHs8hmYBwjdXO4yPP1
+HiAmCFKlb2iU/YX94OroycvotZtUmn9Is+kiqeDCz6x/HT061dgryzZaFTLkhKiU
+LxY9I3h7H6gRM1In6qbIuz29wbc7zaMnpk0PVClF/0PMyACSW+elFK92yRm1/1xt
+rbNZuEOVsooe4mS+N9OOGXEiRsFDem8N3U82GLNe2JGSrY30TNVFbU9miRDJiM45
+o+AmqjJtAgMBAAECggEAKydzg3Zl2ecpagB/VwWiO2MTpn5M24qHpZ451/67U0io
+BLp0n+g+xCa/jH0e6f33mR3AVZTH+QJIqAdrqlvjKgwT2WYQuc1Piwy668PywH7G
++dk7uqknx5fh/TfJ6oV46OQMEKaV0kNolUhAH/mw3HvfBq/T2heMTbResBladeJH
+l7Q40MZWFIjr8zKwdW4o/u8nHTQAInL6sygIbNjSUM9L5zUxyFnvJphd0MO8vQ4/
+dSP+9FZyW36/dod6fdWg/tqG4eR8FTcgCMOLzKbcXxz0Cc96Zlo1jwR+YLy69zqj
+eJJoKjaDT46ZH4wchPwKIBJ1NHYgjfspinc6XlShgQKBgQDm1kpudrxmtHHJINeT
+KBC3udaX/97+y2PnnFUINAEVHvcu/bIQY019mP5uGAXL6x/Dxy5qPECmZJGMD9fR
+Ai0QzPhJLPsJHPv8jH71PlNSEVO8+gPh4s5Mu1KArahSxRPAJnTn/+O4CaQbvzNi
+BndN/jrfej1I5C2DtoJccGUxKQKBgQDQmSp5kKH4RUZiYPOJp3Z+i49Qb63n/DL8
+Ysufwvd/Upigdx8JAwBT4NBq+Lm23Ld3ZMSjAZEdpWksLDyl+Ox1YVjYfYGNISo9
+fUhFj5npCeXuvW26iMrqb/4UQcLNxVZcTuSK9JP1to9d0TV0TdmhOTnWtY1qQI04
+B05hXIbLpQKBgGW7nXQPijqtXdRpT/i/2JZQJb45ezrJwo7pvCPwX2XCjue70UUd
+rqIi0kcM+UkEp6wt1UvmoAt1GRwkQ1YO4nOcEfSWCVDb4EZOWQmWXTw2/LO1cA6W
+WZtBlzu0zRElX+34RN+WS/Lo9NVxr6CM/vl1iNbC1c2RGmoI/mzk8AP5AoGAK/s/
+Y2ZFYE1q6685ahqu9zuBuhnx9unL7j7+Y+79tBC8MYksOAAz/3t1Nji/H3kmDbxn
+YV8hM7j+ldu15eC4Kn+d9fdwa0tE1rYlmNUQRHxbyJyUGDJjZk66qZa79hrXfJr9
+wPaUg8g8LjHALYeEjWO9eDHLYU2++MNBmXGi0ikCgYBaq27PGPRj6RYEJNLnoeSw
+CnYKDB4VzcJVj9bDxKINRiPXS+0E6S+XhgrE126Wqw4owfD+RG8DQh8NxCAy5vRb
+OkdM7w7vwV714p8VRLLnv0FQgiFZ37uT86oE5mg5Qs0SaVBpY39An5+Qt5GNsg4P
+KQK8lDMUEtGQEuon2mcYaA==
+-----END PRIVATE KEY-----
+`;
+
+const kCertificate = `
+-----BEGIN CERTIFICATE-----
+MIIDYzCCAkugAwIBAgIUXyuXUq+uBb5HoD/SwKsNkTrasvAwDQYJKoZIhvcNAQEL
+BQAwMjEOMAwGA1UEAwwFQWxpY2UxIDAeBgkqhkiG9w0BCQEWEWFsaWNlQGV4YW1w
+bGUuY29tMB4XDTI2MDkwMzA2MjAxNVoXDTQ2MDgyOTA2MjAxNVowMjEOMAwGA1UE
+AwwFQWxpY2UxIDAeBgkqhkiG9w0BCQEWEWFsaWNlQGV4YW1wbGUuY29tMIIBIjAN
+BgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAvBg42QJn7j4HyJi109FNc2OeXeEj
+YH3othJg8t2qFoq24Xa6GSUX+qVICkuELFmmogpgWszy9GSMd9zr8JnfALx5USS+
+ahJGSeWKmTaGguugzWcimDnLB0gDFVi5R7PIZmAcI3VzuMjz9R4gJghSpW9olP2F
+/eDq6MnL6LWbVJp/SLPpIqngws+sfx09OtXYK8s2WhUy5ISolC8WPSN4ex+oETNS
+J+qmyLs9vcG3O82jJ6ZND1QpRf9DzMgAklvnpRSvdskZtf9cba2zWbhDlbKKHuJk
+vjfTjhlxIkbBQ3pvDd1PNhizXtiRkq2N9EzVRW1PZokQyYjOOaPgJqoybQIDAQAB
+o3EwbzAdBgNVHQ4EFgQUF0F17SK7ICCjTydpJIr7I/DvBG4wHwYDVR0jBBgwFoAU
+F0F17SK7ICCjTydpJIr7I/DvBG4wDwYDVR0TAQH/BAUwAwEB/zAcBgNVHREEFTAT
+gRFhbGljZUBleGFtcGxlLmNvbTANBgkqhkiG9w0BAQsFAAOCAQEAWnSpEFF0ULep
+QpYTbOb2HcBL22IofcWyMlrN9RP0uPww9Nt6ZARZVWk8nIQrxgmHqD7C+I1RGXix
+SR9kQ+0zsCbiO5gGBhnO2T+emaAK58uw4a9mfHBAAACv4XhPX70kBEuDJJmZiE0x
+dCXBbvH4u/dvkqQCzCO4co6YKmhyyX2KeU0fzGdiNkTmcuMk7XOTMiTefQHpLkJv
+dAXfOIEh+HG8jMkDozoFf18/cHb0YfXsFhkgx16xsFU04iWHkG0KmYgugxu4nSKe
+bPcN5G0J3+GPy+ab/uhNFsL/HU6veJhZ/lSomdl47V8VtnrUKZkWi82FDJ1VWKN+
+h/EjNKGJQg==
+-----END CERTIFICATE-----
+`;

--- a/app/test/logic/Mail/Encryption/SMIME/signedMessages.ts
+++ b/app/test/logic/Mail/Encryption/SMIME/signedMessages.ts
@@ -232,3 +232,159 @@ XFo+Kq4MhISmx2bscNFVWM6A3eKUs1UhTnnAsTPIG/EbHrQ/vQHq6HAKtwHwyDDj
 ZikM+dvZ81aszPh+10RuwIX8N8bNIrPvCslMy1G0DwRPObDzYlbxJrwGJl3cIsE=
 
 ------72D4E9ED7779F5B28FF1B7EC321EEE7F--`;
+
+/* Clear-signed with an EC certificate, as Thunderbird and Apple Mail sign
+ * when the user's key is on a NIST curve, and as many European CAs issue.
+ * One message per curve, each with the hash that goes with it:
+ * openssl ecparam -name prime256v1 -genkey -noout -out ec256.key
+ * openssl req -x509 -key ec256.key -sha256 -days 3650 -out ec256.crt \
+ *   -subj "/CN=EC Alice/emailAddress=ec256@example.com" \
+ *   -addext "subjectAltName=email:ec256@example.com"
+ * printf 'Content-Type: text/plain; charset=utf-8\n\nHello, this is signed.' > body.txt
+ * openssl cms -sign -signer ec256.crt -inkey ec256.key -md sha256 \
+ *   -in body.txt -outform SMIME
+ * The other two use -name secp384r1 with -sha384/-md sha384,
+ * and -name secp521r1 with -sha512/-md sha512. */
+
+/** ECDSA on P-256, with SHA-256 */
+export const kECClearSigned256 = `From: EC Alice <ec256@example.com>
+To: User <user@example.com>
+Subject: Signed test
+Date: Tue, 14 Jul 2026 10:00:00 +0000
+Message-ID: <sig-ec256@example.com>
+MIME-Version: 1.0
+Content-Type: multipart/signed; protocol="application/pkcs7-signature"; micalg="sha-256"; boundary="----60FAF574DFE81B5AAEE8865E94E6AD85"
+
+This is an S/MIME signed message
+
+------60FAF574DFE81B5AAEE8865E94E6AD85
+Content-Type: text/plain; charset=utf-8
+
+Hello, this is signed.
+------60FAF574DFE81B5AAEE8865E94E6AD85
+Content-Type: application/pkcs7-signature; name="smime.p7s"
+Content-Transfer-Encoding: base64
+Content-Disposition: attachment; filename="smime.p7s"
+
+MIIDugYJKoZIhvcNAQcCoIIDqzCCA6cCAQExDTALBglghkgBZQMEAgEwCwYJKoZI
+hvcNAQcBoIIB4TCCAd0wggGDoAMCAQICFEreUJcDmeUDVrgXHxZ6FMwyFQT+MAoG
+CCqGSM49BAMCMDUxETAPBgNVBAMMCEVDIEFsaWNlMSAwHgYJKoZIhvcNAQkBFhFl
+YzI1NkBleGFtcGxlLmNvbTAeFw0yNjA5MDMwNjI3MDZaFw0zNjA4MzEwNjI3MDZa
+MDUxETAPBgNVBAMMCEVDIEFsaWNlMSAwHgYJKoZIhvcNAQkBFhFlYzI1NkBleGFt
+cGxlLmNvbTBZMBMGByqGSM49AgEGCCqGSM49AwEHA0IABDp2hTMhlULocs5hP+VR
+mo+C7nbDxTGP0ctmNJ9Hf/Qtz54hy1ftvWSKZfGvAzgwVT+tcOjtBYJLWuE2izhV
+pV2jcTBvMB0GA1UdDgQWBBRuG1E8SoaTpWs5YHmdQlQ71tG8hDAfBgNVHSMEGDAW
+gBRuG1E8SoaTpWs5YHmdQlQ71tG8hDAPBgNVHRMBAf8EBTADAQH/MBwGA1UdEQQV
+MBOBEWVjMjU2QGV4YW1wbGUuY29tMAoGCCqGSM49BAMCA0gAMEUCIQCCw6rJ9E+5
+9/Vk6CQMYGxaPpailreX2okvAVCU8b51sgIgKv0lIHddHmK8zxjrs0EEWv1eI2Bj
+zgBkPDZ4WWwPxVYxggGfMIIBmwIBATBNMDUxETAPBgNVBAMMCEVDIEFsaWNlMSAw
+HgYJKoZIhvcNAQkBFhFlYzI1NkBleGFtcGxlLmNvbQIUSt5QlwOZ5QNWuBcfFnoU
+zDIVBP4wCwYJYIZIAWUDBAIBoIHkMBgGCSqGSIb3DQEJAzELBgkqhkiG9w0BBwEw
+HAYJKoZIhvcNAQkFMQ8XDTI2MDkwMzA2MjcwN1owLwYJKoZIhvcNAQkEMSIEINoX
+U0VI6VFWlk73pplSr5kR1/uHPr8UIz3oO6+QsHDDMHkGCSqGSIb3DQEJDzFsMGow
+CwYJYIZIAWUDBAEqMAsGCWCGSAFlAwQBFjALBglghkgBZQMEAQIwCgYIKoZIhvcN
+AwcwDgYIKoZIhvcNAwICAgCAMA0GCCqGSIb3DQMCAgFAMAcGBSsOAwIHMA0GCCqG
+SIb3DQMCAgEoMAoGCCqGSM49BAMCBEcwRQIhAIDyNN/JlvRTvJZh9yJJ/KaRaDOF
+q+YEfluAH6euDc/BAiBC9UEq+sz+DoWsZchYFN60MOhw4vXP72mfuuOeDHaSEQ==
+
+------60FAF574DFE81B5AAEE8865E94E6AD85--
+
+`;
+
+/** ECDSA on P-384, with SHA-384 */
+export const kECClearSigned384 = `From: EC Alice <ec384@example.com>
+To: User <user@example.com>
+Subject: Signed test
+Date: Tue, 14 Jul 2026 10:00:00 +0000
+Message-ID: <sig-ec384@example.com>
+MIME-Version: 1.0
+Content-Type: multipart/signed; protocol="application/pkcs7-signature"; micalg="sha-384"; boundary="----25E51055B53B71BB24C715CC4466A099"
+
+This is an S/MIME signed message
+
+------25E51055B53B71BB24C715CC4466A099
+Content-Type: text/plain; charset=utf-8
+
+Hello, this is signed.
+------25E51055B53B71BB24C715CC4466A099
+Content-Type: application/pkcs7-signature; name="smime.p7s"
+Content-Transfer-Encoding: base64
+Content-Disposition: attachment; filename="smime.p7s"
+
+MIIEKAYJKoZIhvcNAQcCoIIEGTCCBBUCAQExDTALBglghkgBZQMEAgIwCwYJKoZI
+hvcNAQcBoIICHjCCAhowggGgoAMCAQICFBztuvaZR4Hhf1N78JpFG7o/qUiCMAoG
+CCqGSM49BAMDMDUxETAPBgNVBAMMCEVDIEFsaWNlMSAwHgYJKoZIhvcNAQkBFhFl
+YzM4NEBleGFtcGxlLmNvbTAeFw0yNjA5MDMwNjI3MDZaFw0zNjA4MzEwNjI3MDZa
+MDUxETAPBgNVBAMMCEVDIEFsaWNlMSAwHgYJKoZIhvcNAQkBFhFlYzM4NEBleGFt
+cGxlLmNvbTB2MBAGByqGSM49AgEGBSuBBAAiA2IABAqzRCFv9cPCl9mNFvoj53Vd
+AeTpWZ068vnamuqLGPxVy1NI2eEn5K8+syU4LAu/wQNxpfMwdhnM2JwyJqAYgv/d
+WW40KrX0diynyflRSwILtjFuf+mQMc99N4L3p6HYzqNxMG8wHQYDVR0OBBYEFALX
+shbusFFTuBXeI7plX7IJQSp/MB8GA1UdIwQYMBaAFALXshbusFFTuBXeI7plX7IJ
+QSp/MA8GA1UdEwEB/wQFMAMBAf8wHAYDVR0RBBUwE4ERZWMzODRAZXhhbXBsZS5j
+b20wCgYIKoZIzj0EAwMDaAAwZQIxAIUDKWmRQ27iTp6AKQVCoEWUQZXo6LAHDjDM
+vFAGzKqAypuBBPxhZeiEs3HAJggeEAIwRKVNFWMmx8dtmBKl8n2dL+QKU2v4qdVy
+9J776wiQiZ5gv2xpDnHY3UyNwNWRmgwtMYIB0DCCAcwCAQEwTTA1MREwDwYDVQQD
+DAhFQyBBbGljZTEgMB4GCSqGSIb3DQEJARYRZWMzODRAZXhhbXBsZS5jb20CFBzt
+uvaZR4Hhf1N78JpFG7o/qUiCMAsGCWCGSAFlAwQCAqCB9DAYBgkqhkiG9w0BCQMx
+CwYJKoZIhvcNAQcBMBwGCSqGSIb3DQEJBTEPFw0yNjA5MDMwNjI3MDdaMD8GCSqG
+SIb3DQEJBDEyBDDptjzglRziurbIV5C6jbHU48uyR4JfjSKrxRd2z/ixd7qf4dHN
+Pzn7700jSco/PtYweQYJKoZIhvcNAQkPMWwwajALBglghkgBZQMEASowCwYJYIZI
+AWUDBAEWMAsGCWCGSAFlAwQBAjAKBggqhkiG9w0DBzAOBggqhkiG9w0DAgICAIAw
+DQYIKoZIhvcNAwICAUAwBwYFKw4DAgcwDQYIKoZIhvcNAwICASgwCgYIKoZIzj0E
+AwMEaDBmAjEAyZjQY1GZ/jgyNiANfUFIdfFfyqq0+6qFj5XUW/F6ksx5a5j51SBC
+t5madqRJyVpTAjEAjLXZcIsz+FvzpVNqo5SRHk1VIIDygjWVxV6ytWGBe3JRInIP
+XwdKGUdkGCL08J3e
+
+------25E51055B53B71BB24C715CC4466A099--
+
+`;
+
+/** ECDSA on P-521, with SHA-512 */
+export const kECClearSigned521 = `From: EC Alice <ec521@example.com>
+To: User <user@example.com>
+Subject: Signed test
+Date: Tue, 14 Jul 2026 10:00:00 +0000
+Message-ID: <sig-ec521@example.com>
+MIME-Version: 1.0
+Content-Type: multipart/signed; protocol="application/pkcs7-signature"; micalg="sha-512"; boundary="----3BE2B724EE772B743C71A2505ED03F5B"
+
+This is an S/MIME signed message
+
+------3BE2B724EE772B743C71A2505ED03F5B
+Content-Type: text/plain; charset=utf-8
+
+Hello, this is signed.
+------3BE2B724EE772B743C71A2505ED03F5B
+Content-Type: application/pkcs7-signature; name="smime.p7s"
+Content-Transfer-Encoding: base64
+Content-Disposition: attachment; filename="smime.p7s"
+
+MIIEpgYJKoZIhvcNAQcCoIIElzCCBJMCAQExDTALBglghkgBZQMEAgMwCwYJKoZI
+hvcNAQcBoIICaDCCAmQwggHGoAMCAQICFCKUt3ew41m6JYWhnY6mSHOOymlNMAoG
+CCqGSM49BAMEMDUxETAPBgNVBAMMCEVDIEFsaWNlMSAwHgYJKoZIhvcNAQkBFhFl
+YzUyMUBleGFtcGxlLmNvbTAeFw0yNjA5MDMwNjI3MDZaFw0zNjA4MzEwNjI3MDZa
+MDUxETAPBgNVBAMMCEVDIEFsaWNlMSAwHgYJKoZIhvcNAQkBFhFlYzUyMUBleGFt
+cGxlLmNvbTCBmzAQBgcqhkjOPQIBBgUrgQQAIwOBhgAEALla9Jb+8BKJjIJqGTl1
+SUcVv4XAmmjwA67VTIvnl9VHYN3kFEyVpwGKegMPonTtlSwjRiyfVw4A+hGFadMp
+662qAG2E1eVMZw2k20H8THCJd+MUZSua2YhwIufO7wsJ4G0ZE53bdsLWMZePfmoN
+RmTMenQQNVDox/JLaj0qQvwLa747o3EwbzAdBgNVHQ4EFgQUVncAOXc7fusE0e/K
+OP4XfSdSzmAwHwYDVR0jBBgwFoAUVncAOXc7fusE0e/KOP4XfSdSzmAwDwYDVR0T
+AQH/BAUwAwEB/zAcBgNVHREEFTATgRFlYzUyMUBleGFtcGxlLmNvbTAKBggqhkjO
+PQQDBAOBiwAwgYcCQXV4EcmKSh0jSVg9dAQ7Z6mECXBSj4A7CASXGlg17tB73md9
+Ms27SgXgcCTcPdfgES2FDXH+ayi2RyugMFAlhD95AkIBxEkozmh6WpH2kdwqks8q
+WO0678vMCXwiNC4hL1FXt48mXy62zcVyVPwLDrVwuOnL4ulPZ5l8BL6t6omzqCpr
+XjoxggIEMIICAAIBATBNMDUxETAPBgNVBAMMCEVDIEFsaWNlMSAwHgYJKoZIhvcN
+AQkBFhFlYzUyMUBleGFtcGxlLmNvbQIUIpS3d7DjWbolhaGdjqZIc47KaU0wCwYJ
+YIZIAWUDBAIDoIIBBDAYBgkqhkiG9w0BCQMxCwYJKoZIhvcNAQcBMBwGCSqGSIb3
+DQEJBTEPFw0yNjA5MDMwNjI3MDdaME8GCSqGSIb3DQEJBDFCBECZJ9CANovdf0xk
+DmXviA+izhxNFRY/JV/vE0JhoIMxoB38tnO5zgyRx7nrGHJLQUB0zh690vfaqoiI
+PyawAO73MHkGCSqGSIb3DQEJDzFsMGowCwYJYIZIAWUDBAEqMAsGCWCGSAFlAwQB
+FjALBglghkgBZQMEAQIwCgYIKoZIhvcNAwcwDgYIKoZIhvcNAwICAgCAMA0GCCqG
+SIb3DQMCAgFAMAcGBSsOAwIHMA0GCCqGSIb3DQMCAgEoMAoGCCqGSM49BAMEBIGK
+MIGHAkEBTvz/Jfm3uILTxp/g3BrtfggffFIHhbKVG6K82bGhQH8KunZfmayeRzUj
+y+MjMf9g1ttttnHQe906JxHk2uGRTQJCARcny51C1uc8vMFJuno+++NQrdc3Ecou
+hmvW9DdKzC0ATulo6GPcJmurI+EWRrzV1GTGOPU8b99Mc/4DvZxX/yCC
+
+------3BE2B724EE772B743C71A2505ED03F5B--
+
+`;

--- a/app/test/logic/Mail/Encryption/SMIME/signedMessages.ts
+++ b/app/test/logic/Mail/Encryption/SMIME/signedMessages.ts
@@ -170,3 +170,65 @@ OnfjFum6XxRrfLktYt8qmkFD/ZN4JVLcKlIft1zlZM1HZ69bUJ4wwRceFRBnlBk/
 QxETfQXeq9VhSoBhtmy68UOkroqbu/jawehgvWiI5qQqVJ9OZJIBupOgARO4UFfW
 yD6/Z6pMwfCgw1sAA6nsHryvEv9paPdHJEGNePqE+RXqJ1gSAUUgp7y1085LzeU=
 ------LF74A9C1D0E5B34F2A9C8E1D6B3A5F7E20--`;
+
+/**
+ * The signature part with the generic file type that Microsoft uses and
+ * that gateways rewrite to. MS-OXOSMIME section 2.2.1
+ * `openssl cms -sign -in part.txt -signer alice.crt -inkey alice.key
+ *   -outform SMIME -md sha256`, with the Content-Type of the signature
+ * part replaced by `application/octet-stream; name="smime.p7s"`.
+ */
+export const kClearSignedOctetStream = `From: Alice <alice@example.com>
+To: User <user@example.com>
+Subject: Signed, signature delivered as a file
+Date: Tue, 14 Jul 2026 10:00:00 +0000
+Message-ID: <sig-octet@example.com>
+MIME-Version: 1.0
+Content-Type: multipart/signed; protocol="application/pkcs7-signature"; micalg="sha-256"; boundary="----72D4E9ED7779F5B28FF1B7EC321EEE7F"
+
+This is an S/MIME signed message
+
+------72D4E9ED7779F5B28FF1B7EC321EEE7F
+Content-Type: text/plain; charset=utf-8
+
+Hello, this is signed.
+
+------72D4E9ED7779F5B28FF1B7EC321EEE7F
+Content-Type: application/octet-stream; name="smime.p7s"
+Content-Transfer-Encoding: base64
+Content-Disposition: attachment; filename="smime.p7s"
+
+MIIF+wYJKoZIhvcNAQcCoIIF7DCCBegCAQExDTALBglghkgBZQMEAgEwCwYJKoZI
+hvcNAQcBoIIDZzCCA2MwggJLoAMCAQICFCU93aAAPLxS6p8XXbZN1DUiDMjCMA0G
+CSqGSIb3DQEBCwUAMDIxDjAMBgNVBAMMBUFsaWNlMSAwHgYJKoZIhvcNAQkBFhFh
+bGljZUBleGFtcGxlLmNvbTAeFw0yNjA5MDMwNjMwMTRaFw0zNjA4MzEwNjMwMTRa
+MDIxDjAMBgNVBAMMBUFsaWNlMSAwHgYJKoZIhvcNAQkBFhFhbGljZUBleGFtcGxl
+LmNvbTCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAMy4QL8/QVloRTcr
+DDa9419gY2s2DSzqmjKJovYqt4ht2zcA5O81JDnp5XyOkkMm9AMTvtwNezsT1b9K
++oNgVRsTSu6FYgYtY0lwP+q/p6WI6532/ME3psvQz2x2qFOe0+r2GN+u1cHU7IP5
+yxhhxXPjppRgLz4aCH113so69kE3uOqwBBVPar00Zu7Yuk+HjMwwPTGgKRVZzOQu
+U/E8+S/bEdLD51hr4QU0I7Eq6zTxnrmK3Zk6n9LojPiyjP+XU7SJH29YTN0GBVTO
+ADHWh+zQ2XYS24AKJiva30MNnDdem3Lefg5WG/CKagKQM+Y4mwTLwslNYmRFtof1
+DWOSjDcCAwEAAaNxMG8wHQYDVR0OBBYEFAnxFxy0bwgmpgbktYu8/b6z1qRqMB8G
+A1UdIwQYMBaAFAnxFxy0bwgmpgbktYu8/b6z1qRqMA8GA1UdEwEB/wQFMAMBAf8w
+HAYDVR0RBBUwE4ERYWxpY2VAZXhhbXBsZS5jb20wDQYJKoZIhvcNAQELBQADggEB
+AKTiUpNzRRSUJ0RGGwkfwDyPu+8WSLGfdtFYE/vnOAbTVi03P4kbsSJQBdpcpcI+
+qzPkrAyMThaqy3Dj2rOazOk3Z90dFeV3IeLlgKdBSm0y2tu6hUSKh0bIR6vLp/xE
+2LorhgeGD/PMQVHfDmbbuQyFP6CHz3RhrADxnmDxTF3ALvXS24iZf8QF6OvBIlTo
+njNrscq9sYHCBjn5d/9PCbme2QQDYb35iy/GWbsxnGey9S5fUU+cqTSxJ/nI9Ss4
+ADcNsK6+rWffx1cBYO5SwHa29B/tqoKeLOBql3Z3kUgdxELFDhpvexGTG5uZLQdA
+ZIs05CGB5xbcYYPi/yT6cyYxggJaMIICVgIBATBKMDIxDjAMBgNVBAMMBUFsaWNl
+MSAwHgYJKoZIhvcNAQkBFhFhbGljZUBleGFtcGxlLmNvbQIUJT3doAA8vFLqnxdd
+tk3UNSIMyMIwCwYJYIZIAWUDBAIBoIHkMBgGCSqGSIb3DQEJAzELBgkqhkiG9w0B
+BwEwHAYJKoZIhvcNAQkFMQ8XDTI2MDkwMzA2NDMyMFowLwYJKoZIhvcNAQkEMSIE
+IFDNpJq6fVaV5/0csq6FLnHxb9pDv3/jCVY6ZB3dmRK4MHkGCSqGSIb3DQEJDzFs
+MGowCwYJYIZIAWUDBAEqMAsGCWCGSAFlAwQBFjALBglghkgBZQMEAQIwCgYIKoZI
+hvcNAwcwDgYIKoZIhvcNAwICAgCAMA0GCCqGSIb3DQMCAgFAMAcGBSsOAwIHMA0G
+CCqGSIb3DQMCAgEoMA0GCSqGSIb3DQEBAQUABIIBACgofjVjj2GCaFCqHpExBBtE
+WT54IYoPCouuLErOWuEIk+Fx1wA4HIMlRkS6qQL1sJ4sVLRzU3MYW4c+h+W4gy3D
+RgiNX0Sfhlnfn7Qr62VzaBjRqrw5HuFHi0jBUtcJnwiy2r+IHIoatV9vvIOGsE8I
+rkgAkC/L9OcYqXe2Cl0e6plzReyklKZN5oIpb/dKo8Hk1cxkXeqtiZ5qZvFfwz+k
+XFo+Kq4MhISmx2bscNFVWM6A3eKUs1UhTnnAsTPIG/EbHrQ/vQHq6HAKtwHwyDDj
+ZikM+dvZ81aszPh+10RuwIX8N8bNIrPvCslMy1G0DwRPObDzYlbxJrwGJl3cIsE=
+
+------72D4E9ED7779F5B28FF1B7EC321EEE7F--`;

--- a/app/test/logic/Mail/Encryption/SMIME/signedMessages.ts
+++ b/app/test/logic/Mail/Encryption/SMIME/signedMessages.ts
@@ -1,13 +1,14 @@
 /**
  * `openssl smime -sign`, self-signed certificate for alice@example.com.
  * Stored with LF, but S/MIME digests the signed part with CRLF.
+ * `Date:` is the signing time in the signature, which the verifier compares.
  */
 
 /** Detached signature */
 export const kClearSigned = `From: Alice <alice@example.com>
 To: User <user@example.com>
 Subject: Signed test
-Date: Tue, 14 Jul 2026 10:00:00 +0000
+Date: Mon, 31 Aug 2026 20:20:12 +0000
 Message-ID: <sig-clearsigned@example.com>
 MIME-Version: 1.0
 Content-Type: multipart/signed; protocol="application/x-pkcs7-signature"; micalg="sha-256"; boundary="----3120AE5FA6844B38B313D9FF5848BBF0"
@@ -66,7 +67,7 @@ T1ku
 export const kOpaqueSigned = `From: Alice <alice@example.com>
 To: User <user@example.com>
 Subject: Signed test
-Date: Tue, 14 Jul 2026 10:00:00 +0000
+Date: Mon, 31 Aug 2026 20:20:12 +0000
 Message-ID: <sig-opaque@example.com>
 MIME-Version: 1.0
 Content-Disposition: attachment; filename="smime.p7m"
@@ -121,7 +122,7 @@ Cla1Ekw+ndF8WJpMPM8UDMtACYQ/yYxPWS4=
 export const kClearSignedLF = `From: Alice <alice@example.com>
 To: User <user@example.com>
 Subject: Signed with LF line endings
-Date: Tue, 14 Jul 2026 10:00:00 +0000
+Date: Thu, 03 Sep 2026 06:30:14 +0000
 Message-ID: <sig-lf@example.com>
 MIME-Version: 1.0
 Content-Type: multipart/signed; protocol="application/pkcs7-signature"; micalg="sha-256"; boundary="----LF74A9C1D0E5B34F2A9C8E1D6B3A5F7E20"
@@ -181,7 +182,7 @@ yD6/Z6pMwfCgw1sAA6nsHryvEv9paPdHJEGNePqE+RXqJ1gSAUUgp7y1085LzeU=
 export const kClearSignedOctetStream = `From: Alice <alice@example.com>
 To: User <user@example.com>
 Subject: Signed, signature delivered as a file
-Date: Tue, 14 Jul 2026 10:00:00 +0000
+Date: Thu, 03 Sep 2026 06:43:20 +0000
 Message-ID: <sig-octet@example.com>
 MIME-Version: 1.0
 Content-Type: multipart/signed; protocol="application/pkcs7-signature"; micalg="sha-256"; boundary="----72D4E9ED7779F5B28FF1B7EC321EEE7F"
@@ -250,7 +251,7 @@ ZikM+dvZ81aszPh+10RuwIX8N8bNIrPvCslMy1G0DwRPObDzYlbxJrwGJl3cIsE=
 export const kECClearSigned256 = `From: EC Alice <ec256@example.com>
 To: User <user@example.com>
 Subject: Signed test
-Date: Tue, 14 Jul 2026 10:00:00 +0000
+Date: Thu, 03 Sep 2026 06:27:07 +0000
 Message-ID: <sig-ec256@example.com>
 MIME-Version: 1.0
 Content-Type: multipart/signed; protocol="application/pkcs7-signature"; micalg="sha-256"; boundary="----60FAF574DFE81B5AAEE8865E94E6AD85"
@@ -295,7 +296,7 @@ q+YEfluAH6euDc/BAiBC9UEq+sz+DoWsZchYFN60MOhw4vXP72mfuuOeDHaSEQ==
 export const kECClearSigned384 = `From: EC Alice <ec384@example.com>
 To: User <user@example.com>
 Subject: Signed test
-Date: Tue, 14 Jul 2026 10:00:00 +0000
+Date: Thu, 03 Sep 2026 06:27:07 +0000
 Message-ID: <sig-ec384@example.com>
 MIME-Version: 1.0
 Content-Type: multipart/signed; protocol="application/pkcs7-signature"; micalg="sha-384"; boundary="----25E51055B53B71BB24C715CC4466A099"
@@ -343,7 +344,7 @@ XwdKGUdkGCL08J3e
 export const kECClearSigned521 = `From: EC Alice <ec521@example.com>
 To: User <user@example.com>
 Subject: Signed test
-Date: Tue, 14 Jul 2026 10:00:00 +0000
+Date: Thu, 03 Sep 2026 06:27:07 +0000
 Message-ID: <sig-ec521@example.com>
 MIME-Version: 1.0
 Content-Type: multipart/signed; protocol="application/pkcs7-signature"; micalg="sha-512"; boundary="----3BE2B724EE772B743C71A2505ED03F5B"

--- a/app/test/logic/Mail/Encryption/SMIME/signedMessages.ts
+++ b/app/test/logic/Mail/Encryption/SMIME/signedMessages.ts
@@ -109,3 +109,64 @@ XRpmQu5NpqERE1Vyw0YIc0uaolRAE/oCOusg74n6LU1jCHrQkUd3v/rtbn0JBuji
 Cla1Ekw+ndF8WJpMPM8UDMtACYQ/yYxPWS4=
 
 `;
+
+/**
+ * Bare LF line endings, inside and out, as NSS writes them: the signature
+ * is over the LF bytes of the signed part, so the reader must not convert
+ * them. Thunderbird's own test messages look like this.
+ * `openssl cms -sign -binary -in part.txt -signer alice.crt -inkey alice.key
+ *   -outform DER`, where `part.txt` is the text/plain part below,
+ * with LF endings and without a trailing newline.
+ */
+export const kClearSignedLF = `From: Alice <alice@example.com>
+To: User <user@example.com>
+Subject: Signed with LF line endings
+Date: Tue, 14 Jul 2026 10:00:00 +0000
+Message-ID: <sig-lf@example.com>
+MIME-Version: 1.0
+Content-Type: multipart/signed; protocol="application/pkcs7-signature"; micalg="sha-256"; boundary="----LF74A9C1D0E5B34F2A9C8E1D6B3A5F7E20"
+
+This is an S/MIME signed message
+
+------LF74A9C1D0E5B34F2A9C8E1D6B3A5F7E20
+Content-Type: text/plain; charset=utf-8
+
+Hello, this is signed.
+------LF74A9C1D0E5B34F2A9C8E1D6B3A5F7E20
+Content-Type: application/pkcs7-signature; name="smime.p7s"
+Content-Transfer-Encoding: base64
+Content-Disposition: attachment; filename="smime.p7s"
+
+MIIF+wYJKoZIhvcNAQcCoIIF7DCCBegCAQExDTALBglghkgBZQMEAgEwCwYJKoZI
+hvcNAQcBoIIDZzCCA2MwggJLoAMCAQICFCU93aAAPLxS6p8XXbZN1DUiDMjCMA0G
+CSqGSIb3DQEBCwUAMDIxDjAMBgNVBAMMBUFsaWNlMSAwHgYJKoZIhvcNAQkBFhFh
+bGljZUBleGFtcGxlLmNvbTAeFw0yNjA5MDMwNjMwMTRaFw0zNjA4MzEwNjMwMTRa
+MDIxDjAMBgNVBAMMBUFsaWNlMSAwHgYJKoZIhvcNAQkBFhFhbGljZUBleGFtcGxl
+LmNvbTCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAMy4QL8/QVloRTcr
+DDa9419gY2s2DSzqmjKJovYqt4ht2zcA5O81JDnp5XyOkkMm9AMTvtwNezsT1b9K
++oNgVRsTSu6FYgYtY0lwP+q/p6WI6532/ME3psvQz2x2qFOe0+r2GN+u1cHU7IP5
+yxhhxXPjppRgLz4aCH113so69kE3uOqwBBVPar00Zu7Yuk+HjMwwPTGgKRVZzOQu
+U/E8+S/bEdLD51hr4QU0I7Eq6zTxnrmK3Zk6n9LojPiyjP+XU7SJH29YTN0GBVTO
+ADHWh+zQ2XYS24AKJiva30MNnDdem3Lefg5WG/CKagKQM+Y4mwTLwslNYmRFtof1
+DWOSjDcCAwEAAaNxMG8wHQYDVR0OBBYEFAnxFxy0bwgmpgbktYu8/b6z1qRqMB8G
+A1UdIwQYMBaAFAnxFxy0bwgmpgbktYu8/b6z1qRqMA8GA1UdEwEB/wQFMAMBAf8w
+HAYDVR0RBBUwE4ERYWxpY2VAZXhhbXBsZS5jb20wDQYJKoZIhvcNAQELBQADggEB
+AKTiUpNzRRSUJ0RGGwkfwDyPu+8WSLGfdtFYE/vnOAbTVi03P4kbsSJQBdpcpcI+
+qzPkrAyMThaqy3Dj2rOazOk3Z90dFeV3IeLlgKdBSm0y2tu6hUSKh0bIR6vLp/xE
+2LorhgeGD/PMQVHfDmbbuQyFP6CHz3RhrADxnmDxTF3ALvXS24iZf8QF6OvBIlTo
+njNrscq9sYHCBjn5d/9PCbme2QQDYb35iy/GWbsxnGey9S5fUU+cqTSxJ/nI9Ss4
+ADcNsK6+rWffx1cBYO5SwHa29B/tqoKeLOBql3Z3kUgdxELFDhpvexGTG5uZLQdA
+ZIs05CGB5xbcYYPi/yT6cyYxggJaMIICVgIBATBKMDIxDjAMBgNVBAMMBUFsaWNl
+MSAwHgYJKoZIhvcNAQkBFhFhbGljZUBleGFtcGxlLmNvbQIUJT3doAA8vFLqnxdd
+tk3UNSIMyMIwCwYJYIZIAWUDBAIBoIHkMBgGCSqGSIb3DQEJAzELBgkqhkiG9w0B
+BwEwHAYJKoZIhvcNAQkFMQ8XDTI2MDkwMzA2MzAxNFowLwYJKoZIhvcNAQkEMSIE
+ID9tc/N+DcUR8DtJXm53QX7ZgJigHNsYLlBOMfIJTuWPMHkGCSqGSIb3DQEJDzFs
+MGowCwYJYIZIAWUDBAEqMAsGCWCGSAFlAwQBFjALBglghkgBZQMEAQIwCgYIKoZI
+hvcNAwcwDgYIKoZIhvcNAwICAgCAMA0GCCqGSIb3DQMCAgFAMAcGBSsOAwIHMA0G
+CCqGSIb3DQMCAgEoMA0GCSqGSIb3DQEBAQUABIIBAKKermX8wo3bU5h1RfHWzuy+
+gOvbm/7sm3k0vUSkuf86QNKF+5pMTZoHGKvy8kmGR6/lAV6Gh5hw6IgfO63A+Wqp
+3mXLxrrHWo6i/Qjx9ogkeSAwCcZqOhp5nzjF1UTURahvLi1HesryIFrqv0NFmo4A
+OnfjFum6XxRrfLktYt8qmkFD/ZN4JVLcKlIft1zlZM1HZ69bUJ4wwRceFRBnlBk/
+QxETfQXeq9VhSoBhtmy68UOkroqbu/jawehgvWiI5qQqVJ9OZJIBupOgARO4UFfW
+yD6/Z6pMwfCgw1sAA6nsHryvEv9paPdHJEGNePqE+RXqJ1gSAUUgp7y1085LzeU=
+------LF74A9C1D0E5B34F2A9C8E1D6B3A5F7E20--`;

--- a/app/test/logic/Mail/Encryption/SMIME/verifySigner.test.ts
+++ b/app/test/logic/Mail/Encryption/SMIME/verifySigner.test.ts
@@ -44,7 +44,7 @@ async function signedAttributes(): Promise<any[]> {
     attrValue: [Oid.encode("data")],
   }, {
     attrType: "signingTime",
-    attrValue: [UTCTime.encode(Date.parse("2026-09-03T06:29:01Z"))],
+    attrValue: [UTCTime.encode(Date.parse("2026-09-04T12:00:00Z"))],
   }, {
     attrType: "messageDigest",
     attrValue: [OctetString.encode(messageDigest)],
@@ -144,15 +144,15 @@ describe("Signing time", () => {
   });
 
   test("must be around the time when the message was sent", async () => {
-    let signedData = await signAsEva(await signedAttributes()); // signed 06:29:01
-    expect(await verify(signedData, new Date("2026-09-03T06:00:00Z"))).toBeTruthy();
-    expect(await verify(signedData, new Date("2026-09-03T09:00:00Z"))).toBe(null);
+    let signedData = await signAsEva(await signedAttributes()); // signed at 12:00
+    expect(await verify(signedData, new Date("2026-09-04T12:30:00Z"))).toBeTruthy();
+    expect(await verify(signedData, new Date("2026-09-04T15:00:00Z"))).toBe(null);
   });
 
   test("falls back to the send time, when the message does not say", async () => {
     let attributes = (await signedAttributes()).filter(attr => attr.attrType != "signingTime");
     let signedData = await signAsEva(attributes);
-    expect(await verify(signedData, new Date("2026-09-04T12:00:00Z"))).toBeTruthy();
+    expect(await verify(signedData, new Date("2026-09-04T18:00:00Z"))).toBeTruthy();
     expect(await verify(signedData, new Date("2035-01-01T12:00:00Z"))).toBe(null);
   });
 });
@@ -170,6 +170,18 @@ describe("The certificate that the signer names (RFC 5035)", () => {
     signedData.content.certificates = [substitute];
     signedData.content.signerInfos[0].sid.value.serialNumber = substitute.tbsCertificate.serialNumber;
     expect(await verify(signedData)).toBe(null);
+  });
+});
+
+describe("What the signer certificate is for", () => {
+  test("must include signing", async () => {
+    let cert = Certificate.decodePEM(kEvaEncryptionCert, { label: "CERTIFICATE" });
+    expect(await verify(await signAsEva(await signedAttributes(), cert))).toBe(null);
+  });
+
+  test("must include email", async () => {
+    let cert = Certificate.decodePEM(kEvaServerCert, { label: "CERTIFICATE" });
+    expect(await verify(await signAsEva(await signedAttributes(), cert))).toBe(null);
   });
 });
 
@@ -315,5 +327,61 @@ otV8/KfnUR8VAHRF0HPA4NrPQgcLaVg7wi1Zt3apLJNJL/9gR6Nsw1flPq5iFeMK
 Y+BsgL++oU9ugSSdm0g4BAdBBAS0kahguzUyDafXhpa29OJPmdk17eIFlVkWCk5x
 EAlfYlVEhOegaf2hJ9FH/VJXNErGdfyuv4T//cAj/+G1wbh1FsAcCLdZKoRO3RGD
 JTrM0S1CkAIlZCU+JgwgKeaF4cyCaps=
+-----END CERTIFICATE-----
+`;
+
+/* The same key and subject as `kSignedByEva`, but issued for encrypting only:
+ * keyUsage=critical,keyEncipherment, extendedKeyUsage=emailProtection
+ * openssl verify -CAfile ca.crt -purpose smimesign eva-encipher.crt fails
+ */
+const kEvaEncryptionCert = `
+-----BEGIN CERTIFICATE-----
+MIIDczCCAlugAwIBAgIBLDANBgkqhkiG9w0BAQsFADAmMRAwDgYDVQQDDAdUZXN0
+IENBMRIwEAYDVQRhDAlWQVRERS05OTkwHhcNMjYwOTAzMDY0NDQxWhcNMzQxMTIw
+MDY0NDQxWjBCMQwwCgYDVQQDDANFdmExEjAQBgNVBGEMCVZBVERFLTEyMzEeMBwG
+CSqGSIb3DQEJARYPZXZhQGV4YW1wbGUuY29tMIIBIjANBgkqhkiG9w0BAQEFAAOC
+AQ8AMIIBCgKCAQEAtHnpvtitvfqLmNxgJ2IX4ZH7rcdW5CbEHwzJJbGFCZ8MzwUU
+T7v0QM4Pu3soCmFvDmoqqH/JbP31wz0gkaSj+dUDhSiqCvObn5SQ7QuHvza3j6Vt
+qZIx6PSJ+/lKT6iICvIWrEQkL0+/77HA/af/7Yro9hTC50O8ATctgqvC4ngS/a18
+OyJSZLJy3yDFbXe6xG/uxAi3MtoWD5srQwmkYonyeEbpkwaSDGPYvhswp9/LZSTz
+E490IuUtsoLg7aayDECNjHgOr/NCj97mLPWobgKBM3mXNPvt+3rDJNfRUNOx+cwI
+mAPGQkcpgvm9qRl5Xyo5XRt5t5o+eR9nchj4tQIDAQABo4GPMIGMMAkGA1UdEwQC
+MAAwDgYDVR0PAQH/BAQDAgUgMBMGA1UdJQQMMAoGCCsGAQUFBwMEMBoGA1UdEQQT
+MBGBD2V2YUBleGFtcGxlLmNvbTAdBgNVHQ4EFgQU3Zv6m443avRUCiOHUPPtrKxf
+NAEwHwYDVR0jBBgwFoAUhvNcd2obmnDc913nfrD3oVQH0b0wDQYJKoZIhvcNAQEL
+BQADggEBAGaN7NjPgQeNau4u01rnmXr+83MUAGpdVYTUAwL6zXgGy0lBxlM+tAzj
+jB89XKIYLHCMvlcDQPM0baYDudNM1LD3nALxhlhP78TDILMh6Q6niGP0d/iIKK2j
+gNyWZw4mCkJwFF+hAVIHvHYt/Gzt3gVe1uYNIfiSBR+f0Xt0pCdhIbvCjjecZubh
+InmQMMkvBQiHUJSfzJvMFxv/NpSajwM5YfP5BxKmP66nA6r69KCrEgIIVI9IitEB
+3SIp8Igp+lqW5jeoORzlfwO6O6++3FB/Q1acT4a1mXrui7j4AMxmRacdJJpniCM3
+zswrYiqd9CKrmSFDpMv9N13C+s9bCNc=
+-----END CERTIFICATE-----
+`;
+
+/* ... and one for a TLS server:
+ * keyUsage=critical,digitalSignature, extendedKeyUsage=serverAuth
+ * openssl verify -CAfile ca.crt -purpose smimesign eva-tls.crt fails
+ */
+const kEvaServerCert = `
+-----BEGIN CERTIFICATE-----
+MIIDczCCAlugAwIBAgIBLTANBgkqhkiG9w0BAQsFADAmMRAwDgYDVQQDDAdUZXN0
+IENBMRIwEAYDVQRhDAlWQVRERS05OTkwHhcNMjYwOTAzMDY0NDQxWhcNMzQxMTIw
+MDY0NDQxWjBCMQwwCgYDVQQDDANFdmExEjAQBgNVBGEMCVZBVERFLTEyMzEeMBwG
+CSqGSIb3DQEJARYPZXZhQGV4YW1wbGUuY29tMIIBIjANBgkqhkiG9w0BAQEFAAOC
+AQ8AMIIBCgKCAQEAtHnpvtitvfqLmNxgJ2IX4ZH7rcdW5CbEHwzJJbGFCZ8MzwUU
+T7v0QM4Pu3soCmFvDmoqqH/JbP31wz0gkaSj+dUDhSiqCvObn5SQ7QuHvza3j6Vt
+qZIx6PSJ+/lKT6iICvIWrEQkL0+/77HA/af/7Yro9hTC50O8ATctgqvC4ngS/a18
+OyJSZLJy3yDFbXe6xG/uxAi3MtoWD5srQwmkYonyeEbpkwaSDGPYvhswp9/LZSTz
+E490IuUtsoLg7aayDECNjHgOr/NCj97mLPWobgKBM3mXNPvt+3rDJNfRUNOx+cwI
+mAPGQkcpgvm9qRl5Xyo5XRt5t5o+eR9nchj4tQIDAQABo4GPMIGMMAkGA1UdEwQC
+MAAwDgYDVR0PAQH/BAQDAgeAMBMGA1UdJQQMMAoGCCsGAQUFBwMBMBoGA1UdEQQT
+MBGBD2V2YUBleGFtcGxlLmNvbTAdBgNVHQ4EFgQU3Zv6m443avRUCiOHUPPtrKxf
+NAEwHwYDVR0jBBgwFoAUhvNcd2obmnDc913nfrD3oVQH0b0wDQYJKoZIhvcNAQEL
+BQADggEBAB0huPurNBZ8YlWKGvVO4HRlsfURtRtC9WlYc/mOpQHk4+CU1r/mbSLL
+yMQA/BjYFftr4FPvszB8mTrsbUnuE9kHhUSH36pctKoWRweCXvZvB1rSjjp1KyR9
+F8qhv93n7nBa36+Q4HdrLvYYQFCy0fIzQG5fVBk2GzgQWKnGhVh374/WJIKTP8kY
+wRwxgXTK46XfMeOh6AEvqgMh1/yCt/XalD/CXpIyhtXn2DEZCPw3/lYES5dV+L+9
+w5VtgGqrCduHyrD/OZJ6Er3Rq773kDr4jHGUzRJf3bV8IX6CJWmf2YP/4zDvKDdo
+wGsiG7V2Som0wpt2oln0qG11yIpQVwo=
 -----END CERTIFICATE-----
 `;

--- a/app/test/logic/Mail/Encryption/SMIME/verifySigner.test.ts
+++ b/app/test/logic/Mail/Encryption/SMIME/verifySigner.test.ts
@@ -1,0 +1,106 @@
+import { SignedData, OctetString, RDNSequence } from "../../../../../logic/Mail/Encryption/SMIME/SMIMEASN1";
+import { verifySignedData, sameName } from "../../../../../logic/Mail/Encryption/SMIME/SMIMEVerify";
+import { appGlobal } from "../../../../../logic/app";
+import { expect, test, describe } from "vitest";
+
+// `verifySignedData()` compares digests using `indexedDB.cmp()`,
+// which the browser has, but Node does not.
+globalThis.indexedDB ??= {
+  cmp(a: Uint8Array, b: Uint8Array): number {
+    let length = Math.min(a.length, b.length);
+    for (let i = 0; i < length; i++) {
+      if (a[i] != b[i]) {
+        return a[i] < b[i] ? -1 : 1;
+      }
+    }
+    return Math.sign(a.length - b.length);
+  },
+} as any;
+
+// The test CA is not a real CA, so no CA certificate vouches for it.
+appGlobal.remoteApp ??= {
+  async getCACertificates(type: string): Promise<string[]> {
+    return [];
+  },
+};
+
+/** The certificates of `kSignedByEva`, in the order that they are sent */
+function certificates(): any[] {
+  return SignedData.decodeFromBase64(kSignedByEva).content.certificates;
+}
+
+async function verify(signedData: any): Promise<any> {
+  return await verifySignedData(signedData, OctetString.decode(signedData.content.contentInfo.content));
+}
+
+describe("Which certificate signed", () => {
+  test("compares attribute types that our OID map does not know", () => {
+    let subject = certificates()[1].tbsCertificate.subject;
+    // organizationIdentifier (2.5.4.97), as eIDAS certificates have it
+    expect(subject.some(attr => Array.isArray(attr.type))).toBe(true);
+    expect(sameName(subject, RDNSequence.decode(RDNSequence.encode(subject)))).toBe(true);
+
+    let other = RDNSequence.decode(RDNSequence.encode(subject));
+    other[1].value.value = "VATDE-666";
+    expect(sameName(subject, other)).toBe(false);
+  });
+
+  test("finds the signer, even when the CA certificate is sent first", async () => {
+    let signer = await verify(SignedData.decodeFromBase64(kSignedByEva));
+    expect(signer?.userIDs.contents).toEqual(["eva@example.com"]);
+  });
+});
+
+/* A CA and a signer certificate that both have an organizationIdentifier
+ * (2.5.4.97) in their name, which our OID map does not know. The CA
+ * certificate comes first in the message, so that the signer is only found
+ * by matching the name.
+ * openssl genpkey -quiet -algorithm RSA -pkeyopt rsa_keygen_bits:2048 -out ca.key
+ * openssl req -x509 -key ca.key -out ca.crt -days 3650 -sha256 \
+ *   -subj "/CN=Test CA/2.5.4.97=VATDE-999" \
+ *   -addext "basicConstraints=critical,CA:TRUE" -addext "keyUsage=critical,keyCertSign,cRLSign"
+ * openssl genpkey -quiet -algorithm RSA -pkeyopt rsa_keygen_bits:2048 -out eva.key
+ * openssl req -new -key eva.key -out eva.csr \
+ *   -subj "/CN=Eva/2.5.4.97=VATDE-123/emailAddress=eva@example.com"
+ * openssl x509 -req -in eva.csr -out eva.crt -CA ca.crt -CAkey ca.key -days 3000 -sha256 \
+ *   -set_serial 0x2a -extfile <(printf "basicConstraints=CA:FALSE\nkeyUsage=critical,digitalSignature,keyEncipherment\nextendedKeyUsage=emailProtection\nsubjectAltName=email:eva@example.com\nsubjectKeyIdentifier=hash\nauthorityKeyIdentifier=keyid,issuer\n")
+ * printf 'Content-Type: text/plain\r\n\r\nHello from Eva.\r\n' > body.txt
+ * openssl cms -sign -in body.txt -signer eva.crt -inkey eva.key -certfile ca.crt \
+ *   -nodetach -binary -md sha256 -outform DER -out eva.p7m
+ * openssl cms -verify -inform DER -in eva.p7m -CAfile ca.crt -purpose smimesign
+ */
+const kSignedByEva = `
+  MIIJXgYJKoZIhvcNAQcCoIIJTzCCCUsCAQExDTALBglghkgBZQMEAgEwPAYJKoZIhvcNAQcBoC8ELUNvbnRlbnQtVHlwZTogdGV4
+  dC9wbGFpbg0KDQpIZWxsbyBmcm9tIEV2YS4NCqCCBrgwggM9MIICJaADAgECAhRwmSaYzDhNKqZGUs9xwff8EeaSYjANBgkqhkiG
+  9w0BAQsFADAmMRAwDgYDVQQDDAdUZXN0IENBMRIwEAYDVQRhDAlWQVRERS05OTkwHhcNMjYwOTAzMDYyODUwWhcNMzYwODMxMDYy
+  ODUwWjAmMRAwDgYDVQQDDAdUZXN0IENBMRIwEAYDVQRhDAlWQVRERS05OTkwggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIB
+  AQC5Uxu5DJQABVR8siFhBqnkdc6UXMDM1r8lTvOTTipPAvYXC/BB4xCfHYmT0stAQ+8cLG1mDeAMMmXIyeY59JJSJu0INtaNQ5Kg
+  Oyh7/9qnTGzC37K3wzgYe7rr31iRbCHOchwIECdODGHOmqlNCW0oXkKZIiKHgL18SJqM080ZqOVi4kVyp83pzPE66IeNf2t/0CVJ
+  50C+/MpeasXTx9Np3cTYcVDeCPM45bmweg4XLiXh7AMNFSvrcs60iq6LNXEVQxCcW7kV1QHm7wpOTkXNwRWH9jRFuegwDMyy6hNe
+  dZTFjmHQPkcKPLjAvIt1BTML3gCGnZJmP9mt23o+TBePAgMBAAGjYzBhMB0GA1UdDgQWBBSG81x3ahuacNz3Xed+sPehVAfRvTAf
+  BgNVHSMEGDAWgBSG81x3ahuacNz3Xed+sPehVAfRvTAPBgNVHRMBAf8EBTADAQH/MA4GA1UdDwEB/wQEAwIBBjANBgkqhkiG9w0B
+  AQsFAAOCAQEArSO0SQRxzKQul4hO57wp56ZF18Ls3eZB8fzwUiYOAl6xuYWad5LvMZ/vyYQ5mVrPLfvQ6gOMLrfDsqn+Bi78qvrL
+  wyXeOTbRH6og4Y8k/s2BK2WCIfzXxz22xLIwRZTGpPHpvNNG0vbTCl6jKQJEUOl5+FxUekr1bai2HkMc4VPH9Vnhn0v1xoAuHRw5
+  aNK8GeTpxnOwlrwn5L6RcAwQILmpRM84EB08ZZ1I+NoasNLy3ueQAkZdYDXrYgYi+rWZlwR0wDzkKUR1H4g9hUQB1hNAEoxIh6hI
+  WL7aMn7SCHVKCoB486trqgG1OQfGIuGkO2zRqu4+F71HeT9efsDCxTCCA3MwggJboAMCAQICASowDQYJKoZIhvcNAQELBQAwJjEQ
+  MA4GA1UEAwwHVGVzdCBDQTESMBAGA1UEYQwJVkFUREUtOTk5MB4XDTI2MDkwMzA2Mjg1MFoXDTM0MTEyMDA2Mjg1MFowQjEMMAoG
+  A1UEAwwDRXZhMRIwEAYDVQRhDAlWQVRERS0xMjMxHjAcBgkqhkiG9w0BCQEWD2V2YUBleGFtcGxlLmNvbTCCASIwDQYJKoZIhvcN
+  AQEBBQADggEPADCCAQoCggEBALR56b7Yrb36i5jcYCdiF+GR+63HVuQmxB8MySWxhQmfDM8FFE+79EDOD7t7KAphbw5qKqh/yWz9
+  9cM9IJGko/nVA4Uoqgrzm5+UkO0Lh782t4+lbamSMej0ifv5Sk+oiAryFqxEJC9Pv++xwP2n/+2K6PYUwudDvAE3LYKrwuJ4Ev2t
+  fDsiUmSyct8gxW13usRv7sQItzLaFg+bK0MJpGKJ8nhG6ZMGkgxj2L4bMKffy2Uk8xOPdCLlLbKC4O2msgxAjYx4Dq/zQo/e5iz1
+  qG4CgTN5lzT77ft6wyTX0VDTsfnMCJgDxkJHKYL5vakZeV8qOV0bebeaPnkfZ3IY+LUCAwEAAaOBjzCBjDAJBgNVHRMEAjAAMA4G
+  A1UdDwEB/wQEAwIFoDATBgNVHSUEDDAKBggrBgEFBQcDBDAaBgNVHREEEzARgQ9ldmFAZXhhbXBsZS5jb20wHQYDVR0OBBYEFN2b
+  +puON2r0VAojh1Dz7aysXzQBMB8GA1UdIwQYMBaAFIbzXHdqG5pw3Pdd536w96FUB9G9MA0GCSqGSIb3DQEBCwUAA4IBAQCSW0jR
+  LPwqKptMYjp3VFqUqWRNnl7Uu3cXBN+m8Rkt++gjw0IbQNYixbhTWuvMXl93xT0w07GI9uAX7PqyPQef2CsC/2q5uOrlkOP2eLa1
+  LRoNUp3dBW7Hh7uFsZou+IewElWxi3gEXZuX5vJdoUiSTfOncBI/OhUXwFO/gBNVNpo7ph/OqKCaAX86g/gAZ7rJAe3dkQ/uWYSS
+  xYHirAG7Yz79zH7Yhl283rUW7Q+UTe0/lN/6xg0wPk3riA2K7jf2c9Bjefv4lfxfN57HPBgLuSn1xU1kQkZTRaYZEP7I9/P9/6O+
+  mTJYjL4GcDlnU+S4uSM+VFTuB2XWVVk6eRA0MYICOzCCAjcCAQEwKzAmMRAwDgYDVQQDDAdUZXN0IENBMRIwEAYDVQRhDAlWQVRE
+  RS05OTkCASowCwYJYIZIAWUDBAIBoIHkMBgGCSqGSIb3DQEJAzELBgkqhkiG9w0BBwEwHAYJKoZIhvcNAQkFMQ8XDTI2MDkwMzA2
+  MjkwMVowLwYJKoZIhvcNAQkEMSIEIPfrvefO3DKyP3wg6nUyLh7A+Qie3g4GoulIgIGeuo1pMHkGCSqGSIb3DQEJDzFsMGowCwYJ
+  YIZIAWUDBAEqMAsGCWCGSAFlAwQBFjALBglghkgBZQMEAQIwCgYIKoZIhvcNAwcwDgYIKoZIhvcNAwICAgCAMA0GCCqGSIb3DQMC
+  AgFAMAcGBSsOAwIHMA0GCCqGSIb3DQMCAgEoMA0GCSqGSIb3DQEBAQUABIIBABUChTKuWReRiTD0G6GF8BahQ4DIYeR5yu8zhvA8
+  v7VEAK+DQF55dyWee0HjbTVdpRgLP94q0h9LVXDNU4RzUbc4DsW/i76FrDDpWrMJdQj3M9SlIJGizEW0DPoReHwnQs2i5tdkzMkD
+  PYPoRjJ8O2L1N2a6u5QdismVkcjwzeskRLwS84BQWTfoGdrgwmNECjUUBpSm+rwnEIz9xsWuoSwPyvBt2mlhD5YuwiN6qXJe2/LK
+  pkYT0tN998SbHQ/Q6mdND1AdyiVssuCmfkmYqJEqDHno7+yhfqh4l5uGtE863/cMzqfc1dNiLKQyh7957aS44BgbPkvtKjPrY+Ia
+  F5M=
+`;

--- a/app/test/logic/Mail/Encryption/SMIME/verifySigner.test.ts
+++ b/app/test/logic/Mail/Encryption/SMIME/verifySigner.test.ts
@@ -1,4 +1,4 @@
-import { SignedData, OctetString, RDNSequence, Oid, UTCTime, Attributes, DigestInfo, Null, PrivateKeyInfo, RSAPrivateKey } from "../../../../../logic/Mail/Encryption/SMIME/SMIMEASN1";
+import { SignedData, OctetString, RDNSequence, Certificate, Oid, UTCTime, Attributes, DigestInfo, Null, PrivateKeyInfo, RSAPrivateKey } from "../../../../../logic/Mail/Encryption/SMIME/SMIMEASN1";
 import { verifySignedData, sameName } from "../../../../../logic/Mail/Encryption/SMIME/SMIMEVerify";
 import { decrypt, padFF } from "../../../../../logic/Mail/Encryption/SMIME/SMIMERSAES";
 import { appGlobal } from "../../../../../logic/app";
@@ -157,6 +157,22 @@ describe("Signing time", () => {
   });
 });
 
+describe("The certificate that the signer names (RFC 5035)", () => {
+  test("must be the one that verified the signature", async () => {
+    expect((await verify(SignedData.decodeFromBase64(kSignedByEvaESS)))?.userIDs.contents)
+      .toEqual(["eva@example.com"]);
+  });
+
+  test("catches a certificate that was swapped for another one of the same owner", async () => {
+    let signedData = SignedData.decodeFromBase64(kSignedByEvaESS);
+    // Same subject and same key, so nothing else notices the swap
+    let substitute = Certificate.decodePEM(kEvaSecondCert, { label: "CERTIFICATE" });
+    signedData.content.certificates = [substitute];
+    signedData.content.signerInfos[0].sid.value.serialNumber = substitute.tbsCertificate.serialNumber;
+    expect(await verify(signedData)).toBe(null);
+  });
+});
+
 /* A CA and a signer certificate that both have an organizationIdentifier
  * (2.5.4.97) in their name, which our OID map does not know. The CA
  * certificate comes first in the message, so that the signer is only found
@@ -241,4 +257,63 @@ a9deOF7ZsKdJ4ZGKvSKBv1atVOB/MRloecqYuK9vAoGBAJhBElyFNcrH57rjAVbJ
 Qx5tVPeCThb0Y7Q0McOz9eZNfSZ/Jmq2EMUi2OR+SQjN0yNZMTTRhwun89YR9Ozw
 d1kTfZ40oM8sTyaJlTdJANWn
 -----END PRIVATE KEY-----
+`;
+
+/* The same message, signed with the ESS signingCertificateV2 attribute:
+ * openssl cms -sign -cades -in body.txt -signer eva.crt -inkey eva.key \
+ *   -nodetach -binary -md sha256 -outform DER -out eva-cades.p7m
+ * openssl cms -verify -cades -inform DER -in eva-cades.p7m -CAfile ca.crt -purpose smimesign
+ */
+const kSignedByEvaESS = `
+MIIGiAYJKoZIhvcNAQcCoIIGeTCCBnUCAQExDTALBglghkgBZQMEAgEwPAYJKoZIhvcNAQcBoC8ELUNvbnRlbnQtVHlwZTogdGV4
+dC9wbGFpbg0KDQpIZWxsbyBmcm9tIEV2YS4NCqCCA3cwggNzMIICW6ADAgECAgEqMA0GCSqGSIb3DQEBCwUAMCYxEDAOBgNVBAMM
+B1Rlc3QgQ0ExEjAQBgNVBGEMCVZBVERFLTk5OTAeFw0yNjA5MDMwNjI4NTBaFw0zNDExMjAwNjI4NTBaMEIxDDAKBgNVBAMMA0V2
+YTESMBAGA1UEYQwJVkFUREUtMTIzMR4wHAYJKoZIhvcNAQkBFg9ldmFAZXhhbXBsZS5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IB
+DwAwggEKAoIBAQC0eem+2K29+ouY3GAnYhfhkfutx1bkJsQfDMklsYUJnwzPBRRPu/RAzg+7eygKYW8Oaiqof8ls/fXDPSCRpKP5
+1QOFKKoK85uflJDtC4e/NrePpW2pkjHo9In7+UpPqIgK8hasRCQvT7/vscD9p//tiuj2FMLnQ7wBNy2Cq8LieBL9rXw7IlJksnLf
+IMVtd7rEb+7ECLcy2hYPmytDCaRiifJ4RumTBpIMY9i+GzCn38tlJPMTj3Qi5S2yguDtprIMQI2MeA6v80KP3uYs9ahuAoEzeZc0
+++37esMk19FQ07H5zAiYA8ZCRymC+b2pGXlfKjldG3m3mj55H2dyGPi1AgMBAAGjgY8wgYwwCQYDVR0TBAIwADAOBgNVHQ8BAf8E
+BAMCBaAwEwYDVR0lBAwwCgYIKwYBBQUHAwQwGgYDVR0RBBMwEYEPZXZhQGV4YW1wbGUuY29tMB0GA1UdDgQWBBTdm/qbjjdq9FQK
+I4dQ8+2srF80ATAfBgNVHSMEGDAWgBSG81x3ahuacNz3Xed+sPehVAfRvTANBgkqhkiG9w0BAQsFAAOCAQEAkltI0Sz8KiqbTGI6
+d1RalKlkTZ5e1Lt3FwTfpvEZLfvoI8NCG0DWIsW4U1rrzF5fd8U9MNOxiPbgF+z6sj0Hn9grAv9qubjq5ZDj9ni2tS0aDVKd3QVu
+x4e7hbGaLviHsBJVsYt4BF2bl+byXaFIkk3zp3ASPzoVF8BTv4ATVTaaO6YfzqigmgF/OoP4AGe6yQHt3ZEP7lmEksWB4qwBu2M+
+/cx+2IZdvN61Fu0PlE3tP5Tf+sYNMD5N64gNiu439nPQY3n7+JX8XzeexzwYC7kp9cVNZEJGU0WmGRD+yPfz/f+jvpkyWIy+BnA5
+Z1PkuLkjPlRU7gdl1lVZOnkQNDGCAqYwggKiAgEBMCswJjEQMA4GA1UEAwwHVGVzdCBDQTESMBAGA1UEYQwJVkFUREUtOTk5AgEq
+MAsGCWCGSAFlAwQCAaCCAU4wGAYJKoZIhvcNAQkDMQsGCSqGSIb3DQEHATAcBgkqhkiG9w0BCQUxDxcNMjYwOTAzMDY0MDM4WjAv
+BgkqhkiG9w0BCQQxIgQg9+u9587cMrI/fCDqdTIuHsD5CJ7eDgai6UiAgZ66jWkwaAYLKoZIhvcNAQkQAi8xWTBXMFUwUwQgKDkD
+jevo9AZa6LyfLe8pgZZFAQZrulMDTRHhf3TUnkAwLzAqpCgwJjEQMA4GA1UEAwwHVGVzdCBDQTESMBAGA1UEYQwJVkFUREUtOTk5
+AgEqMHkGCSqGSIb3DQEJDzFsMGowCwYJYIZIAWUDBAEqMAsGCWCGSAFlAwQBFjALBglghkgBZQMEAQIwCgYIKoZIhvcNAwcwDgYI
+KoZIhvcNAwICAgCAMA0GCCqGSIb3DQMCAgFAMAcGBSsOAwIHMA0GCCqGSIb3DQMCAgEoMA0GCSqGSIb3DQEBAQUABIIBABeoVWv6
+JGRq6KN/IveN64cuSnPQGQvVxmEOmxWy61fCnR78YLk4d4yKPk/kKTdx1LHyd1UYodpQRad6ZCIzKXCsQr4vpi6IOJwmvwEzd4eQ
+HcTUDzbyQT23X2bBKH5HKKwcRRixFoAXFg1FnI2VeXgQVgb0lJjV8Q5HBlfivaTPMPv8w1IcJR0N9T6WhszHpVJjwYukr69qMl1N
+1LdR63twHdWqMZ7xAZNX7RK5OFKRk+o9HCULCsM8dVHIU7FWq1lBUCYAJXEOvRey1OWYaN7Bh4ftl9ymk74yMKbEwCc/XlhwhP2b
+40DBr1lHLdFSKFOG6hJCuU66aAKHZkAHP9c=
+`;
+
+/* A second certificate for the same key and the same subject:
+ * openssl x509 -req -in eva.csr -out eva2.crt -CA ca.crt -CAkey ca.key -days 3000 \
+ *   -sha256 -set_serial 0x2b -extfile <(...as eva.crt...)
+ */
+const kEvaSecondCert = `
+-----BEGIN CERTIFICATE-----
+MIIDczCCAlugAwIBAgIBKzANBgkqhkiG9w0BAQsFADAmMRAwDgYDVQQDDAdUZXN0
+IENBMRIwEAYDVQRhDAlWQVRERS05OTkwHhcNMjYwOTAzMDY0MDI2WhcNMzQxMTIw
+MDY0MDI2WjBCMQwwCgYDVQQDDANFdmExEjAQBgNVBGEMCVZBVERFLTEyMzEeMBwG
+CSqGSIb3DQEJARYPZXZhQGV4YW1wbGUuY29tMIIBIjANBgkqhkiG9w0BAQEFAAOC
+AQ8AMIIBCgKCAQEAtHnpvtitvfqLmNxgJ2IX4ZH7rcdW5CbEHwzJJbGFCZ8MzwUU
+T7v0QM4Pu3soCmFvDmoqqH/JbP31wz0gkaSj+dUDhSiqCvObn5SQ7QuHvza3j6Vt
+qZIx6PSJ+/lKT6iICvIWrEQkL0+/77HA/af/7Yro9hTC50O8ATctgqvC4ngS/a18
+OyJSZLJy3yDFbXe6xG/uxAi3MtoWD5srQwmkYonyeEbpkwaSDGPYvhswp9/LZSTz
+E490IuUtsoLg7aayDECNjHgOr/NCj97mLPWobgKBM3mXNPvt+3rDJNfRUNOx+cwI
+mAPGQkcpgvm9qRl5Xyo5XRt5t5o+eR9nchj4tQIDAQABo4GPMIGMMAkGA1UdEwQC
+MAAwDgYDVR0PAQH/BAQDAgWgMBMGA1UdJQQMMAoGCCsGAQUFBwMEMBoGA1UdEQQT
+MBGBD2V2YUBleGFtcGxlLmNvbTAdBgNVHQ4EFgQU3Zv6m443avRUCiOHUPPtrKxf
+NAEwHwYDVR0jBBgwFoAUhvNcd2obmnDc913nfrD3oVQH0b0wDQYJKoZIhvcNAQEL
+BQADggEBADQ/QRppzX9KgXWPQJUcjZkxidcDlypLMYXLrrV57XyHwWnIsHdOCdMh
+rOaXpD51n4fwhifMyoJ7Y+hvuBQLeeerjb6fTjwpqJ0UY6gWVPrqYta+SkhMmfDP
+otV8/KfnUR8VAHRF0HPA4NrPQgcLaVg7wi1Zt3apLJNJL/9gR6Nsw1flPq5iFeMK
+Y+BsgL++oU9ugSSdm0g4BAdBBAS0kahguzUyDafXhpa29OJPmdk17eIFlVkWCk5x
+EAlfYlVEhOegaf2hJ9FH/VJXNErGdfyuv4T//cAj/+G1wbh1FsAcCLdZKoRO3RGD
+JTrM0S1CkAIlZCU+JgwgKeaF4cyCaps=
+-----END CERTIFICATE-----
 `;

--- a/app/test/logic/Mail/Encryption/SMIME/verifySigner.test.ts
+++ b/app/test/logic/Mail/Encryption/SMIME/verifySigner.test.ts
@@ -1,5 +1,6 @@
-import { SignedData, OctetString, RDNSequence } from "../../../../../logic/Mail/Encryption/SMIME/SMIMEASN1";
+import { SignedData, OctetString, RDNSequence, Oid, UTCTime, Attributes, DigestInfo, Null, PrivateKeyInfo, RSAPrivateKey } from "../../../../../logic/Mail/Encryption/SMIME/SMIMEASN1";
 import { verifySignedData, sameName } from "../../../../../logic/Mail/Encryption/SMIME/SMIMEVerify";
+import { decrypt, padFF } from "../../../../../logic/Mail/Encryption/SMIME/SMIMERSAES";
 import { appGlobal } from "../../../../../logic/app";
 import { expect, test, describe } from "vitest";
 
@@ -33,6 +34,60 @@ async function verify(signedData: any): Promise<any> {
   return await verifySignedData(signedData, OctetString.decode(signedData.content.contentInfo.content));
 }
 
+const kContent = "Content-Type: text/plain\r\n\r\nHello from Eva.\r\n";
+
+/** The attributes of a correct message, for the tests to vary */
+async function signedAttributes(): Promise<any[]> {
+  let messageDigest = new Uint8Array(await crypto.subtle.digest("SHA-256", new TextEncoder().encode(kContent)));
+  return [{
+    attrType: "contentType",
+    attrValue: [Oid.encode("data")],
+  }, {
+    attrType: "signingTime",
+    attrValue: [UTCTime.encode(Date.parse("2026-09-03T06:29:01Z"))],
+  }, {
+    attrType: "messageDigest",
+    attrValue: [OctetString.encode(messageDigest)],
+  }];
+}
+
+/** Signs the attributes with Eva's key, and wraps them in an opaque-signed
+ * message, the same way that `SMIMESend` builds it */
+async function signAsEva(signedAttrs: any[], cert = certificates()[1]): Promise<any> {
+  let attributesDigest = new Uint8Array(await crypto.subtle.digest("SHA-256", Attributes.encode(signedAttrs)));
+  let digestInfo = {
+    digestAlgorithm: { algorithm: "sha256", parameters: Null.encode() },
+    digest: attributesDigest,
+  };
+  let key = RSAPrivateKey.decode(PrivateKeyInfo.decodePEM(kEvaKey, { label: "PRIVATE KEY" }).privateKey);
+  return {
+    contentType: "signedData",
+    content: {
+      version: 1n,
+      digestAlgorithms: [{ algorithm: "sha256", parameters: Null.encode() }],
+      contentInfo: {
+        contentType: "data",
+        content: OctetString.encode(new TextEncoder().encode(kContent)),
+      },
+      certificates: [cert],
+      signerInfos: [{
+        version: 1n,
+        sid: {
+          type: "issuerAndSerialNumber",
+          value: {
+            issuer: cert.tbsCertificate.issuer,
+            serialNumber: cert.tbsCertificate.serialNumber,
+          },
+        },
+        digestAlgorithm: { algorithm: "sha256", parameters: Null.encode() },
+        signedAttrs,
+        signatureAlgorithm: { algorithm: "rsaEncryption", parameters: Null.encode() },
+        signature: decrypt(padFF(DigestInfo.encode(digestInfo), key), key),
+      }],
+    },
+  };
+}
+
 describe("Which certificate signed", () => {
   test("compares attribute types that our OID map does not know", () => {
     let subject = certificates()[1].tbsCertificate.subject;
@@ -61,6 +116,20 @@ describe("Which certificate signed", () => {
     let signedData = SignedData.decodeFromBase64(kSignedByEva);
     signedData.content.signerInfos[0].digestAlgorithm.algorithm = "rsaESOAEP";
     expect(await verify(signedData)).toBe(null);
+  });
+});
+
+describe("Signed attributes", () => {
+  test("the message that the other tests vary verifies", async () => {
+    let signer = await verify(await signAsEva(await signedAttributes()));
+    expect(signer?.userIDs.contents).toEqual(["eva@example.com"]);
+  });
+
+  test("the content type must be signed, and must be the one of the message", async () => {
+    let attributes = await signedAttributes();
+    attributes[0].attrValue = [Oid.encode("encryptedData")];
+    expect(await verify(await signAsEva(attributes))).toBe(null);
+    expect(await verify(await signAsEva(attributes.slice(1)))).toBe(null);
   });
 });
 
@@ -116,4 +185,36 @@ const kSignedByEva = `
   PYPoRjJ8O2L1N2a6u5QdismVkcjwzeskRLwS84BQWTfoGdrgwmNECjUUBpSm+rwnEIz9xsWuoSwPyvBt2mlhD5YuwiN6qXJe2/LK
   pkYT0tN998SbHQ/Q6mdND1AdyiVssuCmfkmYqJEqDHno7+yhfqh4l5uGtE863/cMzqfc1dNiLKQyh7957aS44BgbPkvtKjPrY+Ia
   F5M=
+`;
+
+/** Eva's private key, to sign the messages that the tests build */
+const kEvaKey = `
+-----BEGIN PRIVATE KEY-----
+MIIEvgIBADANBgkqhkiG9w0BAQEFAASCBKgwggSkAgEAAoIBAQC0eem+2K29+ouY
+3GAnYhfhkfutx1bkJsQfDMklsYUJnwzPBRRPu/RAzg+7eygKYW8Oaiqof8ls/fXD
+PSCRpKP51QOFKKoK85uflJDtC4e/NrePpW2pkjHo9In7+UpPqIgK8hasRCQvT7/v
+scD9p//tiuj2FMLnQ7wBNy2Cq8LieBL9rXw7IlJksnLfIMVtd7rEb+7ECLcy2hYP
+mytDCaRiifJ4RumTBpIMY9i+GzCn38tlJPMTj3Qi5S2yguDtprIMQI2MeA6v80KP
+3uYs9ahuAoEzeZc0++37esMk19FQ07H5zAiYA8ZCRymC+b2pGXlfKjldG3m3mj55
+H2dyGPi1AgMBAAECggEAGTvqjiqnBacgbvvGiKXTMlDtCxE8zvhfTPrGrSSIYMis
+9nfUAooEeYMro/Ubq3KQH/MsNRRuSh+q2zo9cYpppabpBRdNyeuMg4rhm03qFGGc
+LNOJOmpx3AvvtxwrYxPstvW+bHu3632PwqiXPrWHYo6c9WYAZ8GKv0jDGOrXJumS
+yq9X7aicCvNuMrghMWkUceATurCHGNmMbOt2xIr4RVTS+g/xWQvwQ66Y7nwnWuHf
+IkRtRoSH8y4tu2o+jBAuKTXHwJTxXqO9OnFBIBG2XwKu9wWdiTILeJPO0uBf26m2
+rRTodhkUWAfBWTb+1yjCP+uS+d7Q9ZgHyvdfClVlyQKBgQDm+aXs+KewmBmlFXmt
+r0dHmbSyuLTry4ByVTM/WVhG76zisHzqNIG343cXbLl9N5rsMH/AemJqMv+H97+h
+2vvHU6Rg12jM9uEJ3l9LLaGRelNmjpphzRA930ltr6UIZMJSqci5v7gf1wI3z8w2
+Zj0EC3QEY1YwuRWTGRnfulMtPwKBgQDIB57QeZNDNyCyWVXHVU30sgbv+iXfEgei
+sNEy0WA/ztcX0f0L4EyH7DO3u6mdyTmMJzEVdg3/H8J1PdO/yAknI45iR/jyBRE4
+KrI4trk/g/XvesgsLrwxvbW31ZYXWcynx1YD+1LAoW2LluVDEiZEUwvRxqtpF5jW
+uYmxUM05CwKBgQChLdMY44f5VpqGtc68YhUmpN8Q3I38AX13y3bAnTNaBQSrCCeT
+M+LVlNjVMtzZwYTNjyaHBaBJpZ7lngBPDUYnmXmazpbmeN0fCtuK1aPqpecvKRIY
+b4YG9xsBfNF4Yv+rualF3cC6D0sP8WT7DStE+E0UhtFtnKquhJSmqBpE9wKBgAS4
+wVP0erhsdbYgC7lP1y4+gZFqmzg/ybRabiW/8YCwFj22tD1yhvvyZGoi4Ocbl+Mq
+DauPBNeP3Vw9IGF3jFfDLBo/zq2P1w83Wsuh7I+GQujrQgxg8gpOixqSzR8x/HW9
+a9deOF7ZsKdJ4ZGKvSKBv1atVOB/MRloecqYuK9vAoGBAJhBElyFNcrH57rjAVbJ
+4bMcRQFh3SQX3a/Ma/a0ooFRexZGVaysXvfFJ/lAQDAIOM/rRspcyS1enCmTVsXI
+Qx5tVPeCThb0Y7Q0McOz9eZNfSZ/Jmq2EMUi2OR+SQjN0yNZMTTRhwun89YR9Ozw
+d1kTfZ40oM8sTyaJlTdJANWn
+-----END PRIVATE KEY-----
 `;

--- a/app/test/logic/Mail/Encryption/SMIME/verifySigner.test.ts
+++ b/app/test/logic/Mail/Encryption/SMIME/verifySigner.test.ts
@@ -30,8 +30,8 @@ function certificates(): any[] {
   return SignedData.decodeFromBase64(kSignedByEva).content.certificates;
 }
 
-async function verify(signedData: any): Promise<any> {
-  return await verifySignedData(signedData, OctetString.decode(signedData.content.contentInfo.content));
+async function verify(signedData: any, sent?: Date): Promise<any> {
+  return await verifySignedData(signedData, OctetString.decode(signedData.content.contentInfo.content), sent);
 }
 
 const kContent = "Content-Type: text/plain\r\n\r\nHello from Eva.\r\n";
@@ -130,6 +130,30 @@ describe("Signed attributes", () => {
     attributes[0].attrValue = [Oid.encode("encryptedData")];
     expect(await verify(await signAsEva(attributes))).toBe(null);
     expect(await verify(await signAsEva(attributes.slice(1)))).toBe(null);
+  });
+});
+
+describe("Signing time", () => {
+  /* Eva's certificate is valid from 2026-09-03 to 2034-11-20 */
+  test("must be within the validity of the signer certificate", async () => {
+    let attributes = await signedAttributes();
+    attributes[1].attrValue = [UTCTime.encode(Date.parse("2026-09-01T12:00:00Z"))];
+    expect(await verify(await signAsEva(attributes))).toBe(null);
+    attributes[1].attrValue = [UTCTime.encode(Date.parse("2035-01-01T12:00:00Z"))];
+    expect(await verify(await signAsEva(attributes))).toBe(null);
+  });
+
+  test("must be around the time when the message was sent", async () => {
+    let signedData = await signAsEva(await signedAttributes()); // signed 06:29:01
+    expect(await verify(signedData, new Date("2026-09-03T06:00:00Z"))).toBeTruthy();
+    expect(await verify(signedData, new Date("2026-09-03T09:00:00Z"))).toBe(null);
+  });
+
+  test("falls back to the send time, when the message does not say", async () => {
+    let attributes = (await signedAttributes()).filter(attr => attr.attrType != "signingTime");
+    let signedData = await signAsEva(attributes);
+    expect(await verify(signedData, new Date("2026-09-04T12:00:00Z"))).toBeTruthy();
+    expect(await verify(signedData, new Date("2035-01-01T12:00:00Z"))).toBe(null);
   });
 });
 

--- a/app/test/logic/Mail/Encryption/SMIME/verifySigner.test.ts
+++ b/app/test/logic/Mail/Encryption/SMIME/verifySigner.test.ts
@@ -49,6 +49,19 @@ describe("Which certificate signed", () => {
     let signer = await verify(SignedData.decodeFromBase64(kSignedByEva));
     expect(signer?.userIDs.contents).toEqual(["eva@example.com"]);
   });
+
+  test("does not accept a certificate that the signature does not name", async () => {
+    let signedData = SignedData.decodeFromBase64(kSignedByEva);
+    signedData.content.certificates = [certificates()[1]]; // only the signer
+    signedData.content.signerInfos[0].sid.value.serialNumber = 4711n;
+    expect(await verify(signedData)).toBe(null);
+  });
+
+  test("fails cleanly on a digest algorithm that we do not know", async () => {
+    let signedData = SignedData.decodeFromBase64(kSignedByEva);
+    signedData.content.signerInfos[0].digestAlgorithm.algorithm = "rsaESOAEP";
+    expect(await verify(signedData)).toBe(null);
+  });
 });
 
 /* A CA and a signer certificate that both have an organizationIdentifier


### PR DESCRIPTION
Fixes for #1379
Fable 5.1 orchestration, Opus 5 coding
    
### Commits
    
  - Send, 2 commits. The inner part keeps its Content-Transfer-Encoding, so single-part
    mail no longer arrives as raw quoted-printable in every client. A recipient without a
    key gives a message instead of a null dereference.
  - Read, 7 commits. 3DES and RC2 content decrypt using the ciphers already written for
    PKCS#12. Unsupported ciphers and key transports name themselves in a user-visible 
    error. A certificate-less key no longer aborts decryption for all keys. Recipients are
    matched by subjectKeyIdentifier. Signed content with LF line endings verifies. A p7m or
    p7s sent as application/octet-stream is read, as Microsoft specifies. A mislabelled
    part renders instead of leaking an ASN.1 parser error. RSA-OAEP key transport decrypts
    via WebCrypto.
  - ECDSA and PSS, 4 commits. ECDSA signatures on P-256, P-384 and P-521 verify, chains
    signed by EC CAs and by RSA-PSS CAs validate, and encrypting to an EC certificate gives
    a clear error instead of a crash.
  - Trust, 9 commits, your mid-job request. DN attribute types outside our OID map compare
    by value, which fixes signing and decryption for eIDAS-style certificates. A key you
    marked bad stays bad. The Signed state requires the certificate's address to equal
    From, for PGP too since the check lives in the shared rememberSigner. No fallback to
    the first certificate when the sid matches none. The contentType attribute is checked.
    signingTime is read, used for certificate validity at signing time, and compared with
    the Date header within an hour as PGP does. ESS signingCertificate and V2 are checked.
    Chains are checked for basicConstraints, pathLen, keyCertSign, rfc822 name constraints,
    and the leaf for keyUsage and extKeyUsage. A certificate whose key usage forbids
    encryption is never chosen for it.

### Verification
  
  Test count in the S/MIME directory rose from 47 to 97, the whole app suite from 757 to
  807 tests with only the three failures that already fail on master. svelte-check is at
  the same baseline. Every "must fail" fixture was cross-checked with openssl, and our
  signed and encrypted output was verified by the real NSS tools that Thunderbird uses.

### Behaviour changes to be aware of

  - Mail we signed with the old subject-in-sid bug now shows as unsigned, because that
    fallback is gone.
  - A signature whose Date header is more than about an hour from the signing time shows as
    unsigned, mirroring PGP and Thunderbird.
  - A From address not covered by the signer certificate shows as unsigned, also for PGP.
 
### Left out
    
  The SignerInfo sid in subjectKeyIdentifier form (Outlook 2010 RTM only) is rejected with
  a TODO. A multipart/signed nested inside a multipart/mixed wrapper is still never
  verified. Outlook Android reportedly shows raw source when the first signed part is a
  bare text/plain, which only plain-text send mode produces. Message signatures with
  RSA-PSS, ECDH key agreement and ECDSA signing remain unsupported. A latent PGP bug was
  found and not touched: the inner-versus-outer From check in the PGP reader runs before
  the MIME is replaced, so it can never fire. The own-identity and recipient-certificate
  gaps from the inventory earlier in this session (self-signed certificate creation, CSR
  without SAN, DER and .p7b import, dropped renewed certificates, GAL certificates not
  persisted) are untouched.
 
  Only a live test can settle what New Outlook, OWA and Outlook mobile put on the wire, how
  Outlook presents an untrusted signer, and whether current Apple Mail still emits 3DES.

  Summary: send-side encoding fix, 3DES/RC2/OAEP/SKI/octet-stream reading, ECDSA and PSS
  verification, and the From-binding plus certificate input checks you asked for.
